### PR TITLE
Fix broken MCP integration links

### DIFF
--- a/future-agi/products/agent-compass/overview.mdx
+++ b/future-agi/products/agent-compass/overview.mdx
@@ -180,7 +180,7 @@ The following integrations are currently supported
   </Card>
   <Card 
     title="MCP" 
-    href="/future-agi/integrations/mcp"
+    href="/integrations/mcp"
   >
   </Card>
 </CardGroup>

--- a/integrations/overview.mdx
+++ b/integrations/overview.mdx
@@ -190,7 +190,7 @@ import { Card, CardGroup } from 'nextra-theme-docs'
   </Card>
   <Card 
     title="MCP" 
-    href="/future-agi/integrations/mcp"
+    href="/integrations/mcp"
   >
   </Card>
   <Card 

--- a/product/agent-compass/overview.mdx
+++ b/product/agent-compass/overview.mdx
@@ -180,7 +180,7 @@ The following integrations are currently supported
   </Card>
   <Card 
     title="MCP" 
-    href="/future-agi/integrations/mcp"
+    href="/integrations/mcp"
   >
   </Card>
 </CardGroup>


### PR DESCRIPTION
## Summary
- Fix 3 broken links pointing to `/future-agi/integrations/mcp` which should now be `/integrations/mcp` after the integrations folder was moved

## Files updated
- `integrations/overview.mdx`
- `product/agent-compass/overview.mdx`
- `future-agi/products/agent-compass/overview.mdx`

## Test plan
- Merge this PR to fix the Mintlify link-rot validation error on PR #404

🤖 Generated with [Claude Code](https://claude.com/claude-code)