### PR TITLE
docs(prompt-sdk): Improve SDK documentation with installation and format details

### DIFF
--- a/product/prompt/how-to/prompt-workbench-using-sdk.mdx
+++ b/product/prompt/how-to/prompt-workbench-using-sdk.mdx
@@ -2,6 +2,25 @@
 title: "Prompt Workbench Using SDK"
 ---
 
+### **Installation**
+
+<CodeGroup>
+
+```bash npm
+npm install @future-agi/sdk
+```
+
+```bash pip
+pip install futureagi
+```
+
+</CodeGroup>
+
+<Note>
+The Python package is installed as `futureagi` but imported as `fi`.
+</Note>
+
+---
 
 ### **Template structure**
 
@@ -58,8 +77,7 @@ const compiled = client.compile({
 ```
 
 ```python Python
-from fi.prompt.types import PromptTemplate, SystemMessage, UserMessage, ModelConfig
-from fi.prompt.client import Prompt
+from fi.prompt import Prompt, PromptTemplate, ModelConfig, SystemMessage, UserMessage
 
 tpl = PromptTemplate(
     name="chat-template",
@@ -102,8 +120,7 @@ await client.commitCurrentVersion("Finish v1", true); // set default
 ```
 
 ```python Python
-from fi.prompt.types import PromptTemplate, SystemMessage, UserMessage, ModelConfig
-from fi.prompt.client import Prompt
+from fi.prompt import Prompt, PromptTemplate, ModelConfig, SystemMessage, UserMessage
 
 tpl = PromptTemplate(
     name="intro-template",
@@ -213,8 +230,9 @@ mapping = Prompt.get_template_labels(template_name="intro-template")
 <ul>
 <li><b>Precedence</b>: version > label</li>
 <li><b>Python default</b>: if no label is provided, defaults to <code>"production"</code></li>
+<li><b>Return type</b>: <code>get_template_by_name()</code> returns a <code>Prompt</code> object (not a <code>PromptTemplate</code>). You can call <code>.compile()</code> directly on it.</li>
 </ul>
- </Note>
+</Note>
 
 <CodeGroup>
 
@@ -225,7 +243,7 @@ const tplByVersion = await Prompt.getTemplateByName("intro-template", { version:
 ```
 
 ```python Python
-from fi.prompt.client import Prompt
+from fi.prompt import Prompt
 tpl_by_label = Prompt.get_template_by_name("intro-template", label="Production")
 tpl_by_version = Prompt.get_template_by_name("intro-template", version="v2")
 ```
@@ -276,7 +294,7 @@ const resultText = completion.choices[0]?.message?.content;
 import os
 import random
 from openai import OpenAI
-from fi.prompt.client import Prompt
+from fi.prompt import Prompt
 
 openai_client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 
@@ -304,5 +322,71 @@ result_text = response.choices[0].message.content
 <Note>
 For analytics, attach the selected label/version to your logs or tracing so A/B results can be compared.
 </Note>
+
+---
+
+### **Compile output format**
+
+The `compile()` method returns messages in a provider-agnostic format. Each message contains structured content that you may need to convert for your target LLM provider.
+
+**Output structure:**
+```json
+[
+  {"role": "system", "content": "[{'text': 'You are a helpful assistant.', 'type': 'text'}]"},
+  {"role": "user", "content": "[{'text': 'Hello Ada from Berlin!', 'type': 'text'}]"}
+]
+```
+
+<Note>
+The `content` field contains a stringified list of content parts. This format supports multimodal content (text, images, etc.) and is intentionally provider-agnostic. Write an adapter function to convert to your target provider's format.
+</Note>
+
+#### **OpenAI adapter example**
+
+<CodeGroup>
+
+```typescript JS/TS
+function toOpenAIFormat(compiled: any[]): { role: string; content: string }[] {
+  return compiled.map((msg) => {
+    let content = msg.content;
+    try {
+      // Parse the stringified content array
+      const parsed = JSON.parse(content.replace(/'/g, '"'));
+      if (Array.isArray(parsed)) {
+        content = parsed.map((item: any) => item.text || "").join("");
+      }
+    } catch {
+      // Already plain text
+    }
+    return { role: msg.role, content };
+  });
+}
+
+const openaiMessages = toOpenAIFormat(compiled);
+```
+
+```python Python
+import json
+
+def to_openai_format(compiled_messages):
+    """Convert compiled messages to OpenAI format"""
+    openai_msgs = []
+    for msg in compiled_messages:
+        role = msg.get("role", "user")
+        content = msg.get("content", "")
+        try:
+            # Parse stringified content (Python dict syntax uses single quotes)
+            content_list = json.loads(content.replace("'", '"'))
+            if isinstance(content_list, list):
+                content = "".join(item.get("text", "") for item in content_list)
+        except (json.JSONDecodeError, TypeError):
+            pass  # Already plain text
+        openai_msgs.append({"role": role, "content": content})
+    return openai_msgs
+
+openai_messages = to_openai_format(compiled)
+```
+
+</CodeGroup>
 
 ---


### PR DESCRIPTION
## Summary
- Add Installation section with pip/npm commands
- Note that pip package is `futureagi` but import is `fi`
- Simplify Python imports to use unified `from fi.prompt import ...`
- Document that `get_template_by_name()` returns `Prompt` object, not `PromptTemplate`
- Add Compile output format section explaining provider-agnostic structure
- Add OpenAI adapter example for converting compiled messages

## Context
Discovered these gaps while testing the SDK end-to-end. Key issues that would block new users:
1. No installation instructions (users wouldn't know to run `pip install futureagi`)
2. Import paths were split across `fi.prompt.types` and `fi.prompt.client` but unified import works
3. `compile()` output format was undocumented - users need to write adapters for their LLM provider

## Test plan
- [ ] Verify installation section renders correctly
- [ ] Verify code examples are syntactically correct
- [ ] Test that the documented imports work with latest SDK version

🤖 Generated with [Claude Code](https://claude.com/claude-code)