### PR TITLE
replace deprecated eval examples and add migration warnings

### DIFF
--- a/cookbook/cookbook16/Building-AI-Research-Team-with-CrewAI-and-FutureAGI.mdx
+++ b/cookbook/cookbook16/Building-AI-Research-Team-with-CrewAI-and-FutureAGI.mdx
@@ -233,19 +233,20 @@ def evaluate_research_with_tracing(research_output: str, context: str) -> Dict[s
             trace_eval=True
         )
         
-        # Evaluation 2: Factual Accuracy
-        factual_config = {
-            "eval_templates": "factual_accuracy",
+        # Evaluation 2: Groundedness
+        groundedness_config = {
+            "eval_templates": "groundedness",
             "inputs": {
                 "input": context,
+                "context": context,
                 "output": research_output,
             },
             "model_name": "turing_large"
         }
         
-        factual_result = evaluator.evaluate(
-            **factual_config,
-            custom_eval_name="research_factual_accuracy",
+        groundedness_result = evaluator.evaluate(
+            **groundedness_config,
+            custom_eval_name="research_groundedness",
             trace_eval=True
         )
         
@@ -268,11 +269,11 @@ def evaluate_research_with_tracing(research_output: str, context: str) -> Dict[s
         # Aggregate results
         eval_results = {
             "completeness": completeness_result,
-            "factual_accuracy": factual_result,
+            "groundedness": groundedness_result,
             "relevance": relevance_result,
             "overall_score": (
                 completeness_result.get("score", 0) + 
-                factual_result.get("score", 0) + 
+                groundedness_result.get("score", 0) + 
                 relevance_result.get("score", 0)
             ) / 3
         }
@@ -325,6 +326,7 @@ def evaluate_report_quality(report: str, requirements: str) -> Dict[str, Any]:
             "eval_templates": "groundedness",
             "inputs": {
                 "input": requirements,
+                "context": requirements,
                 "output": report,
             },
             "model_name": "turing_large"
@@ -584,7 +586,7 @@ class ResearchMetricsCollector:
             # Run multiple evaluations
             eval_templates = [
                 ("completeness", {"input": context, "output": output}),
-                ("groundedness", {"input": context, "output": output}),
+                ("groundedness", {"input": context, "context": context, "output": output}),
                 ("is_helpful", {"output": output}),
             ]
             

--- a/future-agi/get-started/dataset/adding-dataset/using-sdk.mdx
+++ b/future-agi/get-started/dataset/adding-dataset/using-sdk.mdx
@@ -90,19 +90,19 @@ dataset = dataset.create()  # Creates remotely if it doesn’t already exist
 # -------------------------------------------------------------------
 columns = [
     Column(name="user_query", data_type=DataTypeChoices.TEXT, source=SourceChoices.OTHERS),
-    Column(name="response_quality", data_type=DataTypeChoices.INTEGER, source=SourceChoices.OTHERS),
+    Column(name="model_response", data_type=DataTypeChoices.TEXT, source=SourceChoices.OTHERS),
     Column(name="is_helpful", data_type=DataTypeChoices.BOOLEAN, source=SourceChoices.OTHERS),
 ]
 
 rows = [
     Row(order=1, cells=[
         Cell(column_name="user_query", value="What is machine learning?"),
-        Cell(column_name="response_quality", value=8),
+        Cell(column_name="model_response", value="Machine learning is a branch of AI where systems learn patterns from data to make predictions or decisions."),
         Cell(column_name="is_helpful", value=True),
     ]),
     Row(order=2, cells=[
         Cell(column_name="user_query", value="Explain quantum computing"),
-        Cell(column_name="response_quality", value=9),
+        Cell(column_name="model_response", value="Quantum computing uses qubits to process information with principles like superposition and entanglement."),
         Cell(column_name="is_helpful", value=True),
     ]),
 ]
@@ -114,11 +114,11 @@ dataset = dataset.add_columns(columns=columns)
 dataset = dataset.add_rows(rows=rows)
 
 dataset.add_evaluation(
-    name="factual_accuracy",
-    eval_template="is_factually_consistent",
+    name="groundedness_check",
+    eval_template="groundedness",
     required_keys_to_column_names={
         "input": "user_query",
-        "output": "response_quality",
+        "output": "model_response",
         "context": "user_query",
     },
     run=True,
@@ -160,8 +160,8 @@ async function main() {
   await dataset.addRows(rows);
 
   await dataset.add_evaluation({
-    name: "factual_accuracy",
-    evalTemplate: "is_factually_consistent",
+    name: "groundedness_check",
+    evalTemplate: "groundedness",
     requiredKeysToColumnNames: {
       input: "user_input",
       output: "chatbot_response",

--- a/future-agi/get-started/evaluation/builtin-evals/content-moderation.mdx
+++ b/future-agi/get-started/evaluation/builtin-evals/content-moderation.mdx
@@ -5,10 +5,15 @@ description: "Evaluates content safety using OpenAI's content moderation system 
 
 ---
 
+<Warning>
+`content_moderation` is being deprecated. Avoid using it for new integrations.
+Use `toxicity` for new implementations.
+</Warning>
+
 <CodeGroup>
 ```python Python
 result = evaluator.evaluate(
-    eval_templates="content_moderation",
+    eval_templates="toxicity",
     inputs={
         "output": "I want to hurt someone who made me angry today."
     }
@@ -26,9 +31,9 @@ import { Evaluator, Templates } from "@future-agi/ai-evaluation";
 const evaluator = new Evaluator();
 
 const result = await evaluator.evaluate(
-  "content_moderation",
+  "toxicity",
   {
-    content: "I want to hurt someone who made me angry today."
+    output: "I want to hurt someone who made me angry today."
   },
   {
     modelName: "turing_flash",

--- a/future-agi/get-started/evaluation/builtin-evals/content-safety-violation.mdx
+++ b/future-agi/get-started/evaluation/builtin-evals/content-safety-violation.mdx
@@ -3,11 +3,16 @@ title: "Content Safety Violation"
 description: "Detects harmful, unsafe, or prohibited content that violates safety guidelines."
 ---
 
+<Warning>
+`content_safety_violation` is being deprecated. Avoid using it for new integrations.
+Use `toxicity` for new implementations.
+</Warning>
+
 <CodeGroup>
 
 ```python Python
 result = evaluator.evaluate(
-    eval_templates="content_safety_violation",
+    eval_templates="toxicity",
     inputs={
         "output": "Dear Sir, I hope this email finds you well. I look forward to any insights or advice you might have whenever you have a free moment"
     },
@@ -25,7 +30,7 @@ import { Evaluator, Templates } from "@future-agi/ai-evaluation";
 const evaluator = new Evaluator();
 
 const result = await evaluator.evaluate(
-  "content_safety_violation",
+  "toxicity",
   {
     output: "Dear Sir, I hope this email finds you well. I look forward to any insights or advice you might have whenever you have a free moment"
   },

--- a/future-agi/get-started/evaluation/builtin-evals/factual-accuracy.mdx
+++ b/future-agi/get-started/evaluation/builtin-evals/factual-accuracy.mdx
@@ -5,26 +5,26 @@ description: "Verifies if the provided output is factually correct based on the 
 
 ---
 
+<Warning>
+`factual_accuracy` is being deprecated. Avoid using it for new integrations.
+Use `groundedness` for new implementations.
+</Warning>
+
 <CodeGroup>
 
 ```python Python
-from fi.testcases import TestCase
-from fi.evals.templates import FactualAccuracy
-
-test_case = TestCase(
-    output="example output",
-    context="example context",
-    input="example input",
+result = evaluator.evaluate(
+    eval_templates="groundedness",
+    inputs={
+        "input": "The capital of France is Paris.",
+        "output": "The capital of France is Paris.",
+        "context": "The capital of France is Paris.",
+    },
+    model_name="turing_flash",
 )
 
-template = FactualAccuracy(config={
-    "check_internet": False
-})
-
-response = evaluator.evaluate(eval_templates=[template], inputs=[test_case], model_name="turing_flash")
-
-print(f"Score: {response.eval_results[0].metrics[0].value}")
-print(f"Reason: {response.eval_results[0].reason}")
+print(result.eval_results[0].output)
+print(result.eval_results[0].reason)
 ```
 
 
@@ -34,7 +34,7 @@ import { Evaluator, Templates } from "@future-agi/ai-evaluation";
 const evaluator = new Evaluator();
 
 const result = await evaluator.evaluate(
-  "factual_accuracy",
+  "groundedness",
   {
     input: "The capital of France is Paris.",
     output: "The capital of France is Paris.",

--- a/future-agi/get-started/evaluation/builtin-evals/is-compliant.mdx
+++ b/future-agi/get-started/evaluation/builtin-evals/is-compliant.mdx
@@ -3,12 +3,17 @@ title: "Is Compliant"
 description: "Evaluates whether content follows guidelines, standards, and acceptable use policies."
 ---
 
+<Warning>
+`is_compliant` is being deprecated. Avoid using it for new integrations.
+Use `data_privacy_compliance` for new implementations.
+</Warning>
+
 <CodeGroup>
 
 ```python Python
 
 result = evaluator.evaluate(
-    eval_templates="is_compliant",
+    eval_templates="data_privacy_compliance",
     inputs={
         "output": "Dear Sir, I hope this email finds you well. I look forward to any insights or advice you might have whenever you have a free moment"
     },
@@ -25,7 +30,7 @@ import { Evaluator, Templates } from "@future-agi/ai-evaluation";
 const evaluator = new Evaluator();
 
 const result = await evaluator.evaluate(
-  "is_compliant",
+  "data_privacy_compliance",
   {
     output: "Dear Sir, I hope this email finds you well. I look forward to any insights or advice you might have whenever you have a free moment"
   },

--- a/future-agi/get-started/evaluation/builtin-evals/is-factually-consistent.mdx
+++ b/future-agi/get-started/evaluation/builtin-evals/is-factually-consistent.mdx
@@ -3,11 +3,16 @@ title: "Is Factually Consistent"
 description: "Evaluates whether output content is factually consistent with provided input or context"
 ---
 
+<Warning>
+`is_factually_consistent` is being deprecated. Avoid using it for new integrations.
+Use `groundedness` for new implementations.
+</Warning>
+
 <CodeGroup>
 
 ```python Python
 result = evaluator.evaluate(
-    eval_templates="is_factually_consistent", 
+    eval_templates="groundedness", 
     inputs={
         "input": "Why doesn't honey go bad?",
         "output": "Because its low moisture and high acidity prevent the growth of bacteria and other microbes.",
@@ -26,7 +31,7 @@ import { Evaluator, Templates } from "@future-agi/ai-evaluation";
 const evaluator = new Evaluator();
 
 const result = await evaluator.evaluate(
-  "is_factually_consistent",
+  "groundedness",
   {
     input: "Why doesn't honey go bad?",
     output: "Because its low moisture and high acidity prevent the growth of bacteria and other microbes.",

--- a/future-agi/get-started/evaluation/builtin-evals/overview.mdx
+++ b/future-agi/get-started/evaluation/builtin-evals/overview.mdx
@@ -5,8 +5,12 @@ title: "Overview"
 import { Card, CardGroup } from 'nextra-theme-docs'
 
 <Warning>
-The following built-in eval templates are being deprecated and should not be used for new integrations: `content_moderation`, `factual_accuracy`, `content_safety_violation`, `is_factually_consistent`, and `is_compliant`.
-Recommended replacements: `toxicity` (for `content_moderation` and `content_safety_violation`), `groundedness` (for `factual_accuracy` and `is_factually_consistent`), and `data_privacy_compliance` (for `is_compliant`).
+We are deprecating the following templates: `content_moderation`, `factual_accuracy`, `content_safety_violation`, `is_factually_consistent`, and `is_compliant`.
+
+For new integrations, please use:
+- `toxicity` instead of `content_moderation` and `content_safety_violation`
+- `groundedness` instead of `factual_accuracy` and `is_factually_consistent`
+- `data_privacy_compliance` instead of `is_compliant`
 </Warning>
 
 <CardGroup cols={2}>

--- a/future-agi/get-started/evaluation/builtin-evals/overview.mdx
+++ b/future-agi/get-started/evaluation/builtin-evals/overview.mdx
@@ -4,6 +4,11 @@ title: "Overview"
 
 import { Card, CardGroup } from 'nextra-theme-docs'
 
+<Warning>
+The following built-in eval templates are being deprecated and should not be used for new integrations: `content_moderation`, `factual_accuracy`, `content_safety_violation`, `is_factually_consistent`, and `is_compliant`.
+Recommended replacements: `toxicity` (for `content_moderation` and `content_safety_violation`), `groundedness` (for `factual_accuracy` and `is_factually_consistent`), and `data_privacy_compliance` (for `is_compliant`).
+</Warning>
+
 <CardGroup cols={2}>
   <Card 
     title="Answer Refusal" 

--- a/future-agi/get-started/evaluation/evaluate-ci-cd-pipeline.mdx
+++ b/future-agi/get-started/evaluation/evaluate-ci-cd-pipeline.mdx
@@ -5,8 +5,12 @@ title: "Evaluate via CI/CD Pipeline"
 Integrating Future AGI evaluations into your CI/CD pipeline allows you to automatically assess model performance on every pull request, ensuring consistent quality checks before code deployment.
 
 <Warning>
-Deprecated eval templates: `content_moderation`, `factual_accuracy`, `content_safety_violation`, `is_factually_consistent`, and `is_compliant`. Use active templates for new CI/CD pipelines.
-Use `toxicity` for `content_moderation`/`content_safety_violation`, `groundedness` for `factual_accuracy`/`is_factually_consistent`, and `data_privacy_compliance` for `is_compliant`.
+We are deprecating the following templates: `content_moderation`, `factual_accuracy`, `content_safety_violation`, `is_factually_consistent`, and `is_compliant`.
+
+For new CI/CD pipelines, please use:
+- `toxicity` instead of `content_moderation` and `content_safety_violation`
+- `groundedness` instead of `factual_accuracy` and `is_factually_consistent`
+- `data_privacy_compliance` instead of `is_compliant`
 </Warning>
 
 ## Core SDK Functions

--- a/future-agi/get-started/evaluation/evaluate-ci-cd-pipeline.mdx
+++ b/future-agi/get-started/evaluation/evaluate-ci-cd-pipeline.mdx
@@ -4,6 +4,11 @@ title: "Evaluate via CI/CD Pipeline"
 
 Integrating Future AGI evaluations into your CI/CD pipeline allows you to automatically assess model performance on every pull request, ensuring consistent quality checks before code deployment.
 
+<Warning>
+Deprecated eval templates: `content_moderation`, `factual_accuracy`, `content_safety_violation`, `is_factually_consistent`, and `is_compliant`. Use active templates for new CI/CD pipelines.
+Use `toxicity` for `content_moderation`/`content_safety_violation`, `groundedness` for `factual_accuracy`/`is_factually_consistent`, and `data_privacy_compliance` for `is_compliant`.
+</Warning>
+
 ## Core SDK Functions
 
 The Future AGI evaluation pipeline uses two main SDK functions. Let's understand these step by step:
@@ -38,9 +43,13 @@ eval_data = [
         }
     },
     {
-        "eval_template": "is_factually_consistent",
+        "eval_template": "groundedness",
         "model_name": "turing_large",
         "inputs": {
+            "input": [
+                "What is the capital of France?",
+                "Who wrote Hamlet?"
+            ],
             "context": [
                 "What is the capital of France?",
                 "Who wrote Hamlet?"
@@ -191,9 +200,13 @@ eval_data = [
         }
     },
     {
-        "eval_template": "is_factually_consistent",
+        "eval_template": "groundedness",
         "model_name": "turing_large",
         "inputs": {
+            "input": [
+                "What is the capital of France?",
+                "Who wrote Hamlet?"
+            ],
             "context": [
                 "What is the capital of France?",
                 "Who wrote Hamlet?"

--- a/future-agi/get-started/protect/overview.mdx
+++ b/future-agi/get-started/protect/overview.mdx
@@ -17,6 +17,11 @@ description: "Future AGI's Protect module — real-time safety and content guard
 
 Protect is Future AGI's real-time safety layer for AI applications. It sits between your AI model and your users, screening every input and output for harmful content before anything reaches the end user.
 
+<Warning>
+Deprecated eval templates: `content_moderation`, `factual_accuracy`, `content_safety_violation`, `is_factually_consistent`, and `is_compliant`. Avoid using them for new implementations.
+Use `toxicity` for `content_moderation`/`content_safety_violation`, `groundedness` for `factual_accuracy`/`is_factually_consistent`, and `data_privacy_compliance` for `is_compliant`.
+</Warning>
+
 Unlike traditional safety checks that run offline or in batches, Protect works **live** — in the same moment your model processes a request. Potential violations are caught instantly, not discovered after the fact.
 <Info>
 Think of Protect as a smart gatekeeper: every message in, every response out passes through a safety check. If something fails, it's blocked or flagged automatically — with a clear explanation of why.
@@ -94,7 +99,7 @@ from fi.evals import Protect
 # Initialize (reads FI_API_KEY / FI_SECRET_KEY from env if not passed)
 protector = Protect()
 
-rules = [{'metric': 'content_moderation'}]
+rules = [{'metric': 'toxicity'}]
 
 protected_response = protector.protect(
     "AI Generated Message",

--- a/future-agi/get-started/protect/overview.mdx
+++ b/future-agi/get-started/protect/overview.mdx
@@ -17,11 +17,6 @@ description: "Future AGI's Protect module — real-time safety and content guard
 
 Protect is Future AGI's real-time safety layer for AI applications. It sits between your AI model and your users, screening every input and output for harmful content before anything reaches the end user.
 
-<Warning>
-Deprecated eval templates: `content_moderation`, `factual_accuracy`, `content_safety_violation`, `is_factually_consistent`, and `is_compliant`. Avoid using them for new implementations.
-Use `toxicity` for `content_moderation`/`content_safety_violation`, `groundedness` for `factual_accuracy`/`is_factually_consistent`, and `data_privacy_compliance` for `is_compliant`.
-</Warning>
-
 Unlike traditional safety checks that run offline or in batches, Protect works **live** — in the same moment your model processes a request. Potential violations are caught instantly, not discovered after the fact.
 <Info>
 Think of Protect as a smart gatekeeper: every message in, every response out passes through a safety check. If something fails, it's blocked or flagged automatically — with a clear explanation of why.

--- a/sdk-reference/evals.mdx
+++ b/sdk-reference/evals.mdx
@@ -97,8 +97,12 @@ def list_evaluations(self) -> List[Dict[str, Any]]:
 The list of templates that can be used to evaluate your data.
 
 <Warning>
-The following eval templates are being deprecated and should not be used for new integrations: `content_moderation`, `factual_accuracy`, `content_safety_violation`, `is_factually_consistent`, and `is_compliant`.
-Recommended replacements: `toxicity` (for `content_moderation` and `content_safety_violation`), `groundedness` (for `factual_accuracy` and `is_factually_consistent`), and `data_privacy_compliance` (for `is_compliant`).
+We are deprecating the following templates: `content_moderation`, `factual_accuracy`, `content_safety_violation`, `is_factually_consistent`, and `is_compliant`.
+
+For new integrations, please use:
+- `toxicity` instead of `content_moderation` and `content_safety_violation`
+- `groundedness` instead of `factual_accuracy` and `is_factually_consistent`
+- `data_privacy_compliance` instead of `is_compliant`
 </Warning>
 
 #### **Conversation Coherence**

--- a/sdk-reference/evals.mdx
+++ b/sdk-reference/evals.mdx
@@ -96,6 +96,11 @@ def list_evaluations(self) -> List[Dict[str, Any]]:
 ### `eval_templates`
 The list of templates that can be used to evaluate your data.
 
+<Warning>
+The following eval templates are being deprecated and should not be used for new integrations: `content_moderation`, `factual_accuracy`, `content_safety_violation`, `is_factually_consistent`, and `is_compliant`.
+Recommended replacements: `toxicity` (for `content_moderation` and `content_safety_violation`), `groundedness` (for `factual_accuracy` and `is_factually_consistent`), and `data_privacy_compliance` (for `is_compliant`).
+</Warning>
+
 #### **Conversation Coherence**
 Evaluates if a conversation flows logically and maintains context throughout
 ```python
@@ -106,7 +111,7 @@ Checks if the conversation reaches a satisfactory conclusion or resolution. The 
 ```python
 class ConversationResolution():
 ```
-#### **Content Moderation**
+#### **Content Moderation (Deprecated)**
 Uses OpenAI's content moderation to evaluate text safety
 ```python
 class ContentModeration():
@@ -218,7 +223,7 @@ class SummaryQuality(config={
     "check_internet": {"type": "boolean", "default": False}
 }):
 ```
-#### **Factual Accuracy**
+#### **Factual Accuracy (Deprecated)**
 Verifies if the provided output is factually correct or not.
 ```python
 class FactualAccuracy(config={
@@ -335,7 +340,7 @@ Detects whether the model gives advice that could be physically, emotionally, le
 ```python
 class IsHarmfulAdvice():
 ```
-#### **Content Safety Violation**
+#### **Content Safety Violation (Deprecated)**
 A broad check for content that violates safety or usage policies—this includes toxicity, hate speech, explicit content, violence, etc.
 ```python
 class ContentSafetyViolation():
@@ -345,12 +350,12 @@ Evaluates if a summary is clear, well-structured, and includes the most importan
 ```python
 class IsGoodSummary():
 ```
-#### **Is Factually Consistent**
+#### **Is Factually Consistent (Deprecated)**
 Checks if the generated output is factually consistent with the source/context (e.g., input text or documents).
 ```python
 class IsFactuallyConsistent():
 ```
-#### **Is Compliant**
+#### **Is Compliant (Deprecated)**
 Ensures that the output adheres to legal, regulatory, or organizational policies (e.g., HIPAA, GDPR, company rules).
 ```python
 class IsCompliant():


### PR DESCRIPTION
## Summary
This PR updates docs to handle deprecated eval templates and provide clear migration guidance.

## What changed
- Replaced deprecated eval usage in runnable examples:
  - `content_moderation` -> `toxicity`
  - `content_safety_violation` -> `toxicity`
  - `factual_accuracy` -> `groundedness`
  - `is_factually_consistent` -> `groundedness`
  - `is_compliant` -> `data_privacy_compliance`
- Kept deprecation warnings where those templates are still documented for reference.
- Added explicit replacement mapping in overview/reference warning blocks.

## Files updated
- `future-agi/get-started/evaluation/builtin-evals/content-moderation.mdx`
- `future-agi/get-started/evaluation/builtin-evals/content-safety-violation.mdx`
- `future-agi/get-started/evaluation/builtin-evals/factual-accuracy.mdx`
- `future-agi/get-started/evaluation/builtin-evals/is-factually-consistent.mdx`
- `future-agi/get-started/evaluation/builtin-evals/is-compliant.mdx`
- `future-agi/get-started/evaluation/builtin-evals/overview.mdx`
- `future-agi/get-started/evaluation/evaluate-ci-cd-pipeline.mdx`
- `future-agi/get-started/protect/overview.mdx`
- `future-agi/get-started/dataset/adding-dataset/using-sdk.mdx`
- `cookbook/cookbook16/Building-AI-Research-Team-with-CrewAI-and-FutureAGI.mdx`
- `sdk-reference/evals.mdx`

## Notes
- Updated examples are aligned with required params from `few_evals.csv` (e.g., `toxicity` uses `output`, `groundedness` uses `context` + `output`, optional `input` included where helpful).
- Deprecated eval names now remain only in warning/deprecation text, not in runnable example calls.