### PR TITLE
remove model name and update the ts sample code

### DIFF
--- a/future-agi/get-started/evaluation/builtin-evals/hit-rate.mdx
+++ b/future-agi/get-started/evaluation/builtin-evals/hit-rate.mdx
@@ -23,8 +23,7 @@ result = evaluator.evaluate(
             "Paris is the capital of France.",
             "The Eiffel Tower was built in 1889."
         ])
-    },
-
+    }
 )
 
 print(result.eval_results[0].output)   # 1.0
@@ -48,8 +47,7 @@ const result = await evaluator.evaluate(
       "Paris is the capital of France.",
       "The Eiffel Tower was built in 1889."
     ])
-  },
-  {}
+  }
 );
 
 console.log(result.eval_results[0]?.output);   // 1.0
@@ -95,7 +93,6 @@ results = evaluator.evaluate(
             json.dumps(["The Louvre is in Paris."]),
         ],
     },
-    model_name="turing_flash",
 )
 
 for i, r in enumerate(results.eval_results):

--- a/future-agi/get-started/evaluation/builtin-evals/hit-rate.mdx
+++ b/future-agi/get-started/evaluation/builtin-evals/hit-rate.mdx
@@ -24,7 +24,7 @@ result = evaluator.evaluate(
             "The Eiffel Tower was built in 1889."
         ])
     },
-    model_name="turing_flash"
+
 )
 
 print(result.eval_results[0].output)   # 1.0
@@ -32,7 +32,7 @@ print(result.eval_results[0].reason)
 ```
 
 ```typescript JS/TS
-import { Evaluator, Templates } from "@future-agi/ai-evaluation";
+import { Evaluator } from "@future-agi/ai-evaluation";
 
 const evaluator = new Evaluator();
 
@@ -49,12 +49,11 @@ const result = await evaluator.evaluate(
       "The Eiffel Tower was built in 1889."
     ])
   },
-  {
-    modelName: "turing_flash",
-  }
+  {}
 );
 
-console.log(result);
+console.log(result.eval_results[0]?.output);   // 1.0
+console.log(result.eval_results[0]?.reason);
 ```
 
 </CodeGroup>

--- a/future-agi/get-started/evaluation/builtin-evals/mrr.mdx
+++ b/future-agi/get-started/evaluation/builtin-evals/mrr.mdx
@@ -27,7 +27,7 @@ result = evaluator.evaluate(
             "The Louvre is in Paris."
         ])
     },
-    model_name="turing_flash"
+
 )
 
 print(result.eval_results[0].output)   # 0.333
@@ -35,7 +35,7 @@ print(result.eval_results[0].reason)
 ```
 
 ```typescript JS/TS
-import { Evaluator, Templates } from "@future-agi/ai-evaluation";
+import { Evaluator } from "@future-agi/ai-evaluation";
 
 const evaluator = new Evaluator();
 
@@ -55,12 +55,11 @@ const result = await evaluator.evaluate(
       "The Louvre is in Paris."
     ])
   },
-  {
-    modelName: "turing_flash",
-  }
+  {}
 );
 
-console.log(result);
+console.log(result.eval_results[0]?.output);   // 0.333
+console.log(result.eval_results[0]?.reason);
 ```
 
 </CodeGroup>

--- a/future-agi/get-started/evaluation/builtin-evals/mrr.mdx
+++ b/future-agi/get-started/evaluation/builtin-evals/mrr.mdx
@@ -26,8 +26,7 @@ result = evaluator.evaluate(
             "The Eiffel Tower was built in 1889.",
             "The Louvre is in Paris."
         ])
-    },
-
+    }
 )
 
 print(result.eval_results[0].output)   # 0.333
@@ -54,8 +53,7 @@ const result = await evaluator.evaluate(
       "The Eiffel Tower was built in 1889.",
       "The Louvre is in Paris."
     ])
-  },
-  {}
+  }
 );
 
 console.log(result.eval_results[0]?.output);   // 0.333
@@ -101,7 +99,6 @@ results = evaluator.evaluate(
             json.dumps(["The Louvre is in Paris."]),
         ],
     },
-    model_name="turing_flash",
 )
 
 for i, r in enumerate(results.eval_results):

--- a/future-agi/get-started/evaluation/builtin-evals/ndcg-at-k.mdx
+++ b/future-agi/get-started/evaluation/builtin-evals/ndcg-at-k.mdx
@@ -104,7 +104,6 @@ results = evaluator.evaluate(
             json.dumps(["The Louvre is in Paris."]),
         ],
     },
-
     eval_config={"k": 3},
 )
 

--- a/future-agi/get-started/evaluation/builtin-evals/ndcg-at-k.mdx
+++ b/future-agi/get-started/evaluation/builtin-evals/ndcg-at-k.mdx
@@ -27,7 +27,6 @@ result = evaluator.evaluate(
             "The Louvre is in Paris."
         ])
     },
-    model_name="turing_flash",
     eval_config={"k": 5}
 )
 
@@ -36,7 +35,7 @@ print(result.eval_results[0].reason)
 ```
 
 ```typescript JS/TS
-import { Evaluator, Templates } from "@future-agi/ai-evaluation";
+import { Evaluator } from "@future-agi/ai-evaluation";
 
 const evaluator = new Evaluator();
 
@@ -57,12 +56,12 @@ const result = await evaluator.evaluate(
     ])
   },
   {
-    modelName: "turing_flash",
     evalConfig: { k: 5 },
   }
 );
 
-console.log(result);
+console.log(result.eval_results[0]?.output);   // Score reflecting ranking quality
+console.log(result.eval_results[0]?.reason);
 ```
 
 </CodeGroup>
@@ -84,7 +83,7 @@ In this example, 3 relevant chunks are scattered across positions 2, 4, and 5 in
 | **Parameter** |  |  |  |
 | ------ | --------- | ---- | ----------- |
 | | **Name** | **Type** | **Description** |
-| | `eval_config` | `dict` | Optional. Pass `{"k": N}` to limit evaluation to the top N retrieved chunks. Defaults to using the full list. |
+| | `eval_config` (`evalConfig` in JS/TS) | `dict` / `Record<string, any>` | Optional. Pass `{"k": N}` to limit evaluation to the top N retrieved chunks. Defaults to using the full list. |
 
 ### Batch evaluation
 
@@ -105,7 +104,7 @@ results = evaluator.evaluate(
             json.dumps(["The Louvre is in Paris."]),
         ],
     },
-    model_name="turing_flash",
+
     eval_config={"k": 3},
 )
 

--- a/future-agi/get-started/evaluation/builtin-evals/precision-at-k.mdx
+++ b/future-agi/get-started/evaluation/builtin-evals/precision-at-k.mdx
@@ -104,7 +104,6 @@ results = evaluator.evaluate(
             json.dumps(["The Louvre is in Paris."]),
         ],
     },
-
     eval_config={"k": 3},
 )
 

--- a/future-agi/get-started/evaluation/builtin-evals/precision-at-k.mdx
+++ b/future-agi/get-started/evaluation/builtin-evals/precision-at-k.mdx
@@ -27,7 +27,6 @@ result = evaluator.evaluate(
             "The Louvre is in Paris."
         ])
     },
-    model_name="turing_flash",
     eval_config={"k": 5}
 )
 
@@ -36,7 +35,7 @@ print(result.eval_results[0].reason)
 ```
 
 ```typescript JS/TS
-import { Evaluator, Templates } from "@future-agi/ai-evaluation";
+import { Evaluator } from "@future-agi/ai-evaluation";
 
 const evaluator = new Evaluator();
 
@@ -57,12 +56,12 @@ const result = await evaluator.evaluate(
     ])
   },
   {
-    modelName: "turing_flash",
     evalConfig: { k: 5 },
   }
 );
 
-console.log(result);
+console.log(result.eval_results[0]?.output);   // 0.6
+console.log(result.eval_results[0]?.reason);
 ```
 
 </CodeGroup>
@@ -84,7 +83,7 @@ In this example, 5 chunks are retrieved. Of those 5, 3 are in the ground truth (
 | **Parameter** |  |  |  |
 | ------ | --------- | ---- | ----------- |
 | | **Name** | **Type** | **Description** |
-| | `eval_config` | `dict` | Optional. Pass `{"k": N}` to limit evaluation to the top N retrieved chunks. Defaults to using the full list. |
+| | `eval_config` (`evalConfig` in JS/TS) | `dict` / `Record<string, any>` | Optional. Pass `{"k": N}` to limit evaluation to the top N retrieved chunks. Defaults to using the full list. |
 
 ### Batch evaluation
 
@@ -105,7 +104,7 @@ results = evaluator.evaluate(
             json.dumps(["The Louvre is in Paris."]),
         ],
     },
-    model_name="turing_flash",
+
     eval_config={"k": 3},
 )
 

--- a/future-agi/get-started/evaluation/builtin-evals/recall-at-k.mdx
+++ b/future-agi/get-started/evaluation/builtin-evals/recall-at-k.mdx
@@ -104,7 +104,6 @@ results = evaluator.evaluate(
             json.dumps(["The Louvre is in Paris."]),
         ],
     },
-
     eval_config={"k": 3},
 )
 

--- a/future-agi/get-started/evaluation/builtin-evals/recall-at-k.mdx
+++ b/future-agi/get-started/evaluation/builtin-evals/recall-at-k.mdx
@@ -27,7 +27,6 @@ result = evaluator.evaluate(
             "The Louvre is in Paris."
         ])
     },
-    model_name="turing_flash",
     eval_config={"k": 5}
 )
 
@@ -36,7 +35,7 @@ print(result.eval_results[0].reason)
 ```
 
 ```typescript JS/TS
-import { Evaluator, Templates } from "@future-agi/ai-evaluation";
+import { Evaluator } from "@future-agi/ai-evaluation";
 
 const evaluator = new Evaluator();
 
@@ -57,12 +56,12 @@ const result = await evaluator.evaluate(
     ])
   },
   {
-    modelName: "turing_flash",
     evalConfig: { k: 5 },
   }
 );
 
-console.log(result);
+console.log(result.eval_results[0]?.output);   // 1.0
+console.log(result.eval_results[0]?.reason);
 ```
 
 </CodeGroup>
@@ -84,7 +83,7 @@ In this example, 5 chunks are retrieved and 3 are in the ground truth. With K se
 | **Parameter** |  |  |  |
 | ------ | --------- | ---- | ----------- |
 | | **Name** | **Type** | **Description** |
-| | `eval_config` | `dict` | Optional. Pass `{"k": N}` to limit evaluation to the top N retrieved chunks. Defaults to using the full list. |
+| | `eval_config` (`evalConfig` in JS/TS) | `dict` / `Record<string, any>` | Optional. Pass `{"k": N}` to limit evaluation to the top N retrieved chunks. Defaults to using the full list. |
 
 ### Batch evaluation
 
@@ -105,7 +104,7 @@ results = evaluator.evaluate(
             json.dumps(["The Louvre is in Paris."]),
         ],
     },
-    model_name="turing_flash",
+
     eval_config={"k": 3},
 )
 


### PR DESCRIPTION
## Summary                                                                                                                                                                                                           
  - Remove unnecessary `model_name`/`modelName` from all retrieval eval examples (retrieval metrics are purely computational — no LLM model needed)                                                                  
  - Fix TypeScript code blocks: remove unused `Templates` import, show proper output access (`result.eval_results[0]?.output`), remove empty `{}` options
  - Add `evalConfig` (JS/TS) naming to parameter tables alongside Python `eval_config`

  ## Files changed
  - `recall-at-k.mdx` — Remove `model_name` from Python (main + batch), fix TS block
  - `precision-at-k.mdx` — Same
  - `ndcg-at-k.mdx` — Same
  - `mrr.mdx` — Same
  - `hit-rate.mdx` — Same

  ## Details

  **Python changes:**
  - Removed `model_name="turing_flash"` from all main and batch examples

  **TypeScript changes:**
  - `import { Evaluator, Templates }` → `import { Evaluator }` (Templates was unused)
  - `console.log(result)` → `console.log(result.eval_results[0]?.output)` + `.reason` with expected output comments
  - Removed `modelName: "turing_flash"` from options
  - Removed empty `{}` options for mrr/hit_rate

  **Parameter tables (recall, precision, ndcg):**
  - `eval_config` → `eval_config` (`evalConfig` in JS/TS)
  - `dict` → `dict` / `Record<string, any>`

  ## Verified
  All code examples tested end-to-end against production API in both Python and TypeScript — all assertions passed.