### PR TITLE
Rewrite setup observability quickstart

### DIFF
--- a/src/pages/docs/quickstart/setup-observability.mdx
+++ b/src/pages/docs/quickstart/setup-observability.mdx
@@ -3,26 +3,43 @@ title: "Setup Observability"
 description: "Set up Future AGI Observe for production monitoring. Configure auto-instrumented tracing for OpenAI, Anthropic, LangChain, and other LLM frameworks."
 ---
 
-## What is it?
+## About
 
-**Observe** is Future AGI's observability product. It gives you full visibility into how your AI application behaves in production — capturing every LLM call, tool use, and agent decision as a trace. You can monitor performance, detect anomalies, track costs, and debug issues without changing your application logic. Observe integrates with OpenAI, Anthropic, LangChain, and other frameworks via auto-instrumentation.
+**Observe** is Future AGI's observability product. It gives you full visibility into how your AI application behaves in production by capturing every LLM call, tool use, and agent decision as a trace. You can monitor performance, detect anomalies, track costs, and debug issues without changing your application logic.
+
+Observe supports auto-instrumentation for OpenAI, Anthropic, LangChain, LlamaIndex, CrewAI and [30+ other frameworks](/docs/integrations). By the end of this guide, you'll have traces flowing into your Future AGI dashboard.
 
 ---
 
 <Steps>
+  <Step title="Install the SDK">
+    Install the Future AGI instrumentation package and the OpenAI integration (used in this example).
+
+    <CodeGroup titles={["Python", "JS/TS"]}>
+    ```bash Python
+    pip install fi-instrumentation traceAI-openai openai
+    ```
+
+    ```bash JS/TS
+    npm install @traceai/fi-core @traceai/openai openai
+    ```
+    </CodeGroup>
+  </Step>
   <Step title="Configure Your Environment">
-    Set up your environment variables to connect to Future AGI. Get your API keys [here](https://app.futureagi.com/dashboard/keys)
+    Set up your environment variables to connect to Future AGI. Get your API keys [here](https://app.futureagi.com/dashboard/keys).
 
     <CodeGroup titles={["Python", "JS/TS"]}>
     ```python Python
     import os
     os.environ["FI_API_KEY"] = "YOUR_API_KEY"
     os.environ["FI_SECRET_KEY"] = "YOUR_SECRET_KEY"
+    os.environ["OPENAI_API_KEY"] = "YOUR_OPENAI_API_KEY"
     ```
 
     ```typescript JS/TS
-    process.env.FI_API_KEY = FI_API_KEY;
-    process.env.FI_SECRET_KEY = FI_SECRET_KEY;
+    process.env.FI_API_KEY = "YOUR_API_KEY";
+    process.env.FI_SECRET_KEY = "YOUR_SECRET_KEY";
+    process.env.OPENAI_API_KEY = "YOUR_OPENAI_API_KEY";
     ```
     </CodeGroup>
   </Step>
@@ -33,21 +50,20 @@ description: "Set up Future AGI Observe for production monitoring. Configure aut
     ```python Python
     from fi_instrumentation import register, Transport
     from fi_instrumentation.fi_types import ProjectType
-    
-    # Setup OTel via our register function
+
     trace_provider = register(
-        project_type=ProjectType.OBSERVE,  
-        project_name="FUTURE_AGI",            # Your project name
-        transport=Transport.GRPC,             # Transport mechanism for your traces
+        project_type=ProjectType.OBSERVE,
+        project_name="my-llm-app",
+        transport=Transport.GRPC,
     )
     ```
 
     ```typescript JS/TS
     import { register, ProjectType } from "@traceai/fi-core";
-    
+
     const traceProvider = register({
         project_type: ProjectType.OBSERVE,
-        project_name: "FUTURE_AGI"
+        project_name: "my-llm-app",
     });
     ```
     </CodeGroup>
@@ -57,52 +73,25 @@ description: "Set up Future AGI Observe for production monitoring. Configure aut
     - **project_name**: A descriptive name for your project
     - **transport** (optional): Set the transport for your traces. The available options are `GRPC` and `HTTP`.
   </Step>
-  <Step title="Instrument Your Project">
+  <Step title="Instrument and Run">
     There are 2 ways to implement tracing in your project:
 
-    1. **Auto Instrumentor**: Instrument your project with FutureAGI's Auto Instrumentor. Recommended for most use cases.
-    2. **Manual Tracing**: Manually track your project with Open Telemetry. Useful for more customized tracing. [Learn more →](/docs/tracing/manual/set-session-user-id)
+    1. **Auto Instrumentor**: Automatically captures all LLM calls. Recommended for most use cases.
+    2. **Manual Tracing**: Gives you full control over what gets traced using OpenTelemetry. [Learn more](/docs/tracing/manual/set-up-tracing)
 
-    **Example: Instrumenting with OpenAI**
-
-    First, install the traceAI openai package:
-
-    <CodeGroup titles={["Python", "JS/TS"]}>
-    ```bash Python
-    pip install traceAI-openai
-    ```
-
-    ```bash JS/TS
-    npm install @traceai/openai
-    ```
-    </CodeGroup>
-
-    Then instrument your project:
+    Here's a complete example using auto-instrumentation with OpenAI:
 
     <CodeGroup titles={["Python", "JS/TS"]}>
     ```python Python
     from traceai_openai import OpenAIInstrumentor
-    
-    OpenAIInstrumentor().instrument(tracer_provider=trace_provider)
-    ```
-
-    ```typescript JS/TS
-    import { OpenAIInstrumentation } from "@traceai/openai";
-    
-    const openaiInstrumentation = new OpenAIInstrumentation({});
-    ```
-    </CodeGroup>
-
-    Now use OpenAI as normal and your requests will be automatically traced:
-
-    <CodeGroup titles={["Python", "JS/TS"]}>
-    ```python Python
     from openai import OpenAI
-    
-    os.environ["OPENAI_API_KEY"] = "your-openai-api-key"
-    
+
+    # Enable auto-instrumentation
+    OpenAIInstrumentor().instrument(tracer_provider=trace_provider)
+
+    # Use OpenAI as normal
     client = OpenAI()
-    
+
     completion = client.chat.completions.create(
         model="gpt-4o",
         messages=[
@@ -112,26 +101,40 @@ description: "Set up Future AGI Observe for production monitoring. Configure aut
             }
         ]
     )
-    
+
     print(completion.choices[0].message.content)
     ```
 
     ```typescript JS/TS
+    import { OpenAIInstrumentation } from "@traceai/openai";
     import { OpenAI } from "openai";
-    
-    const client = new OpenAI({
-        apiKey: process.env.OPENAI_API_KEY,
+
+    // Enable auto-instrumentation
+    const openaiInstrumentation = new OpenAIInstrumentation({
+        tracerProvider: traceProvider,
     });
-    
+
+    // Use OpenAI as normal
+    const client = new OpenAI();
+
     const completion = await client.chat.completions.create({
         model: "gpt-4o",
         messages: [{ role: "user", content: "Write a one-sentence bedtime story about a unicorn." }],
     });
-    
+
     console.log(completion.choices[0].message.content);
     ```
     </CodeGroup>
-    
-    To learn more about supported frameworks and instrumentation options, visit our Auto Instrumentation documentation.
+  </Step>
+  <Step title="View Your Traces">
+    Open your [Future AGI dashboard](https://app.futureagi.com) and navigate to the **Observe** tab. You should see your project listed with the trace from the OpenAI call above.
+
+    Each trace shows the full request and response, latency, token usage, and cost. From here you can set up alerts, track sessions, and add inline evaluations.
   </Step>
 </Steps>
+
+## Next Steps
+
+- [Add more integrations](/docs/integrations) for Anthropic, LangChain, LlamaIndex, and others
+- [Set up manual tracing](/docs/tracing/manual/set-up-tracing) for custom spans and attributes
+- [Add inline evaluations](/docs/tracing/manual/in-line-evals) to evaluate traces as they come in


### PR DESCRIPTION
## Summary
- Added missing install step (pip/npm) so new users don't hit import errors
- Fixed inconsistent JS/TS env var syntax (bare variables to string literals)
- Changed example project name from "FUTURE_AGI" to "my-llm-app"
- Merged instrument + run into one complete copy-pasteable example
- Fixed JS OpenAI instrumentation to pass tracerProvider
- Added "View Your Traces" step so users know how to verify it worked
- Added Next Steps section linking to integrations, manual tracing, and inline evals
- Replaced "What is it?" heading with "About"

## Test plan
- [ ] Verify page renders at /docs/quickstart/setup-observability
- [ ] Check all code blocks display correctly in both Python and JS/TS tabs
- [ ] Verify all links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)