### PR TITLE
Rewrite running evals in simulation quickstart

### DIFF
--- a/src/pages/docs/quickstart/running-evals-in-simulation.mdx
+++ b/src/pages/docs/quickstart/running-evals-in-simulation.mdx
@@ -3,13 +3,13 @@ title: "Running Evals in Simulation"
 description: "Run evaluations in Future AGI simulations. Test AI agents against simulated customers and score interactions for quality, context retention, and escalation."
 ---
 
-## What is it?
+## About
 
-**Simulation** is Future AGI's agent testing product. It lets you run your AI agent against simulated customers in realistic scenarios — without real users, real calls, or production risk. You define who the customer is, what they want, and how they behave; the platform drives the conversation and scores every interaction using evaluations you configure. The result is a detailed breakdown of where your agent succeeds and where it fails, before you ship.
+**Simulation** is Future AGI's agent testing product. It lets you run your AI agent against simulated customers in realistic scenarios without real users, real calls, or production risk. You define who the customer is, what they want, and how they behave. The platform drives the conversation and scores every interaction using evaluations you configure. The result is a detailed breakdown of where your agent succeeds and where it fails, before you ship.
 
 ---
 
-Before starting, make sure you have set up your [Agent Definition](/docs/simulation/set-up/agent-definition) and [Scenarios](/docs/simulation/set-up/scenarios).
+**Prerequisites:** Before starting, make sure you have set up your [Agent Definition](/docs/simulation/set-up/agent-definition), [Scenarios](/docs/simulation/set-up/scenarios), and [Personas](/docs/simulation/set-up/personas).
 
 <Steps>
   <Step title="Open the Run Simulation Dashboard">
@@ -38,12 +38,12 @@ Before starting, make sure you have set up your [Agent Definition](/docs/simulat
 
     ![Configure eval](/screenshot/product/simulation/quickstart-running-evals-in-simulation/image3.png)
 
-    - **Name** — displayed in your simulation dashboard after the run
-    - **Language Model** — recommended: `TURING_LARGE`
-    - **Required Inputs** — map the eval's input keys to your simulation columns:
-      - `conversation` → `Mono Voice Recording` or `Stereo Recording`
-      - `input` → `person` or `situation`
-      - `output` → `Mono Voice Recording`, `Stereo Recording`, or `outcome`
+    - **Name**: displayed in your simulation dashboard after the run
+    - **Language Model**: recommended `TURING_LARGE`
+    - **Required Inputs**: map the eval's input keys to your simulation columns:
+      - `conversation` maps to `Mono Voice Recording` or `Stereo Recording`
+      - `input` maps to `person` or `situation`
+      - `output` maps to `Mono Voice Recording`, `Stereo Recording`, or `outcome`
 
     Click **Save Eval** when done.
 
@@ -57,7 +57,11 @@ Before starting, make sure you have set up your [Agent Definition](/docs/simulat
   </Step>
 
   <Step title="Run the Simulation">
-    Once you've added all the evals you need, click **Next** and then run the simulation. Results will appear in your simulation dashboard with a score for each eval.
+    Once you've added all the evals you need, click **Next** and then run the simulation.
+  </Step>
+
+  <Step title="View Results">
+    After the simulation completes, your results appear in the simulation dashboard. Each scenario shows a score for every eval you configured. You can drill into individual conversations to see the full transcript and where the agent scored well or poorly.
   </Step>
 </Steps>
 
@@ -97,3 +101,9 @@ If the built-in evals don't cover your use case, you can create your own.
     ![Custom eval saved](/screenshot/product/simulation/quickstart-running-evals-in-simulation/image9.png)
   </Step>
 </Steps>
+
+## Next Steps
+
+- [Browse all built-in evals](/docs/evaluation/builtin) to find metrics that fit your use case
+- [Set up agent definitions](/docs/simulation/set-up/agent-definition) if you haven't already
+- [Learn about simulation concepts](/docs/simulation/concepts/concepts) for a deeper understanding of how scenarios and personas work


### PR DESCRIPTION
## Summary
- Replaced "What is it?" with "About" heading
- Removed em-dashes throughout
- Added Personas to prerequisites alongside Agent Definition and Scenarios
- Added "View Results" step so users know what to expect after a run
- Added Next Steps section linking to built-in evals, agent definitions, and simulation concepts

## Test plan
- [ ] Verify page renders at /docs/quickstart/running-evals-in-simulation
- [ ] Check all links resolve
- [ ] Verify screenshots still display

🤖 Generated with [Claude Code](https://claude.com/claude-code)