### PR TITLE
Rewrite generate synthetic data quickstart

### DIFF
--- a/src/pages/docs/quickstart/generate-synthetic-data.mdx
+++ b/src/pages/docs/quickstart/generate-synthetic-data.mdx
@@ -3,37 +3,37 @@ title: "Generate Synthetic Data"
 description: "Generate synthetic datasets with Future AGI. Define schemas, column types, and constraints to create realistic data for training and evaluation."
 ---
 
-## What is it?
+## About
 
-**Dataset** is Future AGI's data management product. The synthetic data generation feature lets you create realistic, structured datasets from scratch — without collecting or exposing real user data. You define the schema, column types, and constraints; the platform generates rows that match your specification. Use it to build training sets, test edge cases, prototype AI pipelines, or create evaluation datasets when real data is unavailable or restricted.
+**Dataset** is Future AGI's data management product. The synthetic data generation feature lets you create realistic, structured datasets from scratch without collecting or exposing real user data. You define the schema, column types, and constraints. The platform generates rows that match your specification. Use it to build training sets, test edge cases, prototype AI pipelines, or create evaluation datasets when real data is unavailable or restricted.
 
 ---
 
 <Steps>
   <Step title="Open the Tool">
     Navigate to the **Dataset** section in the sidebar. Click **Add Dataset** → **Create Synthetic Data**.
-    ![tool](/public/screenshot/product/quickstart/1.png)
+    ![tool](/screenshot/product/quickstart/1.png)
 
     This opens the interface where you'll define the structure and patterns for your synthetic dataset.
   </Step>
 
   <Step title="Set Dataset Details">
     Provide the basic metadata for your dataset:
-    ![set dataset](/public/screenshot/product/quickstart/2.png)
+    ![set dataset](/screenshot/product/quickstart/2.png)
 
-    - **Name** (required) — A clear, descriptive title for the dataset.
-    - **Description** (required) — What the dataset is for and how it will be used.
-    - **Use Case** — The intended application, e.g. *"Simulated customer support logs for LLM fine-tuning"*.
-    - **Pattern** (optional) — Structural or stylistic rules, e.g. *"Follow a conversational pattern"* or *"Keep tone formal"*.
+    - **Name** (required): a clear, descriptive title for the dataset.
+    - **Description** (required): what the dataset is for and how it will be used.
+    - **Use Case**: the intended application, e.g. *"Simulated customer support logs for LLM fine-tuning"*.
+    - **Pattern** (optional): structural or stylistic rules, e.g. *"Follow a conversational pattern"* or *"Keep tone formal"*.
   </Step>
 
   <Step title="Define the Schema">
     Click **Add Column** to define the structure of each row. For every column:
-    ![properties](/public/screenshot/product/quickstart/3.png)
+    ![properties](/screenshot/product/quickstart/3.png)
 
-    - **Name** — e.g. `message`, `label`, `transcript`
-    - **Type** — `text`, `float`, `integer`, `boolean`, `array`, `json`, or `datetime`
-    - **Properties** — Add constraints (min/max, string patterns) and specify categorical values or leave dynamic for the generator to decide.
+    - **Name**: e.g. `message`, `label`, `transcript`
+    - **Type**: `text`, `float`, `integer`, `boolean`, `array`, `json`, or `datetime`
+    - **Properties**: add constraints (min/max, string patterns) and specify categorical values or leave dynamic for the generator to decide.
 
     **Example schema for a product reviews dataset:**
 
@@ -51,7 +51,16 @@ description: "Generate synthetic datasets with Future AGI. Define schemas, colum
 
   <Step title="Generate the Dataset">
     Review the schema and example values in the preview. Make any adjustments needed, then click **Create** to generate the full dataset.
+  </Step>
 
-    Once complete, the dataset is saved and ready to explore or use in downstream tasks.
+  <Step title="Explore Your Dataset">
+    Once generation is complete, the dataset is saved and available in your Dataset section. You can browse the generated rows, edit individual entries, add new columns, or use it directly in evaluations and experiments.
   </Step>
 </Steps>
+
+## Next Steps
+
+- [Run evaluations on your dataset](/docs/evaluation) to test AI outputs against the generated data
+- [Use Knowledge Base](/docs/knowledge-base) to ground synthetic data generation with your own documents
+- [Run prompts on your dataset](/docs/dataset/features/run-prompt) to add model-generated columns
+- [Set up experiments](/docs/dataset/features/experiments) to compare different prompts or models against your dataset


### PR DESCRIPTION
## Summary
- Replaced "What is it?" with "About" heading
- Fixed broken image paths from `/public/screenshot/` to `/screenshot/`
- Added "Explore Your Dataset" step so users know what to do after generation
- Added Next Steps section linking to evaluations, Knowledge Base, run prompts, and experiments

## Test plan
- [ ] Verify page renders at /docs/quickstart/generate-synthetic-data
- [ ] Check all images load (previously had `/public/` prefix bug)
- [ ] Verify all links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)