### PR TITLE
fix: correct required keys for RAG evals (hypothesis/reference, not output/context)

### DIFF
--- a/src/pages/docs/evaluation/builtin/index.mdx
+++ b/src/pages/docs/evaluation/builtin/index.mdx
@@ -96,13 +96,13 @@ description: "All built-in evaluation templates available on the platform."
 | **Answer Similarity** | Measures semantic similarity between generated answer and reference. | `output`, `expected_response` | Text | Statistical Metric |
 | **BLEU Score** | Computes BLEU score between expected answer and model output. | `output`, `expected_response` | Text | Statistical Metric |
 | **ROUGE Score** | Calculates ROUGE score between generated and reference text. | `output`, `expected_response` | Text | Statistical Metric |
-| **Recall Score (Deprecated)** | Evaluates recall of relevant information from retrieved context. Use **Recall@K** instead. | `output`, `context` | Text, RAG & Retrieval | Statistical Metric |
+| **Recall Score (Deprecated)** | Evaluates recall of relevant information from retrieved context. Use **Recall@K** instead. | `hypothesis`, `reference` | Text, RAG & Retrieval | Statistical Metric |
 | **Levenshtein Similarity** | Calculates edit distance between generated and reference text. | `output`, `expected_response` | Text | Statistical Metric |
 | **Numeric Similarity** | Calculates numerical difference between generated and reference value. | `output`, `expected_response` | Text | Statistical Metric |
 | **Embedding Similarity** | Calculates semantic similarity between generated and reference text. | `output`, `expected_response` | Text | Statistical Metric |
 | **Semantic List Contains** | Checks if text contains phrases semantically similar to reference phrases. | `output`, `expected_response` | Text | Statistical Metric |
-| **Recall@K** | Evaluates recall at K for retrieval-based systems. | `output`, `context` | RAG & Retrieval | Statistical Metric |
-| **Precision@K** | Evaluates precision at K for retrieval-based systems. | `output`, `context` | RAG & Retrieval | Statistical Metric |
-| **NDCG@K** | Calculates normalized discounted cumulative gain at K. | `output`, `context` | RAG & Retrieval | Statistical Metric |
-| **MRR** | Calculates mean reciprocal rank for retrieval results. | `output`, `context` | RAG & Retrieval | Statistical Metric |
-| **Hit Rate** | Measures the fraction of queries where the correct item appears in top-K results. | `output`, `context` | RAG & Retrieval | Statistical Metric |
+| **Recall@K** | Evaluates recall at K for retrieval-based systems. | `hypothesis`, `reference` | RAG & Retrieval | Statistical Metric |
+| **Precision@K** | Evaluates precision at K for retrieval-based systems. | `hypothesis`, `reference` | RAG & Retrieval | Statistical Metric |
+| **NDCG@K** | Calculates normalized discounted cumulative gain at K. | `hypothesis`, `reference` | RAG & Retrieval | Statistical Metric |
+| **MRR** | Calculates mean reciprocal rank for retrieval results. | `hypothesis`, `reference` | RAG & Retrieval | Statistical Metric |
+| **Hit Rate** | Measures the fraction of queries where the correct item appears in top-K results. | `hypothesis`, `reference` | RAG & Retrieval | Statistical Metric |


### PR DESCRIPTION
The main builtin evals index page had wrong required keys for all RAG retrieval metrics.

All 6 metrics (Recall@K, Precision@K, NDCG@K, MRR, Hit Rate, Recall Score) were listed with `output`, `context` but the actual required keys are `hypothesis`, `reference`.

**File changed:** `src/pages/docs/evaluation/builtin/index.mdx`