### PR TITLE
Rewrite dataset overview and reorder sidebar alphabetically

### DIFF
--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -54,6 +54,77 @@ export const tabNavigation: NavTab[] = [
         ]
       },
       {
+        group: 'Annotations',
+        icon: 'pen',
+        items: [
+          { title: 'Overview', href: '/docs/annotations' },
+          { title: 'Quickstart', href: '/docs/annotations/quickstart' },
+          {
+            title: 'Concepts',
+            items: [
+              { title: 'Labels', href: '/docs/annotations/concepts/labels' },
+              { title: 'Queues & Workflow', href: '/docs/annotations/concepts/queues' },
+              { title: 'Scores', href: '/docs/annotations/concepts/scores' },
+            ]
+          },
+          {
+            title: 'Features',
+            items: [
+              { title: 'Create & Manage Labels', href: '/docs/annotations/features/labels' },
+              { title: 'Create & Manage Queues', href: '/docs/annotations/features/queues' },
+              { title: 'Add Items to Queues', href: '/docs/annotations/features/add-items' },
+              { title: 'Annotate Items', href: '/docs/annotations/features/annotate' },
+              { title: 'Inline Annotations', href: '/docs/annotations/features/inline' },
+              { title: 'Analytics & Agreement', href: '/docs/annotations/features/analytics' },
+              { title: 'Export Annotations', href: '/docs/annotations/features/export' },
+              { title: 'Automation Rules', href: '/docs/annotations/features/automation' },
+            ]
+          },
+          {
+            title: 'SDK',
+            items: [
+              { title: 'Python SDK', href: '/docs/annotations/sdk/python' },
+              { title: 'JavaScript SDK', href: '/docs/annotations/sdk/javascript' },
+            ]
+          },
+        ]
+      },
+      {
+        group: 'Dataset',
+        icon: 'table',
+        items: [
+          { title: 'Overview', href: '/docs/dataset' },
+          {
+            title: 'Concepts',
+            items: [
+              { title: 'Understanding Datasets', href: '/docs/dataset/concept/understanding-dataset' },
+              { title: 'Static Columns', href: '/docs/dataset/concept/static-column' },
+              { title: 'Dynamic Columns', href: '/docs/dataset/concept/dynamic-column' },
+              { title: 'Synthetic Data', href: '/docs/dataset/concept/synthetic-data' },
+            ]
+          },
+          {
+            title: 'Features',
+            items: [
+              { title: 'Create New Dataset', href: '/docs/dataset/features/create' },
+              { title: 'Add Rows to Dataset', href: '/docs/dataset/features/add-rows' },
+              { title: 'Add Columns to Dataset', href: '/docs/dataset/features/add-columns' },
+              { title: 'Run Prompt in Dataset', href: '/docs/dataset/features/run-prompt' },
+              { title: 'Experiments in Dataset', href: '/docs/dataset/features/experiments' },
+              { title: 'Add Annotation', href: '/docs/dataset/features/annotate' },
+            ]
+          },
+        ]
+      },
+      {
+        group: 'Error Feed',
+        icon: 'compass',
+        items: [
+          { title: 'Overview', href: '/docs/error-feed' },
+          { title: 'Taxonomy', href: '/docs/error-feed/taxonomy' },
+        ]
+      },
+      {
         group: 'Evaluation',
         icon: 'chart',
         items: [
@@ -68,6 +139,26 @@ export const tabNavigation: NavTab[] = [
               { title: 'Use Custom Models', href: '/docs/evaluation/features/custom-models' },
               { title: 'Future AGI Models', href: '/docs/evaluation/features/futureagi-models' },
               { title: 'Evaluate CI/CD Pipeline', href: '/docs/evaluation/features/cicd' },
+            ]
+          },
+        ]
+      },
+      {
+        group: 'Knowledge Base',
+        icon: 'brain',
+        items: [
+          { title: 'Overview', href: '/docs/knowledge-base' },
+          {
+            title: 'Concepts',
+            items: [
+              { title: 'Concept', href: '/docs/knowledge-base/concepts/concept' },
+            ]
+          },
+          {
+            title: 'Features',
+            items: [
+              { title: 'Create KB Using SDK', href: '/docs/knowledge-base/features/sdk' },
+              { title: 'Create KB Using UI', href: '/docs/knowledge-base/features/ui' },
             ]
           },
         ]
@@ -172,139 +263,6 @@ export const tabNavigation: NavTab[] = [
         ]
       },
       {
-        group: 'Dataset',
-        icon: 'table',
-        items: [
-          { title: 'Overview', href: '/docs/dataset' },
-          {
-            title: 'Features',
-            items: [
-              { title: 'Create New Dataset', href: '/docs/dataset/features/create' },
-              { title: 'Add Rows to Dataset', href: '/docs/dataset/features/add-rows' },
-              { title: 'Add Columns to Dataset', href: '/docs/dataset/features/add-columns' },
-              { title: 'Run Prompt in Dataset', href: '/docs/dataset/features/run-prompt' },
-              { title: 'Experiments in Dataset', href: '/docs/dataset/features/experiments' },
-              { title: 'Add Annotation', href: '/docs/dataset/features/annotate' },
-            ]
-          },
-          {
-            title: 'Concepts',
-            items: [
-              { title: 'Understanding Datasets', href: '/docs/dataset/concept/understanding-dataset' },
-              { title: 'Static Columns', href: '/docs/dataset/concept/static-column' },
-              { title: 'Dynamic Columns', href: '/docs/dataset/concept/dynamic-column' },
-              { title: 'Synthetic Data', href: '/docs/dataset/concept/synthetic-data' },
-            ]
-          },
-        ]
-      },
-      {
-        group: 'Simulation',
-        icon: 'play',
-        items: [
-          { title: 'Overview', href: '/docs/simulation' },
-          {
-            title: 'Set Up',
-            items: [
-              { title: 'Agent Definition', href: '/docs/simulation/set-up/agent-definition' },
-              { title: 'Scenarios', href: '/docs/simulation/set-up/scenarios' },
-              { title: 'Personas', href: '/docs/simulation/set-up/personas' },
-            ]
-          },
-          {
-            title: 'Features',
-            items: [
-              { title: 'Simulation Using SDK', href: '/docs/simulation/features/simulation-using-sdk' },
-              { title: 'Evaluate Tool Calling', href: '/docs/simulation/features/evaluate-tool-calling' },
-              { title: 'Fix My Agent', href: '/docs/simulation/features/fix-my-agent' },
-              { title: 'Replay', href: '/docs/simulation/features/observe-to-simulate' },
-              { title: 'Prompt Simulation', href: '/docs/simulation/features/prompt-simulation' },
-            ]
-          },
-          {
-            title: 'Concepts',
-            items: [
-              { title: 'Concepts', href: '/docs/simulation/concepts/concepts' },
-            ]
-          },
-        ]
-      },
-      {
-        group: 'Prompt',
-        icon: 'zap',
-        items: [
-          { title: 'Overview', href: '/docs/prompt' },
-          {
-            title: 'Concepts',
-            items: [
-              { title: 'Concept', href: '/docs/prompt/concepts/concept' },
-            ]
-          },
-          {
-            title: 'Features',
-            items: [
-              { title: 'Create Prompt from Scratch', href: '/docs/prompt/features/create-from-scratch' },
-              { title: 'Create from Existing Template', href: '/docs/prompt/features/create-from-template' },
-              { title: 'Create with AI', href: '/docs/prompt/features/create-with-ai' },
-              { title: 'Prompt Workbench Using SDK', href: '/docs/prompt/features/sdk' },
-              { title: 'Linked Traces', href: '/docs/prompt/features/linked-traces' },
-              { title: 'Manage Folders', href: '/docs/prompt/features/folders' },
-            ]
-          },
-        ]
-      },
-      {
-        group: 'Prototype',
-        icon: 'flask',
-        items: [
-          { title: 'Overview', href: '/docs/prototype' },
-          {
-            title: 'Features',
-            items: [
-              { title: 'Set Up Prototype', href: '/docs/prototype/features/set-up-prototype' },
-              { title: 'Evals', href: '/docs/prototype/features/evals' },
-              { title: 'Choose Winner', href: '/docs/prototype/features/choose-winner' },
-            ]
-          },
-        ]
-      },
-      {
-        group: 'Annotations',
-        icon: 'pen',
-        items: [
-          { title: 'Overview', href: '/docs/annotations' },
-          { title: 'Quickstart', href: '/docs/annotations/quickstart' },
-          {
-            title: 'Concepts',
-            items: [
-              { title: 'Labels', href: '/docs/annotations/concepts/labels' },
-              { title: 'Queues & Workflow', href: '/docs/annotations/concepts/queues' },
-              { title: 'Scores', href: '/docs/annotations/concepts/scores' },
-            ]
-          },
-          {
-            title: 'Features',
-            items: [
-              { title: 'Create & Manage Labels', href: '/docs/annotations/features/labels' },
-              { title: 'Create & Manage Queues', href: '/docs/annotations/features/queues' },
-              { title: 'Add Items to Queues', href: '/docs/annotations/features/add-items' },
-              { title: 'Annotate Items', href: '/docs/annotations/features/annotate' },
-              { title: 'Inline Annotations', href: '/docs/annotations/features/inline' },
-              { title: 'Analytics & Agreement', href: '/docs/annotations/features/analytics' },
-              { title: 'Export Annotations', href: '/docs/annotations/features/export' },
-              { title: 'Automation Rules', href: '/docs/annotations/features/automation' },
-            ]
-          },
-          {
-            title: 'SDK',
-            items: [
-              { title: 'Python SDK', href: '/docs/annotations/sdk/python' },
-              { title: 'JavaScript SDK', href: '/docs/annotations/sdk/javascript' },
-            ]
-          },
-        ]
-      },
-      {
         group: 'Optimization',
         icon: 'gauge',
         items: [
@@ -334,33 +292,6 @@ export const tabNavigation: NavTab[] = [
               { title: 'Using Python SDK', href: '/docs/optimization/features/using-python-sdk' },
               { title: 'Using Platform', href: '/docs/optimization/features/using-platform' },
               { title: 'Dataset Optimization', href: '/docs/optimization/features/dataset-optimization' },
-            ]
-          },
-        ]
-      },
-      {
-        group: 'Error Feed',
-        icon: 'compass',
-        items: [
-          { title: 'Overview', href: '/docs/error-feed' },
-          { title: 'Taxonomy', href: '/docs/error-feed/taxonomy' },
-        ]
-      },
-      {
-        group: 'Protect',
-        icon: 'shield',
-        items: [
-          { title: 'Overview', href: '/docs/protect' },
-          {
-            title: 'Concepts',
-            items: [
-              { title: 'Concept', href: '/docs/protect/concepts/concept' },
-            ]
-          },
-          {
-            title: 'Features',
-            items: [
-              { title: 'Run Protect via SDK', href: '/docs/protect/features/run-protect' },
             ]
           },
         ]
@@ -403,21 +334,59 @@ export const tabNavigation: NavTab[] = [
         ]
       },
       {
-        group: 'Knowledge Base',
-        icon: 'brain',
+        group: 'Prompt',
+        icon: 'zap',
         items: [
-          { title: 'Overview', href: '/docs/knowledge-base' },
+          { title: 'Overview', href: '/docs/prompt' },
           {
             title: 'Concepts',
             items: [
-              { title: 'Concept', href: '/docs/knowledge-base/concepts/concept' },
+              { title: 'Concept', href: '/docs/prompt/concepts/concept' },
             ]
           },
           {
             title: 'Features',
             items: [
-              { title: 'Create KB Using SDK', href: '/docs/knowledge-base/features/sdk' },
-              { title: 'Create KB Using UI', href: '/docs/knowledge-base/features/ui' },
+              { title: 'Create Prompt from Scratch', href: '/docs/prompt/features/create-from-scratch' },
+              { title: 'Create from Existing Template', href: '/docs/prompt/features/create-from-template' },
+              { title: 'Create with AI', href: '/docs/prompt/features/create-with-ai' },
+              { title: 'Prompt Workbench Using SDK', href: '/docs/prompt/features/sdk' },
+              { title: 'Linked Traces', href: '/docs/prompt/features/linked-traces' },
+              { title: 'Manage Folders', href: '/docs/prompt/features/folders' },
+            ]
+          },
+        ]
+      },
+      {
+        group: 'Protect',
+        icon: 'shield',
+        items: [
+          { title: 'Overview', href: '/docs/protect' },
+          {
+            title: 'Concepts',
+            items: [
+              { title: 'Concept', href: '/docs/protect/concepts/concept' },
+            ]
+          },
+          {
+            title: 'Features',
+            items: [
+              { title: 'Run Protect via SDK', href: '/docs/protect/features/run-protect' },
+            ]
+          },
+        ]
+      },
+      {
+        group: 'Prototype',
+        icon: 'flask',
+        items: [
+          { title: 'Overview', href: '/docs/prototype' },
+          {
+            title: 'Features',
+            items: [
+              { title: 'Set Up Prototype', href: '/docs/prototype/features/set-up-prototype' },
+              { title: 'Evals', href: '/docs/prototype/features/evals' },
+              { title: 'Choose Winner', href: '/docs/prototype/features/choose-winner' },
             ]
           },
         ]
@@ -430,6 +399,37 @@ export const tabNavigation: NavTab[] = [
           { title: 'Roles & Permissions', href: '/docs/roles-and-permissions' },
           { title: 'FAQ', href: '/docs/faq' },
           { title: 'Release Notes', href: '/docs/release-notes' },
+        ]
+      },
+      {
+        group: 'Simulation',
+        icon: 'play',
+        items: [
+          { title: 'Overview', href: '/docs/simulation' },
+          {
+            title: 'Concepts',
+            items: [
+              { title: 'Concepts', href: '/docs/simulation/concepts/concepts' },
+            ]
+          },
+          {
+            title: 'Set Up',
+            items: [
+              { title: 'Agent Definition', href: '/docs/simulation/set-up/agent-definition' },
+              { title: 'Scenarios', href: '/docs/simulation/set-up/scenarios' },
+              { title: 'Personas', href: '/docs/simulation/set-up/personas' },
+            ]
+          },
+          {
+            title: 'Features',
+            items: [
+              { title: 'Simulation Using SDK', href: '/docs/simulation/features/simulation-using-sdk' },
+              { title: 'Evaluate Tool Calling', href: '/docs/simulation/features/evaluate-tool-calling' },
+              { title: 'Fix My Agent', href: '/docs/simulation/features/fix-my-agent' },
+              { title: 'Replay', href: '/docs/simulation/features/observe-to-simulate' },
+              { title: 'Prompt Simulation', href: '/docs/simulation/features/prompt-simulation' },
+            ]
+          },
         ]
       },
     ]

--- a/src/pages/docs/dataset/index.mdx
+++ b/src/pages/docs/dataset/index.mdx
@@ -3,23 +3,36 @@ title: "Overview"
 description: "Create, manage and analyze datasets for AI model development and evaluation"
 ---
 
-## What it is
+## About
 
-Datasets are the core data layer for evaluation and experimentation. Each dataset is a table: *columns* (e.g. "user query", "expected answer", "score"), *rows* (one row = one example), and *cells* (the value in each column for each row). Datasets are the single source of truth that prompts, evals, experiments, and optimizations run on.
+Datasets are the core data layer for evaluation and experimentation in Future AGI. Each dataset is a table with columns (e.g. "user query", "expected answer", "score"), rows (one row per example), and cells (the value in each column for each row).
+
+Datasets are the single source of truth that prompts, evaluations, experiments, and optimizations run on. You can create them from file uploads, the SDK, observed production traces, or synthetic generation.
+
 <iframe
   className="w-full aspect-video rounded-xl"
   src="https://www.youtube.com/embed/zDdFn_pcLhI"
-  title="YouTube video player"
+  title="Datasets overview"
   frameBorder="0"
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
   allowFullScreen
 ></iframe>
-## Purpose
 
-- Store and manage test/eval data in one place.
-- Run prompts and evals over the same structured data.
-- Compare model or prompt performance across experiments.
-- Support building datasets from product usage (e.g. from observed traces) as well as from uploads, API, or synthetic generation.
+## Column Types
+
+Datasets support two types of columns:
+
+- **Static columns**: Data you add directly, either manually, via file upload, or through the SDK. These hold your inputs, expected outputs, ground truth labels, or any fixed data.
+- **Dynamic columns**: Generated on-the-fly by running a prompt, evaluation, or model against your dataset rows. For example, running GPT-4o on every row creates a dynamic column with the model's responses.
+
+This distinction matters because dynamic columns let you add model outputs, evaluation scores, and computed fields to your dataset without duplicating data.
+
+## How Datasets Connect to Other Features
+
+- **Evaluation**: Run 70+ built-in metrics across your dataset rows to score model outputs. Results are stored as new columns. [Learn more](/docs/evaluation)
+- **Experiments**: Compare two prompts or models by running both against the same dataset and comparing scores side by side. [Learn more](/docs/dataset/features/experiments)
+- **Optimization**: Use datasets as the training ground for prompt optimization algorithms. [Learn more](/docs/optimization)
+- **Observe**: Build datasets from production traces to test against real user queries. [Learn more](/docs/observe)
 
 ## Getting Started with Datasets
 
@@ -43,4 +56,10 @@ Datasets are the core data layer for evaluation and experimentation. Each datase
     Add metadata and annotations to enrich your dataset
   </Card>
 </CardGroup>
+
+## Next Steps
+
+- [Understanding Datasets](/docs/dataset/concept/understanding-dataset): Deeper dive into dataset concepts, column types, and best practices
+- [Generate Synthetic Data](/docs/quickstart/generate-synthetic-data): Create realistic datasets from scratch when real data is unavailable
+- [Import from HuggingFace](/docs/cookbook/quickstart/huggingface-dataset-import): Bring existing HuggingFace datasets into Future AGI
 


### PR DESCRIPTION
## Summary
- Rewrote dataset overview page: replaced "What it is" with "About", added Column Types section (static vs dynamic), added cross-links to evaluation/experiments/optimization/observe, added Next Steps
- Reordered all sidebar groups alphabetically (Annotations, Dataset, Error Feed, Evaluation, Knowledge Base, Observability, Optimization, Prism, Prompt, Protect, Prototype, Resources, Simulation)
- Swapped Dataset nav order from Features→Concepts to Concepts→Features
- Swapped Simulation nav order to put Concepts before Set Up and Features

## Test plan
- [ ] Verify sidebar groups appear in alphabetical order
- [ ] Verify /docs/dataset page renders correctly with new content
- [ ] Verify Dataset and Simulation sub-sections show Overview→Concepts→Features order

🤖 Generated with [Claude Code](https://claude.com/claude-code)