### PR TITLE
Standardize all dataset feature pages

### DIFF
--- a/src/pages/docs/dataset/features/add-columns.mdx
+++ b/src/pages/docs/dataset/features/add-columns.mdx
@@ -3,22 +3,22 @@ title: "Add Columns to Dataset"
 description: "Add static columns for fixed values or dynamic columns whose values are computed from other columns or external operations."
 ---
 
-## What it is
+## About
 
 Adding a column extends your dataset with a new field. Columns can be of two kinds:
 
-- **Static columns** – Store fixed values (text, numbers, boolean, array, JSON) that you enter or paste. They do not require computation; you edit cells manually.
-- **Dynamic columns** – <Tooltip tip="Dynamic columns are generated on-the-fly and contain data derived from other columns or external operations." cta="Learn more about dynamic columns" href="/docs/dataset/concept/dynamic-column">Values are computed or fetched</Tooltip> when you need them (e.g. from an LLM prompt, vector DB, API, custom code, or from existing columns). You configure the type, test, then create; the system fills the column row by row.
+- **[Static columns](/docs/dataset/concept/static-column)**: Store fixed values (text, numbers, boolean, array, JSON) that you enter or paste. They do not require computation; you edit cells manually.
+- **[Dynamic columns](/docs/dataset/concept/dynamic-column)**: <Tooltip tip="Dynamic columns are generated on-the-fly and contain data derived from other columns or external operations." cta="Learn more about dynamic columns" href="/docs/dataset/concept/dynamic-column">Values are computed or fetched</Tooltip> when you need them (e.g. from an LLM prompt, vector DB, API, custom code, or from existing columns). You configure the type, test, then create; the system fills the column row by row.
 
 Both are added via **+ Add Columns** in your dataset.
 
-## Use cases
+## When to use
 
-- **Store reference data** – Keep fixed labels, scores, or expected outputs alongside generated responses for use in evals.
-- **Generate model responses** – Run a prompt on each row and store the output in a new column, ready for evaluation or comparison.
-- **Add retrieved context** – Fetch relevant chunks from a vector database per row for RAG evaluation or prompt injection.
-- **Classify by category** – Assign topic, sentiment, or intent labels to each row using a model and your predefined categories.
-- **Extract from free text** – Pull specific entities or values from an unstructured column into a clean, structured column.
+- **Store reference data**: Keep fixed labels, scores, or expected outputs alongside generated responses for use in evals.
+- **Generate model responses**: Run a prompt on each row and store the output in a new column, ready for evaluation or comparison.
+- **Add retrieved context**: Fetch relevant chunks from a vector database per row for RAG evaluation or prompt injection.
+- **Classify by category**: Assign topic, sentiment, or intent labels to each row using a model and your predefined categories.
+- **Extract from free text**: Pull specific entities or values from an unstructured column into a clean, structured column.
 
 ## How to
 
@@ -167,7 +167,7 @@ Open your dataset and click **+ Add Columns**. Choose **Static** for fixed value
   </Tab>
 </Tabs>
 
-## What you can do next
+## Next Steps
 
 <CardGroup cols={2}>
   <Card title="Add Rows to Dataset" icon="table-rows" href="/docs/dataset/features/add-rows">

--- a/src/pages/docs/dataset/features/add-rows.mdx
+++ b/src/pages/docs/dataset/features/add-rows.mdx
@@ -3,17 +3,17 @@ title: "Add Rows to Dataset"
 description: "Learn how to add rows to your dataset"
 ---
 
-## What it is
+## About
 
-Add Rows is how you add more data points (rows) to an existing dataset. Each new row gets one cell per column; you either provide the values, copy them from another dataset or source, or generate them (e.g. synthetic or from traces). The dataset's columns stay as they are; only new rows (and their cells) are created.
+Add Rows is how you add more data points (rows) to an existing dataset. Each new row gets one cell per column. You either provide the values, copy them from another dataset or source, or generate them (e.g. synthetic or from traces). The dataset's columns stay as they are; only new rows and their cells are created.
 
-## Use cases
+## When to use
 
-- **Manual or API data entry** – You have new test cases (e.g. new queries or examples). Add rows with cell values via the UI or API so they become part of the same dataset for run prompt and evals.
-- **Copy from another dataset** – You have rows in a different dataset (or an experiment snapshot) and want them in this one. Add rows from that source with a column mapping so the right fields line up.
-- **Append from Hugging Face** – You want more examples from a Hugging Face dataset. Add rows from that dataset into the current one so you don't re-import from scratch.
-- **Generate more synthetic data** – The dataset was created with synthetic config; you want more rows with the same logic. Add synthetic rows to fill more of the table.
-- **Bring in more production data** – You have new traces/spans in the tracer. Add them to an existing dataset (with the same or updated mapping) so evals and experiments stay on one dataset.
+- **Manual or API data entry**: You have new test cases (e.g. new queries or examples). Add rows with cell values via the UI or API so they become part of the same dataset for run prompt and evals.
+- **Copy from another dataset**: You have rows in a different dataset (or an experiment snapshot) and want them in this one. Add rows from that source with a column mapping so the right fields line up.
+- **Append from Hugging Face**: You want more examples from a Hugging Face dataset. Add rows from that dataset into the current one so you don't re-import from scratch.
+- **Generate more synthetic data**: The dataset was created with synthetic config; you want more rows with the same logic. Add synthetic rows to fill more of the table.
+- **Bring in more production data**: You have new traces/spans in the tracer. Add them to an existing dataset so evals and experiments stay on one dataset.
 
 ## How to
 
@@ -112,7 +112,7 @@ Use the SDK to append rows to an existing dataset.
 
     process.env["FI_API_KEY"] = "<fi_api_key>";
     process.env["FI_SECRET_KEY"] = "<fi_secret_key>";
-    process.env["FI_BASE_URL"] = "https://dev.api.futureagi.com";
+    process.env["FI_BASE_URL"] = "https://api.futureagi.com";
 
     async function main() {
       try {
@@ -121,7 +121,7 @@ Use the SDK to append rows to an existing dataset.
         // 1) Open the dataset (fetch if it exists, create if not)
         const dataset = await Dataset.open(dsName);
 
-        // 3) Define rows
+        // 2) Define rows
         const rows = [
           createRow({
             cells: [
@@ -150,7 +150,7 @@ Use the SDK to append rows to an existing dataset.
 
     ```bash Curl
     curl --request POST \
-      --url https://dev.api.futureagi.com/model-hub/develops/<dataset_id>/add_rows/ \
+      --url https://api.futureagi.com/model-hub/develops/<dataset_id>/add_rows/ \
       --header 'content-type: application/json' \
       --header 'X-Api-Key: <fi_api_key>' \
       --header 'X-Secret-Key: <fi_secret_key>' \
@@ -279,7 +279,7 @@ Upload a file (CSV, JSON, JSONL, or Excel) to append rows to your dataset.
 The number of columns will increase automatically to match the number of columns in the new dataset. And the cells will be None by default.
 </Note>
 
-## What you can do next
+## Next Steps
 
 <CardGroup cols={2}>
   <Card title="Add Columns to Dataset" icon="table-columns" href="/docs/dataset/features/add-columns">

--- a/src/pages/docs/dataset/features/annotate.mdx
+++ b/src/pages/docs/dataset/features/annotate.mdx
@@ -3,18 +3,18 @@ title: "Add Annotations"
 description: "Annotations are essential for refining datasets, evaluating model outputs, and improving the quality of AI-generated responses."
 ---
 
-## What it is
+## About
 
-Annotations let you add human labels to dataset rows so you can evaluate model outputs, build training or evaluation data, and improve quality. You create **annotation views** on a dataset: each view defines which columns are shown as context (static fields), which columns hold the content to annotate (response fields), and which **label** (e.g. sentiment, score, free text) is used. Annotators (workspace members you assign) fill in labels per row. For categorical labels, you can optionally use **auto-annotation** to get suggestions based on your existing labels. Human-in-the-loop (HITL) annotation helps maintain accuracy, safety, and coherence in generative AI.
+Annotations let you add human labels to dataset rows so you can evaluate model outputs, build training or evaluation data, and improve quality. You create **annotation views** on a dataset: each view defines which columns are shown as context (static fields), which columns hold the content to annotate (response fields), and which **label** (e.g. sentiment, score, free text) is used. Annotators (workspace members you assign) fill in labels per row. For categorical labels, you can optionally use **auto-annotation** to get suggestions based on your existing labels.
 
-## Use cases
+## When to use
 
-- **Sentiment analysis** – Categorical labels (e.g. Positive, Negative, Neutral) to measure tone of model outputs.
-- **Factuality check** – Boolean or text labels to validate whether the output is grounded in the source.
-- **Toxicity review** – Categorical labels to flag harmful, biased, or unsafe responses.
-- **Relevance scoring** – Numeric (or star) labels to rate how well the response addresses the query.
-- **Grammar / style edits** – Text labels to provide corrections or rewritten versions.
-- **Prompt comparison** – Categorical or numeric labels to compare responses from different prompt variants.
+- **Sentiment analysis**: Categorical labels (e.g. Positive, Negative, Neutral) to measure tone of model outputs.
+- **Factuality check**: Boolean or text labels to validate whether the output is grounded in the source.
+- **Toxicity review**: Categorical labels to flag harmful, biased, or unsafe responses.
+- **Relevance scoring**: Numeric (or star) labels to rate how well the response addresses the query.
+- **Grammar / style edits**: Text labels to provide corrections or rewritten versions.
+- **Prompt comparison**: Categorical or numeric labels to compare responses from different prompt variants.
 
 ## How to
 
@@ -67,7 +67,7 @@ For structured, multi-annotator annotation campaigns with progress tracking, ass
   </Card>
 </CardGroup>
 
-## What you can do next
+## Next Steps
 
 <CardGroup cols={2}>
   <Card title="Add Rows to Dataset" icon="table-rows" href="/docs/dataset/features/add-rows">

--- a/src/pages/docs/dataset/features/create.mdx
+++ b/src/pages/docs/dataset/features/create.mdx
@@ -3,17 +3,17 @@ title: "Create New Dataset"
 description: "Learn to create datasets to do experimentations on them"
 ---
 
-## What it is
+## About
 
 Creating a new dataset adds a blank table (or a table filled from a source) under your organization. You get a dataset with a name and optional columns/rows that you can then use for run prompt, evals, experiments, and optimization. The dataset is the container; you can keep editing it after creation.
 
-## Use cases
+## When to use
 
-- **Evaluate a prompt or model** – You need a set of inputs and (optionally) expected outputs or scores. Creating a dataset gives you that table so you can run prompts and evals on it.
-- **Reuse production data** – You have traces/spans from your app and want to turn them into eval data. Creating a dataset from "observe" (or adding to a new one) turns selected traces into rows.
-- **Import existing data** – You already have test cases in CSV/Excel or on Hugging Face. Creating a dataset from file or Hugging Face imports that data so you don't have to type it in.
-- **Generate test data** – You don't have real data yet but know the kind of examples you need. Creating a synthetic dataset (with description, objective, patterns) generates rows for you.
-- **Branch from an experiment** – You ran an experiment and want to keep that snapshot as a standalone dataset to edit or reuse. Creating a dataset from that experiment copies it into a new dataset.
+- **Evaluate a prompt or model**: You need a set of inputs and (optionally) expected outputs or scores. Creating a dataset gives you that table so you can run prompts and evals on it.
+- **Reuse production data**: You have traces/spans from your app and want to turn them into eval data. Creating a dataset from Observe turns selected traces into rows.
+- **Import existing data**: You already have test cases in CSV/Excel or on Hugging Face. Creating a dataset from file or Hugging Face imports that data so you don't have to type it in.
+- **Generate test data**: You don't have real data yet but know the kind of examples you need. Creating a [synthetic dataset](/docs/dataset/concept/synthetic-data) generates rows for you.
+- **Branch from an experiment**: You ran an experiment and want to keep that snapshot as a standalone dataset to edit or reuse. Creating a dataset from that experiment copies it into a new dataset.
 
 ## How to
 
@@ -29,7 +29,7 @@ Use SDK to import your data to Future AGI.
     ![assign_dataset_name](/screenshot/product/dataset/how-to/create-new-dataset/1.png)
   </Step>
   <Step title="Add Rows via SDK">
-    You will be greeted with a screen containing code snippet to add rows to your dataset.
+    Use the code snippet below to add rows to your dataset.
     
     <CodeGroup>
 
@@ -157,23 +157,28 @@ Use SDK to import your data to Future AGI.
   
     ```
 
-    ```bash Curl
-    curl --request POST     --url https://api.futureagi.com/model-hub/develops/<dataset_id>/add_columns/     --header 'X-Api-Key: <fi_api_key>'     --header 'X-Secret-Key: <fi_secret_key>'     --header 'content-type: application/json'     --data '{
-    "new_columns_data": [
-        {
-        "name": "user_query",
-        "data_type": "text"
-        },
-        {
-        "name": "response_quality",
-        "data_type": "integer"
-        },
-        {
-        "name": "is_helpful",
-        "data_type": "boolean"
-        }
-    ]
-}'
+    ```bash cURL
+    curl --request POST \
+      --url https://api.futureagi.com/model-hub/develops/<dataset_id>/add_columns/ \
+      --header 'X-Api-Key: <fi_api_key>' \
+      --header 'X-Secret-Key: <fi_secret_key>' \
+      --header 'content-type: application/json' \
+      --data '{
+        "new_columns_data": [
+          {
+            "name": "user_query",
+            "data_type": "text"
+          },
+          {
+            "name": "response_quality",
+            "data_type": "integer"
+          },
+          {
+            "name": "is_helpful",
+            "data_type": "boolean"
+          }
+        ]
+      }'
     ```
 
     </CodeGroup>
@@ -240,7 +245,7 @@ Manually create dataset from scratch.
   <Step title="Provide Basic Details">
     To proceed with creating dataset manually from scratch, provide the name you want to assign and the number of columns and rows you want.
     ![manually](/screenshot/product/dataset/how-to/create-new-dataset/8.png)
-    You will be greeted with an empty dataset with the name you assigned and with empty rows and columns.
+    This creates an empty dataset with the name you assigned and empty rows and columns.
     ![empty_dataset](/screenshot/product/dataset/how-to/create-new-dataset/9.png)
   </Step>
   <Step title="Populating the dataset">
@@ -289,7 +294,7 @@ You can create a subset from an existing dataset.
   </Tab>
 </Tabs>
 
-## What you can do next
+## Next Steps
 
 <CardGroup cols={2}>
   <Card title="Add Rows to Dataset" icon="table-rows" href="/docs/dataset/features/add-rows">

--- a/src/pages/docs/dataset/features/experiments.mdx
+++ b/src/pages/docs/dataset/features/experiments.mdx
@@ -3,16 +3,16 @@ title: "Experiments in Dataset"
 description: "To test, validate, and compare different prompt configurations"
 ---
 
-## What it is
+## About
 
-Experiments give you a structured way to answer questions like: *Which prompt performs better? Which model gives the best results for my use case?* You test different prompt and model combinations on the same dataset, score the outputs with evals, and compare results side by side — so you can make data-driven decisions instead of guessing.
+Experiments give you a structured way to answer questions like: *Which prompt performs better? Which model gives the best results for my use case?* You test different prompt and model combinations on the same dataset, score the outputs with evals, and compare results side by side so you can make data-driven decisions instead of guessing.
 
-## Use cases
+## When to use
 
-- **Compare prompts** – Run different prompt templates on the same rows and see which produces better answers or scores.
-- **Compare models** – Run the same prompt with multiple models (or custom models) and compare quality, speed, or cost.
-- **Validate before rollout** – Test prompt and model changes on a dataset before using them in production.
-- **Optimize with evals** – Add built-in or custom evals and use scores to rank prompt–model combinations and pick a winner.
+- **Compare prompts**: Run different prompt templates on the same rows and see which produces better answers or scores.
+- **Compare models**: Run the same prompt with multiple models (or custom models) and compare quality, speed, or cost.
+- **Validate before rollout**: Test prompt and model changes on a dataset before using them in production.
+- **Optimize with evals**: Add built-in or custom evals and use scores to rank prompt/model combinations and pick a winner.
 
 ## How to
 
@@ -92,7 +92,7 @@ You pick a **base column** (the generated responses you want to compare against)
   </Step>
 </Steps>
 
-## What you can do next
+## Next Steps
 
 <CardGroup cols={2}>
   <Card title="Add Rows to Dataset" icon="table-rows" href="/docs/dataset/features/add-rows">

--- a/src/pages/docs/dataset/features/run-prompt.mdx
+++ b/src/pages/docs/dataset/features/run-prompt.mdx
@@ -3,18 +3,18 @@ title: "Run Prompt in Dataset"
 description: "Learn how to execute prompts against your dataset and generate responses"
 ---
 
-## What it is
+## About
 
-Run Prompt lets you add a new column to your dataset that is filled by a model (LLM, Text-to-Speech, Speech-to-Text, or Image Generation). You define a prompt (messages with placeholders that pull from other columns), pick a model and settings, and the system runs the prompt on each row and writes the model output into that column. The result is a <Tooltip tip="Dynamic columns are generated on-the-fly and contain data derived from other columns or external operations." cta="Learn more about dynamic columns" href="/docs/dataset/concept/dynamic-column">dynamic column</Tooltip> of responses you can use for evals, comparison, or export.
+Run Prompt lets you add a new column to your dataset that is filled by a model (LLM, Text-to-Speech, Speech-to-Text, or Image Generation). You define a prompt (messages with placeholders that pull from other columns), pick a model and settings, and the system runs the prompt on each row and writes the model output into that column. The result is a [dynamic column](/docs/dataset/concept/dynamic-column) of responses you can use for evals, comparison, or export.
 
-## Use cases
+## When to use
 
-- **Generate answers or text** – Use an LLM to answer questions, summarize, or complete text per row (e.g. a column of questions → a column of answers).
-- **Produce audio** – Use Text-to-Speech to turn a text column into an audio column (e.g. scripts → voice clips).
-- **Transcribe audio** – Use Speech-to-Text to turn an audio column into a text column for evals or search.
-- **Batch test a prompt** – Run the same prompt across many rows to see how the model behaves and then run evals on the outputs.
-- **Generate images** – Use Image Generation to create images from text (or text + image) per row; the new column stores image URLs.
-- **Structured output** – Use response format (e.g. JSON schema) to get structured fields (object, array) in the new column for downstream use.
+- **Generate answers or text**: Use an LLM to answer questions, summarize, or complete text per row (e.g. a column of questions produces a column of answers).
+- **Produce audio**: Use Text-to-Speech to turn a text column into an audio column (e.g. scripts to voice clips).
+- **Transcribe audio**: Use Speech-to-Text to turn an audio column into a text column for evals or search.
+- **Batch test a prompt**: Run the same prompt across many rows to see how the model behaves and then run evals on the outputs.
+- **Generate images**: Use Image Generation to create images from text (or text + image) per row; the new column stores image URLs.
+- **Structured output**: Use response format (e.g. JSON schema) to get structured fields (object, array) in the new column for downstream use.
 
 ## How to
 
@@ -63,40 +63,27 @@ Run Prompt lets you add a new column to your dataset that is filled by a model (
     </Tabs>
   </Step>
 
-  <Step title="Build the prompt (messages)">
-    Define the prompt as a list of messages (system, user, assistant). In the message content, use placeholders that reference dataset columns (e.g. <code>{`{{column_name}}`}</code>). At runtime, these are replaced by the cell value for that column in each row. The first message must not be from the assistant.
-  </Step>
+  <Step title="Build the prompt">
+    Define the prompt as a list of messages with roles:
 
-  <Step title="Configure Prompt with Roles">
-    Define your prompt using roles. You can configure messages with different roles:
-    
-    - **User Role (Required)**: The main input message from the user perspective. This role is required for the prompt to work.
-    - **System Role (Optional)**: System-level instructions that guide the model's behavior and set the context.
-    
-    ### Using Variables
-    You can reference dataset columns as variables within your prompt using the `{{ }}` syntax. Simply wrap the column name in double curly braces:
-    
-    **Basic Example:**
+    - **System** (optional): Instructions that guide the model's behavior and set context.
+    - **User** (required): The main input message. This role is required for the prompt to work.
+
+    Use `{{column_name}}` placeholders to pull values from other columns. At runtime, these are replaced by the cell value for each row.
+
+    **Example:**
     ```
     System: You are a helpful assistant that summarizes content.
-    
-    User: Please summarize the following text: {{column_name}}
+
+    User: Please summarize the following text: {{article_text}}
     ```
-    
-    The variables (column names) will be dynamically replaced with actual values from your dataset when the prompt runs.
-    
-    ### JSON Dot Notation
-    For JSON type columns, you can access nested fields directly using dot notation. This allows you to reference specific keys within structured data without additional processing:
-    
-    **JSON Example:**
+
+    **JSON dot notation**: For JSON columns, access nested fields directly:
     ```
-    User: Based on this prompt: {{column_name.key_name}}, generate a response that addresses {{column_name.key_name}}
+    User: Based on this prompt: {{config.prompt}}, generate a response that addresses {{config.topic}}
     ```
-    
-    In this example:
-    - `{{column_name.key_name}}` accesses the `key_name` field within the `column_name` JSON column
-    
-    This feature significantly simplifies complex data handling and speeds up setup when working with structured JSON data in your dataset.
+
+    `{{config.prompt}}` accesses the `prompt` field within the `config` JSON column.
   </Step>
 
   <Step title="Configure Model Parameters (optional)">
@@ -118,7 +105,7 @@ Run Prompt lets you add a new column to your dataset that is filled by a model (
 
   
 
-## What you can do next
+## Next Steps
 
 <CardGroup cols={2}>
   <Card title="Add Rows to Dataset" icon="table-rows" href="/docs/dataset/features/add-rows">


### PR DESCRIPTION
## Summary
Applies consistent heading conventions across all 6 dataset feature pages:
- **create.mdx**: About/When to use/Next Steps, formatted cURL, added synthetic data concept link
- **add-rows.mdx**: About/When to use/Next Steps, fixed dev URL to production, fixed TS comment numbering
- **add-columns.mdx**: About/When to use/Next Steps, added links to static/dynamic column concept pages
- **run-prompt.mdx**: About/When to use/Next Steps, merged duplicate prompt steps into one
- **experiments.mdx**: About/When to use/Next Steps
- **annotate.mdx**: About/When to use/Next Steps

## Test plan
- [ ] Verify all 6 pages render correctly
- [ ] Verify all internal links resolve
- [ ] Check code examples display properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)