### PR TITLE
Fix tabs/steps not rendering after View Transitions navigation

### DIFF
--- a/src/components/docs/CodeBlock.astro
+++ b/src/components/docs/CodeBlock.astro
@@ -37,27 +37,34 @@ const { title, language } = Astro.props;
 </div>
 
 <script>
-  document.querySelectorAll('.code-wrapper .copy-btn').forEach(button => {
-    button.addEventListener('click', async () => {
-      const codeBlock = button.closest('.code-wrapper')?.querySelector('code');
-      if (!codeBlock) return;
+  function initCodeBlockCopyButtons() {
+    document.querySelectorAll('.code-wrapper .copy-btn').forEach(button => {
+      if (button.hasAttribute('data-copy-initialized')) return;
+      button.setAttribute('data-copy-initialized', '');
 
-      try {
-        await navigator.clipboard.writeText(codeBlock.textContent || '');
+      button.addEventListener('click', async () => {
+        const codeBlock = button.closest('.code-wrapper')?.querySelector('code');
+        if (!codeBlock) return;
 
-        const copyIcon = button.querySelector('.copy-icon');
-        const checkIcon = button.querySelector('.check-icon');
+        try {
+          await navigator.clipboard.writeText(codeBlock.textContent || '');
 
-        copyIcon?.classList.add('hidden');
-        checkIcon?.classList.remove('hidden');
+          const copyIcon = button.querySelector('.copy-icon');
+          const checkIcon = button.querySelector('.check-icon');
 
-        setTimeout(() => {
-          copyIcon?.classList.remove('hidden');
-          checkIcon?.classList.add('hidden');
-        }, 2000);
-      } catch (err) {
-        console.error('Failed to copy:', err);
-      }
+          copyIcon?.classList.add('hidden');
+          checkIcon?.classList.remove('hidden');
+
+          setTimeout(() => {
+            copyIcon?.classList.remove('hidden');
+            checkIcon?.classList.add('hidden');
+          }, 2000);
+        } catch (err) {
+          console.error('Failed to copy:', err);
+        }
+      });
     });
-  });
+  }
+
+  document.addEventListener('astro:page-load', initCodeBlockCopyButtons);
 </script>

--- a/src/components/docs/CopyButton.astro
+++ b/src/components/docs/CopyButton.astro
@@ -19,27 +19,34 @@
 </button>
 
 <script>
-  document.querySelectorAll('.copy-btn').forEach(button => {
-    button.addEventListener('click', async () => {
-      const codeBlock = button.closest('.code-wrapper')?.querySelector('code');
-      if (!codeBlock) return;
+  function initCopyButtons() {
+    document.querySelectorAll('.copy-btn').forEach(button => {
+      if (button.hasAttribute('data-copy-initialized')) return;
+      button.setAttribute('data-copy-initialized', '');
 
-      try {
-        await navigator.clipboard.writeText(codeBlock.textContent || '');
+      button.addEventListener('click', async () => {
+        const codeBlock = button.closest('.code-wrapper')?.querySelector('code');
+        if (!codeBlock) return;
 
-        const copyIcon = button.querySelector('.copy-icon');
-        const checkIcon = button.querySelector('.check-icon');
+        try {
+          await navigator.clipboard.writeText(codeBlock.textContent || '');
 
-        copyIcon?.classList.add('hidden');
-        checkIcon?.classList.remove('hidden');
+          const copyIcon = button.querySelector('.copy-icon');
+          const checkIcon = button.querySelector('.check-icon');
 
-        setTimeout(() => {
-          copyIcon?.classList.remove('hidden');
-          checkIcon?.classList.add('hidden');
-        }, 2000);
-      } catch (err) {
-        console.error('Failed to copy:', err);
-      }
+          copyIcon?.classList.add('hidden');
+          checkIcon?.classList.remove('hidden');
+
+          setTimeout(() => {
+            copyIcon?.classList.remove('hidden');
+            checkIcon?.classList.add('hidden');
+          }, 2000);
+        } catch (err) {
+          console.error('Failed to copy:', err);
+        }
+      });
     });
-  });
+  }
+
+  document.addEventListener('astro:page-load', initCopyButtons);
 </script>

--- a/src/components/docs/Tabs.astro
+++ b/src/components/docs/Tabs.astro
@@ -50,70 +50,78 @@ const { items, id = `tabs-${Math.random().toString(36).slice(2, 9)}` } = Astro.p
 </style>
 
 <script>
-  document.querySelectorAll('[data-tabs]').forEach((tabsContainer) => {
-    const tabsContent = tabsContainer.querySelector('.tabs-content');
-    const panels = tabsContent?.querySelectorAll(':scope > .tab-panel, :scope > [data-tab-title]');
+  function initTabs() {
+    document.querySelectorAll('[data-tabs]').forEach((tabsContainer) => {
+      if (tabsContainer.hasAttribute('data-tabs-initialized')) return;
+      tabsContainer.setAttribute('data-tabs-initialized', '');
 
-    if (!panels || panels.length === 0) return;
+      const tabsContent = tabsContainer.querySelector('.tabs-content');
+      const panels = tabsContent?.querySelectorAll(':scope > .tab-panel, :scope > [data-tab-title]');
 
-    // Check if we already have buttons (items prop was used)
-    let buttonsContainer = tabsContainer.querySelector('.tabs-buttons');
+      if (!panels || panels.length === 0) return;
 
-    // If no buttons exist, create them from Tab children
-    if (!buttonsContainer) {
-      buttonsContainer = document.createElement('div');
-      buttonsContainer.className = 'tabs-buttons flex border-b border-[var(--color-border-subtle)] mb-4 overflow-x-auto hide-scrollbar';
+      // Check if we already have buttons (items prop was used)
+      let buttonsContainer = tabsContainer.querySelector('.tabs-buttons');
 
-      panels.forEach((panel, index) => {
-        const title = panel.getAttribute('data-tab-title') || `Tab ${index + 1}`;
-        const button = document.createElement('button');
-        button.type = 'button';
-        button.className = index === 0
-          ? 'px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors whitespace-nowrap border-[var(--color-accent-primary)] text-[var(--color-accent-primary)]'
-          : 'px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors whitespace-nowrap border-transparent text-[var(--color-text-tertiary)] hover:text-[var(--color-text-secondary)]';
-        button.setAttribute('data-tab-button', String(index));
-        button.setAttribute('aria-selected', String(index === 0));
-        button.textContent = title;
-        buttonsContainer?.appendChild(button);
-      });
+      // If no buttons exist, create them from Tab children
+      if (!buttonsContainer) {
+        buttonsContainer = document.createElement('div');
+        buttonsContainer.className = 'tabs-buttons flex border-b border-[var(--color-border-subtle)] mb-4 overflow-x-auto hide-scrollbar';
 
-      tabsContent?.parentElement?.insertBefore(buttonsContainer, tabsContent);
-    }
+        panels.forEach((panel, index) => {
+          const title = panel.getAttribute('data-tab-title') || `Tab ${index + 1}`;
+          const button = document.createElement('button');
+          button.type = 'button';
+          button.className = index === 0
+            ? 'px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors whitespace-nowrap border-[var(--color-accent-primary)] text-[var(--color-accent-primary)]'
+            : 'px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors whitespace-nowrap border-transparent text-[var(--color-text-tertiary)] hover:text-[var(--color-text-secondary)]';
+          button.setAttribute('data-tab-button', String(index));
+          button.setAttribute('aria-selected', String(index === 0));
+          button.textContent = title;
+          buttonsContainer?.appendChild(button);
+        });
 
-    const buttons = buttonsContainer.querySelectorAll('[data-tab-button]');
-
-    // Initialize panels visibility
-    panels.forEach((panel, i) => {
-      if (i === 0) {
-        panel.classList.add('active');
-      } else {
-        panel.classList.remove('active');
+        tabsContent?.parentElement?.insertBefore(buttonsContainer, tabsContent);
       }
-    });
 
-    buttons.forEach((button, index) => {
-      button.addEventListener('click', () => {
-        // Update buttons
-        buttons.forEach((btn, i) => {
-          if (i === index) {
-            btn.classList.add('border-[var(--color-accent-primary)]', 'text-[var(--color-accent-primary)]');
-            btn.classList.remove('border-transparent', 'text-[var(--color-text-tertiary)]');
-          } else {
-            btn.classList.remove('border-[var(--color-accent-primary)]', 'text-[var(--color-accent-primary)]');
-            btn.classList.add('border-transparent', 'text-[var(--color-text-tertiary)]');
-          }
-          btn.setAttribute('aria-selected', String(i === index));
-        });
+      const buttons = buttonsContainer.querySelectorAll('[data-tab-button]');
 
-        // Update panels
-        panels.forEach((panel, i) => {
-          if (i === index) {
-            panel.classList.add('active');
-          } else {
-            panel.classList.remove('active');
-          }
+      // Initialize panels visibility
+      panels.forEach((panel, i) => {
+        if (i === 0) {
+          panel.classList.add('active');
+        } else {
+          panel.classList.remove('active');
+        }
+      });
+
+      buttons.forEach((button, index) => {
+        button.addEventListener('click', () => {
+          // Update buttons
+          buttons.forEach((btn, i) => {
+            if (i === index) {
+              btn.classList.add('border-[var(--color-accent-primary)]', 'text-[var(--color-accent-primary)]');
+              btn.classList.remove('border-transparent', 'text-[var(--color-text-tertiary)]');
+            } else {
+              btn.classList.remove('border-[var(--color-accent-primary)]', 'text-[var(--color-accent-primary)]');
+              btn.classList.add('border-transparent', 'text-[var(--color-text-tertiary)]');
+            }
+            btn.setAttribute('aria-selected', String(i === index));
+          });
+
+          // Update panels
+          panels.forEach((panel, i) => {
+            if (i === index) {
+              panel.classList.add('active');
+            } else {
+              panel.classList.remove('active');
+            }
+          });
         });
       });
     });
-  });
+  }
+
+  // Run on initial load and after every View Transition navigation
+  document.addEventListener('astro:page-load', initTabs);
 </script>


### PR DESCRIPTION
## Summary
- Tabs, Steps, and copy buttons fail to render when navigating via Astro View Transitions (client-side navigation) because module scripts only execute once on first page load
- Wrapped initialization logic in `astro:page-load` event listeners so components re-initialize after every navigation
- Added `data-*-initialized` attribute guards to prevent double-initialization on full page loads

**Affected components:** `Tabs.astro`, `CopyButton.astro`, `CodeBlock.astro`

## Test plan
- [ ] Navigate to a page with tabs/steps (e.g. `/docs/evaluation/features/evaluate`) via sidebar link — verify tabs and steps render
- [ ] Refresh the same page — verify it still works
- [ ] Navigate away and back — verify tabs re-initialize
- [ ] Verify copy buttons work on code blocks after client-side navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)