### PR TITLE
Revamp Error Feed: restructure into overview/concepts/features

### DIFF
--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -121,7 +121,18 @@ export const tabNavigation: NavTab[] = [
         icon: 'compass',
         items: [
           { title: 'Overview', href: '/docs/error-feed' },
-          { title: 'Taxonomy', href: '/docs/error-feed/taxonomy' },
+          {
+            title: 'Concepts',
+            items: [
+              { title: 'Error Taxonomy', href: '/docs/error-feed/concepts/taxonomy' },
+            ]
+          },
+          {
+            title: 'Features',
+            items: [
+              { title: 'Using Error Feed', href: '/docs/error-feed/features/using-error-feed' },
+            ]
+          },
         ]
       },
       {
@@ -650,6 +661,13 @@ export const tabNavigation: NavTab[] = [
             items: [
               { title: 'Chat Simulation with Fix My Agent', href: '/docs/cookbook/chat-simulation-fix-agent' },
               { title: 'Simulate SDK Demo', href: '/docs/cookbook/simulate-sdk' },
+            ]
+          },
+          {
+            title: 'Error Feed',
+            icon: 'compass',
+            items: [
+              { title: 'Error Feed with Google ADK', href: '/docs/cookbook/error-feed/google-adk-multi-agent' },
             ]
           },
         ]

--- a/src/pages/docs/cookbook/error-feed/google-adk-multi-agent.mdx
+++ b/src/pages/docs/cookbook/error-feed/google-adk-multi-agent.mdx
@@ -1,0 +1,247 @@
+---
+title: "Error Feed with Google ADK"
+description: "Set up a multi-agent system using Google ADK, send traces to Future AGI, and analyze agent errors with Error Feed."
+---
+
+## About
+
+This cookbook walks through a complete example: build a multi-agent system with Google ADK, instrument it with tracing, and use [Error Feed](/docs/error-feed) to automatically analyze agent performance. By the end, you'll have traces flowing into Observe with Error Feed scores and recommendations visible on each trace.
+
+For a framework-agnostic guide on reading Error Feed results, see [Using Error Feed](/docs/error-feed/features/using-error-feed).
+
+---
+
+## Prerequisites
+
+- Future AGI account at [app.futureagi.com](https://app.futureagi.com)
+- API keys: `FI_API_KEY` and `FI_SECRET_KEY` (see [Admin Settings](/docs/admin-settings))
+- Python 3.12+ and a Google API key
+
+---
+
+## Setup
+
+Create a virtual environment and install the required package:
+
+```bash
+python3.12 -m venv env
+source env/bin/activate
+pip install traceai-google-adk
+```
+
+Create a Python script (e.g. `google_adk_futureagi.py`) and start with the environment variables and imports:
+
+```python
+import asyncio
+import os
+import sys
+from typing import Optional
+
+from google.adk.agents import Agent
+from google.adk.runners import Runner, RunConfig
+from google.adk.artifacts.in_memory_artifact_service import InMemoryArtifactService
+from google.adk.sessions.in_memory_session_service import InMemorySessionService
+from google.adk.memory.in_memory_memory_service import InMemoryMemoryService
+from google.adk.auth.credential_service.in_memory_credential_service import InMemoryCredentialService
+from google.genai import types
+
+# Set up environment variables
+os.environ["FI_API_KEY"] = "YOUR_API_KEY"
+os.environ["FI_SECRET_KEY"] = "YOUR_SECRET_KEY"
+os.environ["FI_BASE_URL"] = "https://api.futureagi.com"
+os.environ['GOOGLE_API_KEY'] = 'YOUR_GOOGLE_API_KEY'
+```
+
+Initialize the trace provider and instrument Google ADK:
+
+```python
+from fi_instrumentation import register
+from fi_instrumentation.fi_types import ProjectType
+from traceai_google_adk import GoogleADKInstrumentor
+from fi_instrumentation import Transport
+
+tracer_provider = register(
+    project_name="google-adk-demo",
+    project_type=ProjectType.OBSERVE,
+    transport=Transport.HTTP
+)
+
+GoogleADKInstrumentor().instrument(tracer_provider=tracer_provider)
+```
+
+---
+
+## Create the Multi-Agent System
+
+Define four specialized agents: planner, researcher, critic, and writer.
+
+```python
+planner_agent = Agent(
+    name="planner_agent",
+    model="gemini-2.5-flash",
+    description="Decomposes requests into a clear plan and collects missing requirements.",
+    instruction="""You are a planning specialist.
+    Responsibilities:
+    - Clarify the user's goal and constraints with 1-3 concise questions if needed.
+    - Produce a short plan with numbered steps and deliverables.
+    - Include explicit assumptions if any details are missing.
+    - End with 'Handoff Summary:' plus a one-paragraph summary of the plan and next agent.
+    - Transfer back to the parent agent without saying anything else."""
+)
+
+researcher_agent = Agent(
+    name="researcher_agent",
+    model="gemini-2.5-flash",
+    description="Expands plan steps into structured notes using internal knowledge (no tools).",
+    instruction="""You are a content researcher.
+    Constraints: do not fetch external data or cite URLs; rely on prior knowledge only.
+    Steps:
+    - Read the plan and assumptions.
+    - For each plan step, create structured notes (bullets) and key talking points.
+    - Flag uncertainties as 'Assumptions' with brief rationale.
+    - End with 'Handoff Summary:' and recommend sending to the critic next.
+    - Transfer back to the parent agent without saying anything else."""
+)
+
+critic_agent = Agent(
+    name="critic_agent",
+    model="gemini-2.5-flash",
+    description="Reviews content for clarity, completeness, and logical flow.",
+    instruction="""You are a critical reviewer.
+    Steps:
+    - Identify issues in clarity, structure, correctness, and style.
+    - Provide a concise list of actionable suggestions grouped by category.
+    - Do not rewrite the full content; focus on improvements.
+    - End with 'Handoff Summary:' suggesting the writer produce the final deliverable.
+    - Transfer back to the parent agent without saying anything else."""
+)
+
+writer_agent = Agent(
+    name="writer_agent",
+    model="gemini-2.5-flash",
+    description="Synthesizes a polished final deliverable from notes and critique.",
+    instruction="""You are the final writer.
+    Steps:
+    - Synthesize the final deliverable in a clean, structured format.
+    - Incorporate the critic's suggestions.
+    - Keep it concise, high-signal, and self-contained.
+    - End with: 'Would you like any changes or a different format?'
+    - Transfer back to the parent agent without saying anything else."""
+)
+```
+
+Create the root orchestrator that coordinates all four agents:
+
+```python
+root_agent = Agent(
+    name="root_agent",
+    model="gemini-2.5-flash",
+    global_instruction="""You are a collaborative multi-agent orchestrator.
+    Coordinate Planner, Researcher, Critic, Writer to fulfill the user's request without using any external tools.
+    Keep interactions polite and focused. Avoid unnecessary fluff.""",
+    instruction="""Process:
+    - If needed, greet the user briefly and confirm their goal.
+    - Transfer to planner_agent to draft a plan.
+    - Then transfer to researcher_agent to expand the plan into notes.
+    - Then transfer to critic_agent to review and propose improvements.
+    - Finally transfer to writer_agent to produce the final deliverable.
+    - After the writer returns, ask the user if they want any changes.
+
+    Notes:
+    - Do NOT call any tools.
+    - At each step, ensure the child agent includes a 'Handoff Summary:' to help routing.
+    - If the user asks for changes at any time, route back to the appropriate sub-agent (planner or writer).
+    """,
+    sub_agents=[planner_agent, researcher_agent, critic_agent, writer_agent]
+)
+```
+
+---
+
+## Run the Agents
+
+```python
+async def run_once(message_text: str, *, app_name: str = "agent-compass-demo", user_id: str = "user-1", session_id: Optional[str] = None) -> None:
+    runner = Runner(
+        app_name=app_name,
+        agent=root_agent,
+        artifact_service=InMemoryArtifactService(),
+        session_service=InMemorySessionService(),
+        memory_service=InMemoryMemoryService(),
+        credential_service=InMemoryCredentialService(),
+    )
+
+    session = await runner.session_service.create_session(
+        app_name=app_name,
+        user_id=user_id,
+        session_id=session_id,
+    )
+
+    content = types.Content(role="user", parts=[types.Part(text=message_text)])
+
+    async for event in runner.run_async(
+        user_id=session.user_id,
+        session_id=session.id,
+        new_message=content,
+        run_config=RunConfig(),
+    ):
+        if getattr(event, "content", None) and getattr(event.content, "parts", None):
+            text = "".join((part.text or "") for part in event.content.parts)
+            if text:
+                author = getattr(event, "author", "agent")
+                print(f"[{author}]: {text}")
+
+    await runner.close()
+
+
+async def main():
+    prompts = [
+        "Explain the formation and characteristics of aurora borealis (northern lights).",
+        "Describe how hurricanes form and what makes them so powerful.",
+        "Explain the process of photosynthesis in plants and its importance to life on Earth.",
+        "Describe how earthquakes occur and why some regions are more prone to them.",
+        "Explain the water cycle and how it affects weather patterns globally."
+    ]
+
+    for prompt in prompts:
+        await run_once(
+            prompt,
+            app_name="agent-compass-demo",
+            user_id="user-1",
+        )
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+Run the script:
+
+```bash
+python3 google_adk_futureagi.py
+```
+
+---
+
+## Viewing Results
+
+After the script runs, your project appears in the **Observe** tab.
+
+![Observe project list](/images/docs/agent-compass-quickstart/observe_list.png)
+
+Click on the project to see the LLM Tracing view with all traces listed.
+
+![LLM Tracing view](/images/docs/agent-compass-quickstart/observe_llm_tracing.png)
+
+Click on a trace to open the trace tree. Error Feed insights appear in a collapsible accordion at the top.
+
+![Error Feed insights expanded](/images/docs/agent-compass-quickstart/agent_compass_expanded.png)
+
+For details on how to read scores, insights, clusters, and recommendations, see [Using Error Feed](/docs/error-feed/features/using-error-feed).
+
+---
+
+## Next Steps
+
+- [Using Error Feed](/docs/error-feed/features/using-error-feed): Understand scores, clusters, and recommendations
+- [Error Taxonomy](/docs/error-feed/concepts/taxonomy): Explore all error categories
+- [Set Up Observability](/docs/quickstart/setup-observability): Send traces from other frameworks

--- a/src/pages/docs/error-feed/concepts/taxonomy.mdx
+++ b/src/pages/docs/error-feed/concepts/taxonomy.mdx
@@ -1,13 +1,15 @@
 ---
-title: "Taxonomy"
-description: "Taxonomy: actions, outcomes, and classifications."
+title: "Error Taxonomy"
+description: "Categories, subcategories, and descriptions of all error types detected by Error Feed."
 ---
 
-**Agent Compass** uses a comprehensive taxonomy to categorize different types of errors and issues that can occur during agent execution. This taxonomy helps in systematically identifying, understanding, and addressing various failure modes.
+## About
+
+Error Feed uses a comprehensive taxonomy to categorize errors and issues in agent execution. Each analyzed trace is classified into one or more of the categories below. This helps you systematically identify, understand, and fix different failure modes.
 
 ![Taxonomy](/images/docs/agent-compass-quickstart/taxonomy.png)
 
-Following is an exhaustive list of **error categories** and their **subcategories** that are currently being used.
+The taxonomy covers five top-level categories:
 
 #### Thinking & Response Issues
 Mistakes in understanding, reasoning, factual grounding, or output formatting.

--- a/src/pages/docs/error-feed/features/using-error-feed.mdx
+++ b/src/pages/docs/error-feed/features/using-error-feed.mdx
@@ -1,0 +1,129 @@
+---
+title: "Using Error Feed"
+description: "How to read scores, insights, clusters, and recommendations from Error Feed."
+---
+
+## About
+
+Once traces are flowing into an [Observe](/docs/observe) project, Error Feed automatically analyzes them and surfaces errors, scores, and recommendations. This page explains how to read and act on the results. Error Feed works with any integration that sends traces. No additional setup is needed.
+
+For full end-to-end examples with code, see the [Error Feed cookbooks](/docs/cookbook/error-feed/google-adk-multi-agent).
+
+---
+
+## Viewing Results
+
+Open your project in the **Observe** tab and click on a trace. Error Feed insights appear in a collapsible accordion at the top of the trace detail view.
+
+![Error Feed insights expanded](/images/docs/agent-compass-quickstart/agent_compass_expanded.png)
+
+---
+
+## Scores
+
+Each analyzed trace is scored across four metrics (out of 5):
+
+| Metric | Description |
+|---|---|
+| **Factual Grounding** | How well agent responses are anchored in verifiable evidence, avoiding hallucinations |
+| **Privacy and Safety** | Adherence to security practices: PII exposure, credential leaks, unsafe advice, bias |
+| **Instruction Adherence** | How well the agent follows user instructions, formatting, tone, and prompt guidelines |
+| **Optimal Plan Execution** | Ability to structure multi-step workflows logically with proper sequencing and tool coordination |
+
+![Trace scores](/images/docs/agent-compass-quickstart/agent_compass_trace.png)
+
+---
+
+## Understanding Each Section
+
+### Clickable Metrics
+
+[Taxonomy metrics](/docs/error-feed/concepts/taxonomy) indicating where your agent needs improvement. They are determined automatically by Error Feed.
+
+### Recommendation
+
+A suggestion for a long-term, robust fix. The recommendation may differ from the immediate fix.
+
+### Immediate Fix
+
+A minimal functional fix to address the issue quickly.
+
+### Insights
+
+A high-level overview of the complete trace execution. Insights don't change with the selected taxonomy metric and give a bird's eye view of what the agent did.
+
+### Description
+
+Explains what went wrong during the agent execution and what happened in the error.
+
+### Evidence
+
+Supporting snippets from the LLM responses generated during execution. These help uncover edge cases or missed scenarios.
+
+### Root Causes
+
+The underlying issue behind an error. Helps developers understand their agentic workflows better.
+
+### Spans
+
+The list of affected spans. Each taxonomy metric can have different spans associated with it. Click on a span to locate it in the trace tree.
+
+---
+
+## Sampling Rate
+
+Sampling rate controls what percentage of traces Error Feed analyzes. You can configure it in two steps:
+
+1. Click the **Configure** button in the top-right corner of the Observe screen
+   ![Configure sampling rate](/images/docs/agent-compass-quickstart/sampling_rate_1.png)
+
+2. Use the slider to adjust the rate and click **Update**
+   ![Adjust sampling rate](/images/docs/agent-compass-quickstart/sampling_rate_2.png)
+
+<Note>
+The updated sampling rate applies to new traces only. Previously analyzed traces are not affected.
+</Note>
+
+---
+
+## Error Feed Tab
+
+All errors identified by Error Feed are grouped and visible under the **Feed** tab.
+
+![Error clusters](/images/docs/agent-compass-quickstart/cluster_list.png)
+
+### Clusters
+
+Multiple traces can have the same error. All those traces are grouped under a common cluster. The listing page lets you filter clusters by project and error age.
+
+### Events
+
+The number of occurrences of a particular error.
+
+### Trends
+
+How error frequency is changing over time: increasing, decreasing, or stable.
+
+---
+
+## Cluster Details
+
+Click on a cluster to see its details page with more information about the error and associated traces. The latest trace is shown by default.
+
+![Cluster detail](/images/docs/agent-compass-quickstart/cluster_detail.png)
+
+**Toggling between traces and filtering**: The upper section lets you switch between traces and shows first/last occurrence times. Filter by time range. The graph displays error trends.
+
+![Cluster filtering](/images/docs/agent-compass-quickstart/cluster_detail_filter.png)
+
+**Insights and trace tree**: The lower section shows the trace tree of the selected trace alongside Error Feed insights. Span attributes and metadata are shown on the right.
+
+![Cluster trace tree](/images/docs/agent-compass-quickstart/cluster_detail_tracetree.png)
+
+---
+
+## Next Steps
+
+- [Error Taxonomy](/docs/error-feed/concepts/taxonomy): Explore all error categories and subcategories
+- [Error Feed with Google ADK](/docs/cookbook/error-feed/google-adk-multi-agent): Full end-to-end walkthrough with code
+- [Set Up Observability](/docs/quickstart/setup-observability): Send traces from other frameworks

--- a/src/pages/docs/error-feed/index.mdx
+++ b/src/pages/docs/error-feed/index.mdx
@@ -3,67 +3,73 @@ title: "Overview"
 description: "Automatically detect, cluster, and fix errors in your AI agent traces with Error Feed."
 ---
 
+## About
+
+**Error Feed** is an intelligent error analysis system built into Future AGI. It automatically monitors traces from your [Observe](/docs/observe) projects, identifies issues in agent execution, groups similar errors into clusters, and surfaces actionable recommendations, all without any additional configuration.
+
+Once traces start flowing in, Error Feed picks them up, scores them across four key metrics, and presents findings directly in the platform UI alongside the trace tree.
+
 <iframe
   className="w-full aspect-video rounded-xl"
   src="https://www.youtube.com/embed/p-bFSq3AEkI?si=GyW3p4VMRSDZUgOP"
-  title="YouTube video player"
+  title="Error Feed overview"
   frameBorder="0"
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
   referrerPolicy="strict-origin-when-cross-origin"
   allowFullScreen
 ></iframe>
 
-## What it is
-
-**Error Feed** is an intelligent error analysis system built into the FutureAGI platform. It automatically monitors traces from your Observe projects, identifies issues in agent execution, groups similar errors into clusters, and surfaces actionable recommendations — all without any additional configuration.
-
-Once traces start flowing in, Error Feed picks them up according to a configurable [sampling rate](/docs/error-feed/features/using-google-adk#sampling-rate), scores them across four key metrics, and presents findings directly in the platform UI alongside the trace tree.
-
 ![Error Feed overview](/images/docs/agent-compass-index/agent_compass_trace.png)
 
 ---
 
-## Purpose
+## What Error Feed Does
 
-- **Error Detection** — Automatically identifies and categorizes errors in agent execution, pointing out root causes and suggesting immediate fixes.
-- **Cluster Grouping** — Groups similar errors from multiple traces into named clusters so you can spot recurring problems at a glance.
-- **Scoring** — Evaluates every analyzed trace across four metrics: Factual Grounding, Privacy & Safety, Instruction Adherence, and Optimal Plan Execution (each scored out of 5).
-- **Recommendations** — Provides both an immediate fix (minimal functional fix) and a long-term recommendation (robust architectural fix) per error.
-- **Pattern Detection** — Tracks error trends over time — increasing, decreasing, or stable — so you know which problems are getting worse.
-- **Zero Config** — Works automatically on any Observe project; no extra instrumentation or setup required.
+- **Error Detection**: Automatically identifies and categorizes errors in agent execution, pointing out root causes and suggesting immediate fixes.
+- **Cluster Grouping**: Groups similar errors from multiple traces into named clusters so you can spot recurring problems at a glance.
+- **Scoring**: Evaluates every analyzed trace across four metrics (each scored out of 5):
+  - **Factual Grounding**: Is the output supported by the input data and retrieved context?
+  - **Privacy & Safety**: Does the output avoid leaking PII, secrets, or generating harmful content?
+  - **Instruction Adherence**: Does the output follow the instructions, format, and constraints given?
+  - **Optimal Plan Execution**: Did the agent choose the right tools, in the right order, with the right parameters?
+- **Recommendations**: Provides both an immediate fix (minimal functional fix) and a long-term recommendation (robust architectural fix) per error.
+- **Pattern Detection**: Tracks error trends over time (increasing, decreasing, or stable) so you know which problems are getting worse.
+- **Zero Config**: Works automatically on any Observe project. No extra instrumentation or setup required.
 
 ---
+
 ## Supported Integrations
 
-Error Feed works with any integration that sends traces to an Observe project. The following are currently supported.
+Error Feed works with any integration that sends traces to an Observe project.
 
-**LLM Models:** OpenAI, OpenAI Agents SDK, Vertex AI (Gemini), AWS Bedrock, Mistral AI, Anthropic, Groq, Together AI, Google ADK, Google GenAI, Portkey
+**LLM Providers**: OpenAI, OpenAI Agents SDK, Vertex AI (Gemini), AWS Bedrock, Mistral AI, Anthropic, Groq, Together AI, Google ADK, Google GenAI, Portkey
 
-**Orchestration Frameworks:** LlamaIndex, LlamaIndex Workflows, LangChain, LangGraph, LiteLLM, CrewAI, Haystack, Autogen, PromptFlow, Vercel, Pipecat
+**Orchestration Frameworks**: LlamaIndex, LlamaIndex Workflows, LangChain, LangGraph, LiteLLM, CrewAI, Haystack, Autogen, PromptFlow, Vercel, Pipecat
 
-**Other:** DSPy, Guardrails AI, Hugging Face smolagents, Ollama, Instructor, MCP
+**Other**: DSPy, Guardrails AI, Hugging Face smolagents, Ollama, Instructor, MCP
 
 <Note>
-Error Feed requires **zero configuration**. Once you start sending traces to a FutureAGI Observe project, it automatically picks up traces and generates insights. Use the [sampling rate](/docs/error-feed/features/using-google-adk#sampling-rate) to control what percentage of traces are analyzed.
+Error Feed requires **zero configuration**. Once you start sending traces to a Future AGI Observe project, it automatically picks up traces and generates insights.
 </Note>
 
 ---
-## Getting started with Error Feed
+
+## Getting Started
 
 <CardGroup cols={2}>
   <Card
-    title="Using Google ADK"
-    icon="rocket"
-    href="/docs/error-feed/features/using-google-adk"
-  >
-    Walk through a full Google ADK example and see Error Feed scores and insights in action.
-  </Card>
-  <Card
     title="Taxonomy"
     icon="tags"
-    href="/docs/error-feed/taxonomy"
+    href="/docs/error-feed/concepts/taxonomy"
   >
     Explore the full error taxonomy: categories, subcategories, and what each error type means.
+  </Card>
+  <Card
+    title="Using Error Feed"
+    icon="rocket"
+    href="/docs/error-feed/features/using-error-feed"
+  >
+    How to read scores, insights, clusters, and recommendations.
   </Card>
 </CardGroup>
 


### PR DESCRIPTION
## Summary
- Rewrote **index.mdx** overview: About heading, scoring metrics explained inline, removed broken Google ADK link, fixed video title
- Moved **taxonomy.mdx** to **concepts/taxonomy.mdx**, fixed "Agent Compass" references to "Error Feed"
- Created **features/using-error-feed.mdx**: framework-agnostic feature page covering scores, insights, clusters, sampling rate, feed tab, cluster details
- Created **cookbook/error-feed/google-adk-multi-agent.mdx**: full Google ADK multi-agent walkthrough ported from dev branch with fixed image paths and links
- Updated **navigation.ts**: Error Feed now has Overview, Concepts, Features structure. Added Error Feed section to Cookbooks tab.

## Test plan
- [ ] Verify /docs/error-feed renders correctly
- [ ] Verify /docs/error-feed/concepts/taxonomy renders (moved from /docs/error-feed/taxonomy)
- [ ] Verify /docs/error-feed/features/using-error-feed renders with all screenshots
- [ ] Verify /docs/cookbook/error-feed/google-adk-multi-agent renders
- [ ] Check sidebar shows correct structure for both Error Feed docs and cookbook sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)