### PR TITLE
Revamp Knowledge Base pages

### DIFF
--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -151,7 +151,7 @@ export const tabNavigation: NavTab[] = [
           {
             title: 'Concepts',
             items: [
-              { title: 'Concept', href: '/docs/knowledge-base/concepts/concept' },
+              { title: 'Understanding Knowledge Base', href: '/docs/knowledge-base/concepts/concept' },
             ]
           },
           {

--- a/src/pages/docs/knowledge-base/concepts/concept.mdx
+++ b/src/pages/docs/knowledge-base/concepts/concept.mdx
@@ -1,15 +1,31 @@
 ---
-title: "Concept"
-description: "Understand the Knowledge Base concept in Future AGI. Store organizational content to ground synthetic data and provide reference context for evaluations."
+title: "Understanding Knowledge Base"
+description: "What a Knowledge Base is, what content types are supported, and how files are processed."
 ---
 
-A **Knowledge Base** is a store of your organization's content — documents, policies, FAQs, SOPs — that Future AGI indexes and makes available across the platform.
+## About
 
-**Where it's useful:**
-- **Synthetic data generation** — Generated examples are grounded in your actual content, so the output reflects your domain, terminology, and procedures rather than generic text.
-- **Evaluations** — The KB supplies the reference context that evals check responses against. Instead of judging answers in a vacuum, the evaluator compares them to what your documents actually say — which is what makes hallucination detection meaningful.
+A **Knowledge Base** is a store of your organization's content that Future AGI indexes and makes available across the platform. When you upload documents, the platform processes and indexes them so they can be used as grounding context for synthetic data generation and evaluations.
 
-What are the different knowledge assets?
+## When to use
+
+- **Synthetic data generation**: You want generated examples to reflect your domain, terminology, and procedures instead of generic text. Selecting a KB when creating a synthetic dataset grounds the output in your actual content.
+- **Evaluation**: You want to check whether model outputs are factually consistent with your organization's knowledge. The KB supplies the reference context that hallucination detection and grounding evals compare against.
+
+## Supported Content Types
+
+You can upload the following file types to a Knowledge Base:
+
+| File Type | Extensions |
+|---|---|
+| Word documents | `.doc`, `.docx` |
+| PDF documents | `.pdf` |
+| Plain text | `.txt` |
+| Rich text | `.rtf` |
+
+Maximum file size is 5MB per file.
+
+Examples of content that works well in a KB:
 
 - Technical documentation and manuals
 - FAQs and troubleshooting guides
@@ -18,37 +34,18 @@ What are the different knowledge assets?
 - Legal documents and compliance information
 - Product descriptions and specifications
 
-Features and Functionalities that are supported
+## File Processing
 
-- Upload files in `.doc`, `.docx`, `.pdf`, `.txt`, or `.rtf` (5MB max per file)
-- Drag-and-drop or bulk file upload supported
-- SDK support for large file ingestion
-- You can also remove files from a Knowledge Base or completely delete the Knowledge Base
+After you upload files, the platform processes them automatically. Each file goes through one of three states:
 
-Uploaded files are processed and categorised into:
-<div style={{ display: 'flex', justifyContent: 'center' }}>
-  <table>
-    <thead>
-      <tr>
-        <th>Status</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>✅ Successful</td>
-        <td>Content extracted for knowledge base</td>
-      </tr>
-      <tr>
-        <td>🔄 Processing</td>
-        <td>File is being processed</td>
-      </tr>
-      <tr>
-        <td>❌ Failed</td>
-        <td>Users notified; file not usable</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
+| Status | Description |
+|---|---|
+| Successful | Content extracted and indexed for use |
+| Processing | File is being processed |
+| Failed | Processing failed. You'll be notified and the file won't be usable. |
 
-You can search for your knowledge bases using name and sort them based on the title and time updated.
+## Next Steps
+
+- [Create KB Using UI](/docs/knowledge-base/features/ui): Upload files through the dashboard
+- [Create KB Using SDK](/docs/knowledge-base/features/sdk): Upload and manage knowledge bases programmatically
+- [Synthetic Data](/docs/dataset/concept/synthetic-data): Learn how KB grounds synthetic data generation

--- a/src/pages/docs/knowledge-base/features/sdk.mdx
+++ b/src/pages/docs/knowledge-base/features/sdk.mdx
@@ -3,17 +3,17 @@ title: "Create a Knowledge Base using SDK"
 description: "Create and manage Knowledge Bases programmatically with the Future AGI Python SDK: create, update, add or remove files, and delete KBs from code or automation."
 ---
 
-## What it is
+## About
 
-The **Knowledge Base (SDK)** flow lets you create and manage Knowledge Bases from code using the Future AGI Python SDK. You install the `futureagi` package, authenticate with API credentials, then call methods to create a KB with a name and file paths (or a directory), add more files to an existing KB, remove files by name, or delete entire KBs. Supported file types are PDF, DOCX, TXT, and RTF. The SDK provides extended support for large volumes of files and complex automation workflows, including CI/CD pipelines.
+The Knowledge Base SDK lets you create and manage Knowledge Bases from code using the Future AGI Python SDK. You install the `futureagi` package, authenticate with API credentials, then call methods to create a KB with a name and file paths (or a directory), add more files to an existing KB, remove files by name, or delete entire KBs. Supported file types are PDF, DOCX, TXT, and RTF.
 
-## Use cases
+## When to use
 
-- **Automation** — Create or update KBs from scripts, pipelines, or scheduled jobs.
-- **Bulk ingestion** — Upload many files or point at a directory path instead of selecting files one by one in the UI.
-- **Larger files** — Use the SDK when file size or volume exceeds UI limits.
-- **Reproducibility** — Version and replay KB setup in code (e.g. in a repo or notebook).
-- **Integrations** — Embed KB creation/updates in your own tools or workflows.
+- **Automation**: Create or update KBs from scripts, pipelines, or scheduled jobs.
+- **Bulk ingestion**: Upload many files or point at a directory path instead of selecting files one by one in the UI.
+- **Larger files**: Use the SDK when file size or volume exceeds UI limits.
+- **Reproducibility**: Version and replay KB setup in code (e.g. in a repo or notebook).
+- **Integrations**: Embed KB creation/updates in your own tools or workflows.
 
 ---
 
@@ -105,13 +105,13 @@ The **Knowledge Base (SDK)** flow lets you create and manage Knowledge Bases fro
   Wrap SDK calls in try/except and handle `fi.utils.errors.SDKException` (and optionally `InvalidAuthError`, rate limits) in production. Keep API credentials out of version control (e.g. use environment variables).
 </Note>
 
-## What you can do next
+## Next Steps
 
 <CardGroup cols={2}>
-  <Card title="Create a Knowledge Base using UI" icon="window-maximize" href="/docs/knowledge-base/features/ui">
-    Create and populate a Knowledge Base from the platform without code.
+  <Card title="SDK Reference" icon="code" href="/docs/sdk/knowledgebase">
+    Full SDK reference for the Knowledge Base module with all methods and parameters.
   </Card>
-  <Card title="Knowledge Base overview" icon="brain" href="/docs/knowledge-base">
-    Learn what Knowledge Bases are and how they are used for synthetic data and evaluations.
+  <Card title="Create KB Using UI" icon="window-maximize" href="/docs/knowledge-base/features/ui">
+    Create and populate a Knowledge Base from the platform without code.
   </Card>
 </CardGroup>

--- a/src/pages/docs/knowledge-base/features/ui.mdx
+++ b/src/pages/docs/knowledge-base/features/ui.mdx
@@ -18,16 +18,16 @@ description: "Create and populate a Knowledge Base from the Future AGI platform:
   />
 </div>
 {/* ARCADE EMBED END */}
-## What it is
+## About
 
-The **Create Knowledge Base (UI)** flow lets you create and populate a Knowledge Base directly on the Future AGI platform. Name your KB, upload documents (PDF, DOCX, TXT, RTF, etc.) via drag-and-drop or file picker, and the platform validates, uploads, and ingests them — with per-file status (Successful, Processing, Failed) so you can track progress and retry failures. For larger files, the platform provides extended support through the SDK. Once ingestion finishes, the KB is available for synthetic data generation and evaluations.
+The Knowledge Base UI lets you create and populate a Knowledge Base directly on the Future AGI platform. Name your KB, upload documents (PDF, DOCX, TXT, RTF) via drag-and-drop or file picker, and the platform validates, uploads, and ingests them with per-file status (Successful, Processing, Failed) so you can track progress and retry failures. Once ingestion finishes, the KB is available for synthetic data generation and evaluations.
 
-## Use cases
+## When to use
 
-- **Quick setup** — Create a KB and add documents in a few clicks without writing code.
-- **Small to medium documents** — Upload PDF, DOCX, TXT, RTF (and similar) files within the UI file-size limits.
-- **Visibility** — See processing status per file and retry or fix failed uploads from the same screen.
-- **Team workflow** — Anyone with access can create or update KBs from the platform.
+- **Quick setup**: Create a KB and add documents in a few clicks without writing code.
+- **Small to medium documents**: Upload PDF, DOCX, TXT, RTF files within the UI file-size limits.
+- **Visibility**: See processing status per file and retry or fix failed uploads from the same screen.
+- **Team workflow**: Anyone with platform access can create or update KBs.
 
 ---
 
@@ -61,9 +61,9 @@ The **Create Knowledge Base (UI)** flow lets you create and populate a Knowledge
     After upload, each file is processed. Status is shown per file:
     ![Monitor file processing](/screenshot/product/knowledge-base/4.png)
 
-    - **Successful** — Content extracted and available in the KB.
-    - **Processing** — File is still being ingested.
-    - **Failed** — Upload or processing failed; use retry or tooltips in the UI to fix or remove the file.
+    - **Successful**: Content extracted and available in the KB.
+    - **Processing**: File is still being ingested.
+    - **Failed**: Upload or processing failed. Use retry or tooltips in the UI to fix or remove the file.
 
     The Knowledge Base is ready to use only after all files have completed successfully.
   </Step>
@@ -79,7 +79,7 @@ The **Create Knowledge Base (UI)** flow lets you create and populate a Knowledge
 
 ---
 
-## What you can do next
+## Next Steps
 
 <CardGroup cols={2}>
   <Card title="Create a Knowledge Base using SDK" icon="code" href="/docs/knowledge-base/features/sdk">

--- a/src/pages/docs/knowledge-base/index.mdx
+++ b/src/pages/docs/knowledge-base/index.mdx
@@ -1,35 +1,45 @@
 ---
 title: "Overview"
-description: "Ground synthetic data generation and evaluations in your organization's content so outputs stay relevant, consistent, and under your control."
+description: "Store your organization’s content to ground synthetic data generation and evaluations in real source material."
 ---
 
-## What it is
+## About
 
-A **Knowledge Base (KB)** is a store of organization content—FAQs, documentation, SOPs, manuals—that is semantically processed and indexed. Generation and evaluation runs use this content so outputs stay grounded in real source material instead of drifting into wrong terminology, invented procedures, or generic answers. The result is context-aware synthetic data and evals that reflect the organization’s domain, reduce hallucinations, and keep behavior consistent.
+A **Knowledge Base (KB)** is a store of your organization’s content: FAQs, documentation, SOPs, manuals, policies, and product specs. Future AGI indexes this content and makes it available across the platform. When you generate synthetic data or run evaluations, the platform pulls from your KB so outputs stay grounded in real source material instead of drifting into wrong terminology, invented procedures, or generic answers.
 
-## Purpose
+## How Knowledge Base Connects to Other Features
 
-- **Relevance** — Outputs match your specific context and domain instead of generic or off-domain content.
-- **Reliability** — Consistent behavior aligned with your organization’s knowledge and needs.
-- **Control** — Scalable customization by adding, updating, or removing content in your KB.
-- **Synthetic data generation** — Create training examples from your documents so generated data reflects your domain; optional KB selection when creating synthetic datasets.
-- **Evaluation and hallucination detection** — Run evals that use your KB so you can check whether outputs are grounded in your source materials.
+- **Synthetic data generation**: When creating a synthetic dataset, you can optionally select a KB. The generator uses your documents as context, producing examples that reflect your domain and terminology. [Learn more](/docs/dataset/concept/synthetic-data)
+- **Evaluation**: Run hallucination detection and grounding evals that compare model outputs against what your documents actually say. [Learn more](/docs/evaluation)
+- **Protect**: Use KB content as reference material for guardrails that check whether responses align with your organization’s knowledge. [Learn more](/docs/protect)
 
-## Getting started with knowledge base
+## Getting Started
 
 <CardGroup cols={2}>
   <Card
-    title="Create a Knowledge Base using UI"
+    title="Understanding Knowledge Base"
+    icon="brain"
+    href="/docs/knowledge-base/concepts/concept"
+  >
+    What a KB is, what content types are supported, and how files are processed.
+  </Card>
+  <Card
+    title="Create KB Using UI"
     icon="book"
     href="/docs/knowledge-base/features/ui"
   >
-    Create and manage a KB from the Future AGI platform with drag-and-drop or bulk file upload.
+    Create and manage a KB from the platform with drag-and-drop or bulk file upload.
   </Card>
   <Card
-    title="Create a Knowledge Base using SDK"
+    title="Create KB Using SDK"
     icon="code"
     href="/docs/knowledge-base/features/sdk"
   >
-    Create and update knowledge bases programmatically with the Python SDK for automation and large file ingestion.
+    Create and update knowledge bases programmatically with the Python SDK.
   </Card>
 </CardGroup>
+
+## Next Steps
+
+- [Generate Synthetic Data](/docs/quickstart/generate-synthetic-data): Use a KB to ground synthetic data generation
+- [Knowledge Base Cookbook](/docs/cookbook/quickstart/knowledge-base): Upload documents and query with the SDK


### PR DESCRIPTION
## Summary
- **index.mdx**: Rewrote with About heading, added cross-links to synthetic data/evaluation/protect, added concept page to Getting Started cards, added Next Steps
- **concepts/concept.mdx**: Full rewrite with About, When to use, Supported Content Types table, File Processing table, removed feature-level content. Renamed nav title to "Understanding Knowledge Base"
- **features/sdk.mdx**: About/When to use/Next Steps headings, added SDK Reference link to next steps
- **features/ui.mdx**: About/When to use/Next Steps headings

## Test plan
- [ ] Verify all 4 pages render correctly
- [ ] Verify sidebar shows "Understanding Knowledge Base" under Concepts
- [ ] Verify all links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)