### PR TITLE
Standardize evaluation pages

### DIFF
--- a/src/pages/docs/evaluation/features/custom-models.mdx
+++ b/src/pages/docs/evaluation/features/custom-models.mdx
@@ -21,7 +21,7 @@ Learn how to define eval rules that use your model: [Create custom evals](/docs/
 </Tip>
 
 ---
-## Use cases
+## When to use
 
 - **Control cost and compliance**: Bring your own model and set token costs so evaluation spend is tracked. Keep inference in your chosen region or provider for compliance.
 - **Evaluate with a fine-tuned or internal model**: Run evals with a model tuned on your domain or hosted in-house by connecting it via the custom endpoint option.
@@ -117,7 +117,7 @@ Fields you may see when adding a model (from a provider or custom). **Applies to
 
 ---
 
-## What you can do next
+## Next Steps
 
 <CardGroup cols={2}>
   <Card title="Evaluate via Platform &amp; SDK" icon="play" href="/docs/evaluation/features/evaluate">

--- a/src/pages/docs/evaluation/features/custom.mdx
+++ b/src/pages/docs/evaluation/features/custom.mdx
@@ -11,7 +11,7 @@ Once created, a custom eval works exactly like any built-in template: use it on 
 
 ---
 
-## Use cases
+## When to use
 
 - **Domain-specific validation**: Assess content against industry or regulatory standards that aren’t in the default templates.
 - **Business rule compliance**: Enforce your organization’s guidelines (tone, format, disclosures) in a repeatable eval.
@@ -125,7 +125,7 @@ You can create custom evals from the **UI** or via the **SDK** (by calling the R
 
 ---
 
-## What you can do next
+## Next Steps
 
 <CardGroup cols={2}>
   <Card title="Evaluate via Platform &amp; SDK" icon="play" href="/docs/evaluation/features/evaluate">

--- a/src/pages/docs/evaluation/features/evaluate.mdx
+++ b/src/pages/docs/evaluation/features/evaluate.mdx
@@ -18,7 +18,7 @@ Both support the same [built-in eval templates](/docs/evaluation/builtin) (e.g. 
 
 ---
 
-## Use cases
+## When to use
 
 - **Catch regressions before they ship**: Run evals in CI so a bad prompt change or model update gets flagged before it reaches production.
 - **Score outputs at scale**: Attach evals to a dataset and every row gets a score automatically, without reviewing each one manually.
@@ -146,7 +146,7 @@ For more eval templates and Future AGI models, see [Built-in evals](/docs/evalua
 
 ---
 
-## What you can do next
+## Next Steps
 
 <CardGroup cols={2}>
   <Card title="Create custom evals" icon="wand-magic-sparkles" href="/docs/evaluation/features/custom">

--- a/src/pages/docs/evaluation/features/futureagi-models.mdx
+++ b/src/pages/docs/evaluation/features/futureagi-models.mdx
@@ -71,7 +71,7 @@ All models are available in the platform UI and the SDK, and work with both buil
 
 ---
 
-## What you can do next
+## Next Steps
 
 <CardGroup cols={2}>
   <Card title="Evaluate via Platform &amp; SDK" icon="play" href="/docs/evaluation/features/evaluate">

--- a/src/pages/docs/evaluation/features/groups.mdx
+++ b/src/pages/docs/evaluation/features/groups.mdx
@@ -18,7 +18,7 @@ This keeps your quality checks consistent. Whether you are running evals on a da
 ></iframe>
 ---
 
-## Use cases
+## When to use
 
 - **Full quality suite on a dataset**: Run tone, safety, accuracy, and relevance checks together in one pass instead of configuring each eval separately.
 - **Standardized release checks**: Apply the same eval group before every model or prompt update so every release is measured against the same bar.
@@ -69,7 +69,7 @@ Eval groups can be used across the platform: on [datasets](/docs/dataset), in [s
 
 ---
 
-## What you can do next
+## Next Steps
 
 <CardGroup cols={2}>
   <Card title="Evaluate via Platform &amp; SDK" icon="play" href="/docs/evaluation/features/evaluate">

--- a/src/pages/docs/evaluation/index.mdx
+++ b/src/pages/docs/evaluation/index.mdx
@@ -13,17 +13,15 @@ Evaluations run across every surface in Future AGI: datasets, simulations, exper
 
 Future AGI ships 70+ built-in templates covering quality, safety, factuality, RAG retrieval, format, bias, audio, and image evaluation. You can also create custom templates and bundle any combination into **eval groups** to apply multiple evals in a single run.
 
-## Purpose
+## How Evaluation Connects to Other Features
 
-**Measure quality consistently:** Apply the same eval definitions across datasets, simulations, and experiments so results are always comparable.
+- **Datasets**: Run evals across dataset rows and store scores as new columns. [Learn more](/docs/dataset)
+- **Simulation**: Score simulated agent conversations for quality, context retention, and escalation. [Learn more](/docs/simulation)
+- **Optimization**: Feed eval results into prompt optimization to improve quality automatically. [Learn more](/docs/optimization)
+- **CI/CD**: Gate pull requests on eval scores to catch regressions before they ship. [Learn more](/docs/evaluation/features/cicd)
+- **Error Feed**: Eval-powered scoring for every traced agent execution. [Learn more](/docs/error-feed)
 
-**Compare prompts and agents:** Run evals before and after a change to see exactly whether quality improved or regressed.
-
-**Support optimization:** Feed eval results into prompt optimisation, Fix My Agent, and experiment analysis to iterate on quality systematically.
-
-**Scale evaluation:** Run evals across hundreds of rows or calls and view aggregated summaries, KPIs, and per-row breakdowns without manual review.
-
-## Getting started
+## Getting Started
 
 <CardGroup cols={2}>
   <Card title="Evaluate via Platform & SDK" icon="play" href="/docs/evaluation/features/evaluate">


### PR DESCRIPTION
## Summary
- **index.mdx**: Replaced redundant "Purpose" section with "How Evaluation Connects to Other Features" cross-linking to datasets, simulation, optimization, CI/CD, and error feed
- **custom-models.mdx**: "Use cases" → "When to use", "What you can do next" → "Next Steps"
- **custom.mdx**: "Use cases" → "When to use", "What you can do next" → "Next Steps"
- **evaluate.mdx**: "Use cases" → "When to use", "What you can do next" → "Next Steps"
- **futureagi-models.mdx**: "What you can do next" → "Next Steps"
- **groups.mdx**: "Use cases" → "When to use", "What you can do next" → "Next Steps"

All 5 concept pages were already clean, no changes needed.

## Test plan
- [ ] Verify all 12 evaluation pages render correctly
- [ ] Verify cross-links on overview page resolve
- [ ] Check sidebar shows Overview → Concepts → Features order

🤖 Generated with [Claude Code](https://claude.com/claude-code)