### PR TITLE
Fix sidebar dropdown not closing on single click

### DIFF
--- a/src/components/Sidebar.astro
+++ b/src/components/Sidebar.astro
@@ -307,6 +307,13 @@ function getIconPath(icon?: string): string {
           isOpen ? close() : open();
         });
 
+        // Close dropdown when a link inside it is clicked
+        dropdown.querySelectorAll('a').forEach(function(link) {
+          link.addEventListener('click', function() {
+            close();
+          });
+        });
+
         document.addEventListener('click', function(e) {
           if (!switcher.contains(e.target)) close();
         });


### PR DESCRIPTION
## Summary
Added click event listener on dropdown links to close the dropdown immediately when a section is selected. Previously required clicking twice (once to select, once to dismiss).

## Test plan
- [ ] Open sidebar dropdown, click a section link, verify dropdown closes immediately
- [ ] Verify dropdown still opens/closes via the trigger button
- [ ] Verify clicking outside still closes the dropdown
- [ ] Verify Escape key still closes the dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)