### PR TITLE
Revamp protect: rewrite overview, fix headings, add SDK links

### DIFF
--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -380,7 +380,7 @@ export const tabNavigation: NavTab[] = [
           {
             title: 'Concepts',
             items: [
-              { title: 'Concept', href: '/docs/protect/concepts/concept' },
+              { title: 'Use Cases', href: '/docs/protect/concepts/concept' },
             ]
           },
           {

--- a/src/pages/docs/protect/concepts/concept.mdx
+++ b/src/pages/docs/protect/concepts/concept.mdx
@@ -1,5 +1,5 @@
 ---
-title: Concept
+title: Use Cases
 description: Future AGI's Protect acts as a vital guardrail for AI applications, ensuring security, reliability, and ethical compliance during real-time interactions across text, image, and audio modalities.
 ---
 

--- a/src/pages/docs/protect/features/run-protect.mdx
+++ b/src/pages/docs/protect/features/run-protect.mdx
@@ -3,19 +3,19 @@ title: "Run Protect via SDK"
 description: "Set up and configure Protect to apply real-time safety checks to your AI application's inputs and outputs."
 ---
 
-## What it is
+## About
 
-**Run Protect via SDK** is the programmatic interface to Future AGI's real-time guardrailing system. It exposes rule-based safety checks across four dimensions — Content Moderation, Bias Detection, Security, and Data Privacy Compliance — for text, image, and audio inputs, with configurable actions, explanations, and fail-fast evaluation behavior.
+**Run Protect via SDK** is the programmatic interface to Future AGI's real-time guardrailing system. It exposes rule-based safety checks across four dimensions: Content Moderation, Bias Detection, Security, and Data Privacy Compliance: for text, image, and audio inputs, with configurable actions, explanations, and fail-fast evaluation behavior.
 
 ---
 
-## Use cases
+## When to use
 
-- **Block toxic or harmful content** — Screen user inputs or model outputs for hate speech, threats, and harassment before they reach end users.
-- **Detect prompt injection** — Catch adversarial attempts to override instructions or manipulate your AI system.
-- **Enforce data privacy** — Automatically flag PII (names, emails, phone numbers, SSNs) to stay GDPR/HIPAA compliant.
-- **Multi-modal safety** — Apply the same rules to text, image URLs, and audio files without separate pipelines.
-- **Apply multiple rules at once** — Bundle all four safety dimensions in one call for comprehensive protection.
+- **Block toxic or harmful content**: Screen user inputs or model outputs for hate speech, threats, and harassment before they reach end users.
+- **Detect prompt injection**: Catch adversarial attempts to override instructions or manipulate your AI system.
+- **Enforce data privacy**: Automatically flag PII (names, emails, phone numbers, SSNs) to stay GDPR/HIPAA compliant.
+- **Multi-modal safety**: Apply the same rules to text, image URLs, and audio files without separate pipelines.
+- **Apply multiple rules at once**: Bundle all four safety dimensions in one call for comprehensive protection.
 
 ---
 
@@ -54,8 +54,8 @@ description: "Set up and configure Protect to apply real-time safety checks to y
 
     | Argument | Type | Default Value | Description |
     | --- | --- | --- | --- |
-    | `inputs` | `string` or `list[string]` | — | Input to be evaluated. Can be text, image URL/path, audio URL/path, or data URI |
-    | `protect_rules` | `List[Dict]` | — | List of safety rules to apply |
+    | `inputs` | `string` or `list[string]` |: | Input to be evaluated. Can be text, image URL/path, audio URL/path, or data URI |
+    | `protect_rules` | `List[Dict]` |: | List of safety rules to apply |
     | `action` | `string` | `"Response cannot be generated as the input fails the checks"` | Custom message shown when a rule fails |
     | `reason` | `bool` | `False` | Include detailed explanation of why content failed |
     | `timeout` | `int` | `30000` | Max time in milliseconds for evaluation |
@@ -131,7 +131,7 @@ description: "Set up and configure Protect to apply real-time safety checks to y
     ```
   </Step>
   <Step title="Optional: Use image or audio inputs">
-    Protect natively supports text, image, and audio inputs. Pass your input as a string — the system auto-detects the type.
+    Protect natively supports text, image, and audio inputs. Pass your input as a string: the system auto-detects the type.
 
     ```python
     # Image URL
@@ -154,21 +154,24 @@ description: "Set up and configure Protect to apply real-time safety checks to y
     ```
 
     **Supported formats:**
-    - Images: JPG, PNG, WebP, GIF, BMP, TIFF, SVG — URL, file path, or data URI
-    - Audio: MP3, WAV — URL, file path, or data URI
+    - Images: JPG, PNG, WebP, GIF, BMP, TIFF, SVG: URL, file path, or data URI
+    - Audio: MP3, WAV: URL, file path, or data URI
     - Local files are auto-converted to data URIs (max 20 MB). Use direct download URLs, not preview links.
   </Step>
 </Steps>
 
 ---
 
-## What you can do next
+## Next Steps
 
 <CardGroup cols={2}>
-  <Card title="Concept" icon="book" href="/docs/protect/concepts/concept">
-    Understand how Protect works and the four safety dimensions.
+  <Card title="SDK Reference" icon="code" href="/docs/sdk/protect">
+    Full SDK reference for the Protect module.
   </Card>
-  <Card title="Protect overview" icon="shield" href="/docs/protect">
-    How Protect fits into the platform.
+  <Card title="Use Cases" icon="book" href="/docs/protect/concepts/concept">
+    Real-world use cases across content moderation, healthcare, security, and more.
+  </Card>
+  <Card title="Prism Guardrails" icon="shield" href="/docs/prism/features/guardrails">
+    Apply safety checks as gateway guardrails for all LLM traffic.
   </Card>
 </CardGroup>

--- a/src/pages/docs/protect/index.mdx
+++ b/src/pages/docs/protect/index.mdx
@@ -2,35 +2,46 @@
 title: "Overview"
 description: "Future AGI's Protect module brings real-time safety and policy enforcement directly into your GenAI application flow."
 ---
+## About
+
+**Protect** is Future AGI's real-time guardrailing layer that screens every model input and output as it flows through your application. Unlike offline safety checks, Protect blocks or flags harmful content before it reaches end users, with no separate preprocessing pipeline needed.
+
+It covers four safety dimensions:
+
+| Dimension | What it checks |
+|---|---|
+| **Content Moderation** | Toxicity, hate speech, threats, harassment, harmful language |
+| **Bias Detection** | Sexism, discrimination, harmful stereotypes |
+| **Security** | Prompt injection, adversarial manipulation, system prompt extraction |
+| **Data Privacy Compliance** | PII detection (names, emails, phone numbers, SSNs), GDPR/HIPAA violations |
+
+Built on Google's **Gemma 3n** foundation with specialized fine-tuned adapters, Protect operates natively across text, image, and audio modalities.
+
 <iframe
   className="w-full aspect-video rounded-xl"
   src="https://www.youtube.com/embed/MIGA9cnhgO4"
-  title="YouTube video player"
+  title="Protect overview"
   frameBorder="0"
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
   allowFullScreen
 ></iframe>
 
-## What it is
+## How Protect Connects to Other Features
 
-**Protect** is Future AGI's real-time guardrailing layer that screens every model input and output as it flows through your application. Unlike offline safety checks, Protect blocks or flags harmful content before it reaches end users — with no separate preprocessing pipeline needed. It covers four critical safety dimensions: Content Moderation, Bias Detection, Security (prompt injection), and Data Privacy Compliance. Built on Google's **Gemma 3n** foundation with specialized fine-tuned adapters, Protect operates natively across text, image, and audio modalities.
+- **Prism AI Gateway**: Protect's safety dimensions can also be applied as guardrails in the Prism gateway for all LLM traffic. [Learn more](/docs/prism/features/guardrails)
+- **Evaluation**: The same safety checks (toxicity, bias, PII) are available as evaluation metrics for batch scoring across datasets. [Learn more](/docs/evaluation)
+- **Observability**: Protect results are logged as part of your traces, so you can see which requests were blocked and why. [Learn more](/docs/observe)
 
-
-## Purpose
-
-- **Block harmful content in real time** — Screen inputs and outputs live in production, not as a post-hoc batch job.
-- **Enforce safety across modalities** — Apply the same guardrails to text, image, and audio without separate pipelines.
-- **Stay compliant** — Detect PII, GDPR/HIPAA-sensitive content, and policy violations automatically.
-- **Adapt as policies change** — Update guardrail criteria without redeploying your application.
-
-## Getting started with Protect
+## Getting Started
 
 <CardGroup cols={2}>
   <Card title="Run Protect via SDK" icon="play" href="/docs/protect/features/run-protect">
     Set up Protect and run your first safety check in minutes.
   </Card>
-  <Card title="Concept" icon="book" href="/docs/protect/concepts/concept">
-    Understand how Protect works and the four safety dimensions it covers.
+  <Card title="Use Cases" icon="book" href="/docs/protect/concepts/concept">
+    Explore real-world use cases across content moderation, healthcare, security, and more.
   </Card>
-
+  <Card title="SDK Reference" icon="code" href="/docs/sdk/protect">
+    Full SDK reference for the Protect module.
+  </Card>
 </CardGroup>


### PR DESCRIPTION
## Summary
- **index.mdx**: Rewrote with About heading, safety dimensions table, cross-links to Prism/Evaluation/Observability, SDK Reference card
- **features/run-protect.mdx**: About/When to use/Next Steps headings, all em-dashes removed, SDK Reference and Prism Guardrails added to Next Steps
- **concepts/concept.mdx**: Renamed title from "Concept" to "Use Cases"
- **navigation.ts**: Renamed "Concept" to "Use Cases" in sidebar

## Test plan
- [ ] Verify /docs/protect renders with safety dimensions table
- [ ] Verify /docs/protect/features/run-protect has no em-dashes
- [ ] Verify /docs/protect/concepts/concept shows "Use Cases" as title
- [ ] Verify SDK Reference link at /docs/sdk/protect resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)