### PR TITLE
Add Spring Boot auto-instrumentation docs

### DIFF
--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -545,6 +545,7 @@ export const tabNavigation: NavTab[] = [
                   { title: 'Session-Based Observability for Multi-Turn Conversations', href: '/docs/cookbook/quickstart/session-observability' },
                   { title: 'Monitoring & Alerts: Track LLM Performance and Set Quality Thresholds', href: '/docs/cookbook/quickstart/monitoring-alerts' },
                   { title: 'Inline Evals in Tracing: Score Every Response as It\'s Generated', href: '/docs/cookbook/quickstart/inline-evals-tracing' },
+                  { title: 'Distributed Tracing: Connect Spans Across Services', href: '/docs/cookbook/quickstart/distributed-tracing' },
                 ]
               },
               {

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -164,6 +164,7 @@ export const tabNavigation: NavTab[] = [
               { title: 'Portkey', href: '/docs/tracing/auto/portkey' },
               { title: 'PromptFlow', href: '/docs/tracing/auto/promptflow' },
               { title: 'Smol Agents', href: '/docs/tracing/auto/smol_agents' },
+              { title: 'Spring Boot', href: '/docs/tracing/auto/spring-boot' },
               { title: 'Together AI', href: '/docs/tracing/auto/togetherai' },
               { title: 'Vercel', href: '/docs/tracing/auto/vercel' },
               { title: 'Vertex AI', href: '/docs/tracing/auto/vertexai' },

--- a/src/pages/docs/cookbook/quickstart/distributed-tracing.mdx
+++ b/src/pages/docs/cookbook/quickstart/distributed-tracing.mdx
@@ -1,0 +1,1035 @@
+---
+title: "Distributed Tracing: Connect Spans Across Services into One Trace"
+description: "Propagate OpenTelemetry trace context across microservices so every span - from your API gateway to your LLM backend - shows up in a single trace."
+---
+
+<TLDR>
+Use W3C TraceContext headers to propagate trace IDs across HTTP boundaries. The gateway injects the `traceparent` header into outgoing requests, the backend extracts it and attaches the context - and all spans land in one unified trace on your dashboard.
+</TLDR>
+
+| Time | Difficulty | Languages |
+|------|-----------|-----------|
+| 20 min | Intermediate | Python, TypeScript, Java, C# |
+
+<Prerequisites>
+- FutureAGI account - [app.futureagi.com](https://app.futureagi.com)
+- API keys: `FI_API_KEY` and `FI_SECRET_KEY` (see [Get your API keys](/docs/admin-settings))
+- Google Gemini API key (`GOOGLE_API_KEY`) for the LLM calls
+</Prerequisites>
+
+## The Problem
+
+You have two services - an API gateway and an LLM backend. Both produce OpenTelemetry spans, but they show up as **separate traces** on the dashboard. You can't see the full picture: which gateway request triggered which LLM call, how long the end-to-end flow took, or where the bottleneck is.
+
+You want one trace ID that links everything: which gateway request triggered which LLM call, how long the round trip took, where time was spent.
+
+## The Solution: W3C TraceContext Propagation
+
+OpenTelemetry uses the [W3C TraceContext](https://www.w3.org/TR/trace-context/) standard to pass trace IDs across HTTP boundaries. The flow:
+
+1. Gateway creates a span, injects `traceparent` header into the outgoing HTTP request
+2. Backend extracts the `traceparent` header, attaches the context so new spans become children
+3. Both services export to the same FutureAGI project - the dashboard stitches them into one trace
+
+The `traceparent` header looks like: `00-<traceId>-<spanId>-01` (`00` = version, `01` = sampled flag)
+
+Both services must use the same `project_name` when registering. That's how FutureAGI groups spans from different processes into one trace view.
+
+## Architecture
+
+```
+┌─────────────────────────┐     HTTP + traceparent header     ┌─────────────────────────┐
+│      API Gateway        │ ────────────────────────────────> │    LLM Backend          │
+│      (port 5100)        │                                   │    (port 5101)          │
+│                         │ <──────────────────────────────── │                         │
+│  GET /ask               │         JSON response             │  POST /generate         │
+│                         │                                   │                         │
+│  Spans:                 │                                   │  Spans:                 │
+│  - Gateway.ProcessReq   │                                   │  - (auto) LLM call      │
+│  - Gateway.CallBackend  │                                   │    model, tokens, I/O   │
+│  - Gateway.PostProcess  │                                   │                         │
+└─────────────────────────┘                                   └─────────────────────────┘
+         │                                                              │
+         └──────────────────── Same TraceId ────────────────────────────┘
+                              │
+                    FutureAGI Dashboard
+                    (single unified trace)
+```
+
+## Pick Your Language
+
+<Tabs>
+  <Tab title="Python">
+
+### Install
+
+```bash
+pip install fi-instrumentation-otel traceAI-google-genai flask requests python-dotenv google-genai
+```
+
+```bash
+export FI_API_KEY="your-fi-api-key"
+export FI_SECRET_KEY="your-fi-secret-key"
+export GOOGLE_API_KEY="your-google-api-key"
+```
+
+### Gateway (gateway.py)
+
+```python
+"""
+Gateway Service (port 5100)
+- Receives user requests at GET /ask
+- Calls the Backend Service with trace context propagation
+- Post-processes and returns the response
+"""
+import json
+import requests as http_requests
+from flask import Flask, jsonify
+
+from opentelemetry import trace
+from opentelemetry.propagate import set_global_textmap, inject
+from opentelemetry.propagators.composite import CompositePropagator
+from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+from opentelemetry.baggage.propagation import W3CBaggagePropagator
+
+from fi_instrumentation.otel import register, ProjectType
+
+# Step 1: Set up W3C TraceContext propagator
+# This tells OTel how to encode/decode trace context into HTTP headers.
+# You need this on BOTH services.
+set_global_textmap(CompositePropagator([
+    TraceContextTextMapPropagator(),  # W3C traceparent header
+    W3CBaggagePropagator(),           # W3C baggage header
+]))
+
+# Step 2: Register with FutureAGI
+# Handles all exporter setup - reads API keys from env, configures
+# the OTLP exporter, creates the TracerProvider. One line instead
+# of ~15 lines of manual OTel config.
+provider = register(
+    project_name="distributed_tracing_demo",
+    project_type=ProjectType.OBSERVE,
+    set_global_tracer_provider=True,
+)
+
+tracer = trace.get_tracer("ApiGateway")
+app = Flask(__name__)
+
+
+@app.route("/ask")
+def ask():
+    with tracer.start_as_current_span(
+        "Gateway.ProcessRequest", kind=trace.SpanKind.SERVER
+    ) as span:
+        question = "What is OpenTelemetry context propagation in 2 sentences?"
+        span.set_attribute("input.value", question)
+        trace_id = format(span.get_span_context().trace_id, "032x")
+
+        # Step 3: Call the backend - INJECT trace context into headers
+        # This is the key part. inject() takes the current active span's
+        # context and writes the traceparent header into the dict.
+        with tracer.start_as_current_span(
+            "Gateway.CallBackend", kind=trace.SpanKind.CLIENT
+        ) as call_span:
+            call_span.set_attribute("input.value", question)
+
+            headers = {}
+            inject(headers)  # writes: traceparent: 00-<traceId>-<spanId>-01
+
+            response = http_requests.post(
+                "http://localhost:5101/generate",
+                json={"question": question},
+                headers=headers,
+            )
+            answer = response.json().get("answer", "")
+            call_span.set_attribute("output.value", answer)
+
+        # Post-process the response
+        with tracer.start_as_current_span(
+            "Gateway.PostProcess", kind=trace.SpanKind.INTERNAL
+        ) as post_span:
+            post_span.set_attribute("input.value", answer)
+            post_span.set_attribute("output.value", answer)
+
+        span.set_attribute("output.value", answer)
+        return jsonify({"traceId": trace_id, "answer": answer})
+
+
+if __name__ == "__main__":
+    print("ApiGateway is ready at http://localhost:5100")
+    app.run(host="localhost", port=5100)
+```
+
+### Backend (backend.py)
+
+```python
+"""
+Backend Service (port 5101)
+- Receives requests from the Gateway at POST /generate
+- Extracts propagated trace context (traceparent header)
+- Calls Google Gemini API (auto-instrumented by traceai)
+"""
+import os
+from flask import Flask, jsonify, request
+from google import genai
+
+from opentelemetry import trace, context
+from opentelemetry.propagate import set_global_textmap, extract
+from opentelemetry.propagators.composite import CompositePropagator
+from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+from opentelemetry.baggage.propagation import W3CBaggagePropagator
+
+from fi_instrumentation.otel import register, ProjectType
+from traceai_google_genai import GoogleGenAIInstrumentor
+
+# Same propagator setup as the gateway
+set_global_textmap(CompositePropagator([
+    TraceContextTextMapPropagator(),
+    W3CBaggagePropagator(),
+]))
+
+# Same project name - both services must export to the same project
+provider = register(
+    project_name="distributed_tracing_demo",
+    project_type=ProjectType.OBSERVE,
+    set_global_tracer_provider=True,
+)
+
+# Auto-instrument Google GenAI - creates spans with model name,
+# token counts, input/output automatically. No manual code needed.
+GoogleGenAIInstrumentor().instrument(tracer_provider=provider)
+
+client = genai.Client(api_key=os.environ["GOOGLE_API_KEY"])
+app = Flask(__name__)
+
+
+@app.route("/generate", methods=["POST"])
+def generate():
+    # Step 4: EXTRACT trace context from the gateway's request
+    # extract() parses the traceparent header back into a span context.
+    ctx = extract(request.headers)
+
+    body = request.get_json()
+    question = body.get("question", "Hello")
+
+    # context.attach() makes the extracted context active so all new
+    # spans become CHILDREN of the gateway's span - same TraceId.
+    # The returned token is needed for detach(). Always detach in a
+    # finally block - Flask reuses threads, so leaking context means
+    # the next request on this thread inherits the wrong parent.
+    token = context.attach(ctx)
+    try:
+        # traceai auto-instruments this call - creates a span with
+        # model name, token counts, input/output automatically
+        response = client.models.generate_content(
+            model="gemini-2.0-flash",
+            contents=question,
+        )
+        answer = response.text or "No response"
+    finally:
+        context.detach(token)
+
+    return jsonify({"answer": answer})
+
+
+if __name__ == "__main__":
+    print("BackendService is ready at http://localhost:5101")
+    app.run(host="localhost", port=5101)
+```
+
+### Run it
+
+Start the backend first (so the gateway doesn't get connection errors):
+
+```bash
+# Terminal 1 - start backend first
+python backend.py
+
+# Terminal 2 - then start gateway
+python gateway.py
+```
+
+```bash
+curl http://localhost:5100/ask
+```
+
+Both services log the same TraceId. Open your [FutureAGI dashboard](https://app.futureagi.com) - you'll see one trace with all spans nested correctly.
+
+  </Tab>
+  <Tab title="TypeScript">
+
+### Install
+
+```bash
+npm install @traceai/fi-core @traceai/google-genai @google/genai \
+  @opentelemetry/api @opentelemetry/core @opentelemetry/instrumentation express
+```
+
+```bash
+export FI_API_KEY="your-fi-api-key"
+export FI_SECRET_KEY="your-fi-secret-key"
+export GOOGLE_API_KEY="your-google-api-key"
+```
+
+### Gateway (gateway.ts)
+
+```typescript
+/**
+ * Gateway Service (port 5100)
+ * - Receives user requests at GET /ask
+ * - Calls the Backend Service with trace context propagation
+ */
+import express from "express";
+import { register, ProjectType } from "@traceai/fi-core";
+import { trace, context, propagation, SpanKind } from "@opentelemetry/api";
+import { W3CTraceContextPropagator } from "@opentelemetry/core";
+
+// Step 1: Set up W3C propagator
+propagation.setGlobalPropagator(new W3CTraceContextPropagator());
+
+// Step 2: Register with FutureAGI
+const tracerProvider = register({
+  projectName: "distributed_tracing_demo",
+  projectType: ProjectType.OBSERVE,
+  setGlobalTracerProvider: true,
+});
+
+const tracer = trace.getTracer("ApiGateway");
+const app = express();
+
+app.get("/ask", async (req, res) => {
+  const span = tracer.startSpan("Gateway.ProcessRequest", {
+    kind: SpanKind.SERVER,
+  });
+
+  const ctx = trace.setSpan(context.active(), span);
+
+  await context.with(ctx, async () => {
+    const question =
+      "What is OpenTelemetry context propagation in 2 sentences?";
+    span.setAttribute("input.value", question);
+
+    // Step 3: INJECT trace context into outgoing request headers
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+    propagation.inject(context.active(), headers, {
+      set: (carrier, key, value) => {
+        carrier[key] = String(value);
+      },
+    });
+    // headers now contains: traceparent: 00-<traceId>-<spanId>-01
+
+    const callSpan = tracer.startSpan("Gateway.CallBackend", {
+      kind: SpanKind.CLIENT,
+    });
+    callSpan.setAttribute("input.value", question);
+
+    const response = await fetch("http://localhost:5101/generate", {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ question }),
+    });
+    const body = await response.json();
+    const answer = (body as any).answer || "";
+
+    callSpan.setAttribute("output.value", answer);
+    callSpan.end();
+
+    const traceId = span.spanContext().traceId;
+    span.setAttribute("output.value", answer);
+    span.end();
+
+    res.json({ traceId, answer });
+  });
+});
+
+app.listen(5100, () => {
+  console.log("ApiGateway is ready at http://localhost:5100");
+});
+```
+
+### Backend (backend.ts)
+
+```typescript
+/**
+ * Backend Service (port 5101)
+ * - Receives requests from the Gateway at POST /generate
+ * - Extracts propagated trace context
+ * - Calls Google Gemini (auto-instrumented by traceai)
+ */
+import express from "express";
+import { register, ProjectType } from "@traceai/fi-core";
+import { GoogleGenAIInstrumentation } from "@traceai/google-genai";
+import { registerInstrumentations } from "@opentelemetry/instrumentation";
+import { trace, context, propagation } from "@opentelemetry/api";
+import { W3CTraceContextPropagator } from "@opentelemetry/core";
+
+// Same propagator setup as the gateway
+propagation.setGlobalPropagator(new W3CTraceContextPropagator());
+
+// Same project name - both services must use the same project
+const tracerProvider = register({
+  projectName: "distributed_tracing_demo",
+  projectType: ProjectType.OBSERVE,
+  setGlobalTracerProvider: true,
+});
+
+// Auto-instrument Google GenAI
+registerInstrumentations({
+  tracerProvider,
+  instrumentations: [new GoogleGenAIInstrumentation()],
+});
+
+const { GoogleGenAI } = require("@google/genai");
+const genai = new GoogleGenAI({ apiKey: process.env.GOOGLE_API_KEY });
+
+const app = express();
+app.use(express.json());
+
+app.post("/generate", async (req, res) => {
+  // Step 4: EXTRACT trace context from the gateway's request
+  const extractedCtx = propagation.extract(
+    context.active(),
+    req.headers,
+    {
+      get: (carrier, key) => {
+        const val = carrier[key.toLowerCase()];
+        return Array.isArray(val) ? val[0] : val;
+      },
+    }
+  );
+
+  // Run within the extracted context so new spans become
+  // children of the gateway's span - same TraceId
+  await context.with(extractedCtx, async () => {
+    const question = req.body.question || "Hello";
+
+    // traceai auto-instruments this - creates a span with
+    // model name, token counts, input/output
+    const response = await genai.models.generateContent({
+      model: "gemini-2.0-flash",
+      contents: question,
+    });
+
+    const answer = response.text || "No response";
+    res.json({ answer });
+  });
+});
+
+app.listen(5101, () => {
+  console.log("BackendService is ready at http://localhost:5101");
+});
+```
+
+### Run it
+
+```bash
+# Terminal 1 - start backend first
+npx tsx backend.ts
+
+# Terminal 2 - then start gateway
+npx tsx gateway.ts
+```
+
+```bash
+curl http://localhost:5100/ask
+```
+
+  </Tab>
+  <Tab title="Java">
+
+### Dependencies
+
+```xml
+<!-- In both gateway and backend pom.xml -->
+<dependencies>
+    <dependency>
+        <groupId>com.github.future-agi.traceAI</groupId>
+        <artifactId>traceai-java-core</artifactId>
+        <version>v1.0.0</version>
+    </dependency>
+    <dependency>
+        <groupId>io.opentelemetry</groupId>
+        <artifactId>opentelemetry-api</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>io.opentelemetry</groupId>
+        <artifactId>opentelemetry-sdk</artifactId>
+    </dependency>
+</dependencies>
+```
+
+For Spring Boot apps, add the starter instead:
+
+```xml
+<dependency>
+    <groupId>com.github.future-agi.traceAI</groupId>
+    <artifactId>traceai-spring-boot-starter</artifactId>
+    <version>v1.0.0</version>
+</dependency>
+<!-- Spring Boot's OTel auto-config handles propagation -->
+<dependency>
+    <groupId>io.opentelemetry.instrumentation</groupId>
+    <artifactId>opentelemetry-spring-boot-starter</artifactId>
+</dependency>
+```
+
+```bash
+export FI_API_KEY="your-fi-api-key"
+export FI_SECRET_KEY="your-fi-secret-key"
+export GOOGLE_API_KEY="your-google-api-key"
+```
+
+### Gateway (GatewayService.java)
+
+```java
+import ai.traceai.TraceAI;
+import ai.traceai.FITracer;
+import ai.traceai.FISpanKind;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.context.propagation.TextMapSetter;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.HashMap;
+import java.util.Map;
+
+public class GatewayService {
+
+    public static void main(String[] args) throws Exception {
+        // Step 1: Initialize TraceAI (sets up OTel with W3C propagation)
+        TraceAI.initFromEnvironment();
+        FITracer tracer = TraceAI.getTracer();
+        HttpClient httpClient = HttpClient.newHttpClient();
+
+        // In your HTTP handler (e.g., Spring @GetMapping, Spark, Javalin):
+        String question = "What is OpenTelemetry context propagation?";
+
+        // Create the parent span
+        Span span = tracer.startSpan("Gateway.ProcessRequest", FISpanKind.CHAIN);
+        try (Scope scope = span.makeCurrent()) {
+            tracer.setInputValue(span, question);
+
+            // Step 2: INJECT trace context into outgoing HTTP headers
+            Map<String, String> headers = new HashMap<>();
+            GlobalOpenTelemetry.getPropagators()
+                .getTextMapPropagator()
+                .inject(Context.current(), headers, (carrier, key, value) -> {
+                    carrier.put(key, value);
+                });
+            // headers now contains: traceparent: 00-<traceId>-<spanId>-01
+
+            Span callSpan = tracer.startSpan("Gateway.CallBackend", FISpanKind.CHAIN);
+            try (Scope callScope = callSpan.makeCurrent()) {
+                HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
+                    .uri(URI.create("http://localhost:5101/generate"))
+                    .POST(HttpRequest.BodyPublishers.ofString(
+                        "{\"question\": \"" + question + "\"}"))
+                    .header("Content-Type", "application/json");
+
+                // Add the propagated headers
+                headers.forEach(requestBuilder::header);
+
+                HttpResponse<String> response = httpClient.send(
+                    requestBuilder.build(),
+                    HttpResponse.BodyHandlers.ofString());
+
+                tracer.setOutputValue(callSpan, response.body());
+            } finally {
+                callSpan.end();
+            }
+
+            tracer.setOutputValue(span, "done");
+        } finally {
+            span.end();
+        }
+
+        // For a long-running server, call shutdown() on JVM shutdown hook instead:
+        // Runtime.getRuntime().addShutdownHook(new Thread(TraceAI::shutdown));
+        TraceAI.shutdown();
+    }
+}
+```
+
+### Backend (BackendService.java)
+
+The extract logic is framework-specific. Here's the pattern using Javalin (same idea applies to Spring, Spark, or any Java HTTP framework):
+
+```java
+import ai.traceai.TraceAI;
+import ai.traceai.FITracer;
+import ai.traceai.FISpanKind;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.javalin.Javalin;
+import io.javalin.http.Context as JContext;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class BackendService {
+
+    public static void main(String[] args) {
+        TraceAI.initFromEnvironment();
+        FITracer tracer = TraceAI.getTracer();
+
+        Javalin app = Javalin.create().start(5101);
+
+        app.post("/generate", ctx -> {
+            // Step 3: EXTRACT trace context from incoming request headers
+            // Build a header map from the HTTP request
+            Map<String, String> incomingHeaders = new HashMap<>();
+            ctx.headerMap().forEach(incomingHeaders::put);
+
+            Context extractedCtx = GlobalOpenTelemetry.getPropagators()
+                .getTextMapPropagator()
+                .extract(Context.current(), incomingHeaders, (carrier, key) -> {
+                    return carrier.get(key);
+                });
+
+            String question = ctx.bodyAsClass(Map.class)
+                .getOrDefault("question", "Hello").toString();
+
+            // All spans created within this scope are children of the
+            // gateway's span - same TraceId
+            try (Scope scope = extractedCtx.makeCurrent()) {
+                Span span = tracer.startSpan("Backend.GeminiCall", FISpanKind.LLM);
+                try (Scope spanScope = span.makeCurrent()) {
+                    tracer.setInputValue(span, question);
+
+                    // Call your LLM here
+                    String answer = callGemini(question);
+
+                    tracer.setOutputValue(span, answer);
+                    tracer.setTokenCounts(span, 50, 200, 250);
+                    ctx.json(Map.of("answer", answer));
+                } finally {
+                    span.end();
+                }
+            }
+        });
+    }
+}
+```
+
+<Note>
+  If you're using **Spring Boot** with the OTel Spring Boot starter, inject/extract is handled automatically by Spring's HTTP client and server instrumentation - just like the C# example. You don't need to manually call `inject()` or `extract()`.
+</Note>
+
+### Run it
+
+```bash
+# Terminal 1 - start backend first
+java -jar backend.jar
+
+# Terminal 2 - then start gateway
+java -jar gateway.jar
+```
+
+```bash
+curl http://localhost:5100/ask
+```
+
+  </Tab>
+  <Tab title="C#">
+
+### Install
+
+```bash
+dotnet add package OpenTelemetry
+dotnet add package OpenTelemetry.Exporter.OpenTelemetryProtocol
+dotnet add package OpenTelemetry.Instrumentation.AspNetCore
+dotnet add package OpenTelemetry.Instrumentation.Http
+dotnet add package DotNetEnv
+```
+
+```bash
+export FI_API_KEY="your-fi-api-key"
+export FI_SECRET_KEY="your-fi-secret-key"
+export GOOGLE_API_KEY="your-google-api-key"
+```
+
+### Single-project setup
+
+The C# example runs both gateway and backend from one project - pass `gateway` or `backend` as a CLI arg to pick the role. In production, these would be separate deployments.
+
+`AddAspNetCoreInstrumentation()` and `AddHttpClientInstrumentation()` handle inject/extract automatically, so there are no manual `inject()` or `extract()` calls in the C# version.
+
+### Program.cs
+
+```csharp
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+using OpenTelemetry;
+using OpenTelemetry.Context.Propagation;
+using OpenTelemetry.Exporter;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+
+DotNetEnv.Env.Load("../.env");
+
+var fiApiKey = Environment.GetEnvironmentVariable("FI_API_KEY")
+    ?? throw new Exception("FI_API_KEY not set");
+var fiSecretKey = Environment.GetEnvironmentVariable("FI_SECRET_KEY")
+    ?? throw new Exception("FI_SECRET_KEY not set");
+var googleApiKey = Environment.GetEnvironmentVariable("GOOGLE_API_KEY")
+    ?? throw new Exception("GOOGLE_API_KEY not set");
+
+// Run as gateway or backend based on CLI arg
+var serviceRole = args.Length > 0 ? args[0] : "gateway";
+var servicePort = serviceRole == "gateway" ? 5100 : 5101;
+var serviceName = serviceRole == "gateway" ? "ApiGateway" : "BackendService";
+
+var activitySource = new ActivitySource(serviceName);
+
+// Step 1: Set up W3C TraceContext propagator
+Sdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(
+    new TextMapPropagator[]
+    {
+        new TraceContextPropagator(),
+        new BaggagePropagator()
+    }));
+
+var builder = WebApplication.CreateBuilder(args);
+builder.WebHost.UseUrls($"http://localhost:{servicePort}");
+
+// Step 2: Configure OpenTelemetry with OTLP exporter
+builder.Services.AddOpenTelemetry()
+    .WithTracing(tracerBuilder =>
+    {
+        tracerBuilder
+            .SetResourceBuilder(
+                ResourceBuilder.CreateDefault()
+                    .AddService(serviceName: serviceName, serviceVersion: "1.0.0")
+                    .AddAttributes(new Dictionary<string, object>
+                    {
+                        ["project_name"] = "distributed_tracing_demo",
+                        ["project_type"] = "observe"
+                    }))
+            .AddSource(serviceName)
+            // Auto-EXTRACTS traceparent from incoming requests
+            .AddAspNetCoreInstrumentation(opts => opts.RecordException = true)
+            // Auto-INJECTS traceparent into outgoing requests
+            .AddHttpClientInstrumentation(opts => opts.RecordException = true)
+            .AddOtlpExporter(opts =>
+            {
+                opts.Endpoint = new Uri(
+                    "https://api.futureagi.com/tracer/v1/traces");
+                opts.Protocol = OtlpExportProtocol.HttpProtobuf;
+                opts.Headers = $"X-Api-Key={fiApiKey},X-Secret-Key={fiSecretKey}";
+            });
+    });
+
+builder.Services.AddHttpClient();
+var app = builder.Build();
+
+if (serviceRole == "gateway")
+{
+    // GATEWAY - receives user request, calls backend
+    app.MapGet("/ask", async (IHttpClientFactory httpClientFactory) =>
+    {
+        using var activity = activitySource.StartActivity(
+            "Gateway.ProcessRequest", ActivityKind.Server);
+
+        var question = "What is OpenTelemetry context propagation in 2 sentences?";
+        activity?.SetTag("input.value", question);
+
+        // Step 3: Call backend - traceparent is AUTOMATICALLY injected
+        // by AddHttpClientInstrumentation(). Just make the HTTP call.
+        using var callActivity = activitySource.StartActivity(
+            "Gateway.CallBackend", ActivityKind.Client);
+
+        var client = httpClientFactory.CreateClient();
+        var backendRequest = new HttpRequestMessage(
+            HttpMethod.Post, "http://localhost:5101/generate");
+        backendRequest.Content = new StringContent(
+            JsonSerializer.Serialize(new { question }),
+            Encoding.UTF8, "application/json");
+
+        var response = await client.SendAsync(backendRequest);
+        var responseBody = await response.Content.ReadAsStringAsync();
+
+        using var postActivity = activitySource.StartActivity(
+            "Gateway.PostProcess", ActivityKind.Internal);
+
+        using var doc = JsonDocument.Parse(responseBody);
+        var answer = doc.RootElement.TryGetProperty("answer", out var ans)
+            ? ans.GetString() : responseBody;
+
+        activity?.SetTag("output.value", answer);
+        return Results.Ok(new
+        {
+            traceId = Activity.Current?.TraceId.ToString(),
+            answer
+        });
+    });
+}
+else
+{
+    // BACKEND - receives request from gateway, calls Gemini
+    app.MapPost("/generate", async (
+        HttpRequest httpRequest, IHttpClientFactory httpClientFactory) =>
+    {
+        // Step 4: traceparent is AUTOMATICALLY extracted by
+        // AddAspNetCoreInstrumentation(). Activity.Current already
+        // has the gateway's TraceId - any spans you create are
+        // automatically children. The middleware runs before your
+        // handler code, so the context is ready when you get here.
+
+        var body = await JsonSerializer.DeserializeAsync<JsonElement>(
+            httpRequest.Body);
+        var question = body.GetProperty("question").GetString() ?? "Hello";
+
+        using var activity = activitySource.StartActivity(
+            "Backend.GeminiCall", ActivityKind.Client);
+        activity?.SetTag("gen_ai.span.kind", "llm");
+        activity?.SetTag("gen_ai.request.model", "gemini-2.0-flash");
+        activity?.SetTag("input.value", question);
+
+        // Call Gemini API directly
+        var model = "gemini-2.0-flash";
+        var geminiUrl = $"https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={googleApiKey}";
+
+        var requestBody = new
+        {
+            contents = new[]
+            {
+                new { parts = new[] { new { text = question } } }
+            }
+        };
+
+        var client = httpClientFactory.CreateClient();
+        var geminiRequest = new HttpRequestMessage(HttpMethod.Post, geminiUrl);
+        geminiRequest.Content = new StringContent(
+            JsonSerializer.Serialize(requestBody),
+            Encoding.UTF8, "application/json");
+
+        var response = await client.SendAsync(geminiRequest);
+        var outputJson = await response.Content.ReadAsStringAsync();
+
+        string answer = "No response";
+        if (response.IsSuccessStatusCode)
+        {
+            activity?.SetStatus(ActivityStatusCode.Ok);
+            using var doc = JsonDocument.Parse(outputJson);
+
+            if (doc.RootElement.TryGetProperty("usageMetadata", out var usage))
+            {
+                if (usage.TryGetProperty("promptTokenCount", out var pt))
+                    activity?.SetTag("gen_ai.usage.input_tokens", pt.GetInt32());
+                if (usage.TryGetProperty("candidatesTokenCount", out var ct))
+                    activity?.SetTag("gen_ai.usage.output_tokens", ct.GetInt32());
+                if (usage.TryGetProperty("totalTokenCount", out var tt))
+                    activity?.SetTag("gen_ai.usage.total_tokens", tt.GetInt32());
+            }
+
+            if (doc.RootElement.TryGetProperty("candidates", out var candidates))
+            {
+                var first = candidates[0];
+                if (first.TryGetProperty("content", out var content) &&
+                    content.TryGetProperty("parts", out var parts))
+                {
+                    answer = parts[0].GetProperty("text").GetString()
+                        ?? "No response";
+                }
+            }
+        }
+        else
+        {
+            activity?.SetStatus(ActivityStatusCode.Error,
+                $"HTTP {response.StatusCode}");
+            answer = $"Error: {response.StatusCode}";
+        }
+
+        activity?.SetTag("output.value", answer);
+        return Results.Ok(new { answer });
+    });
+}
+
+Console.WriteLine($"{serviceName} is ready at http://localhost:{servicePort}");
+app.Run();
+```
+
+### Run it
+
+```bash
+# Terminal 1 - start backend first
+dotnet run -- backend
+
+# Terminal 2 - then start gateway
+dotnet run -- gateway
+```
+
+```bash
+curl http://localhost:5100/ask
+```
+
+  </Tab>
+</Tabs>
+
+## How It Works
+
+Three moving parts:
+
+### 1. Propagator setup (both services)
+
+Both services must agree on the same propagation format. W3C TraceContext is the standard:
+
+<Tabs>
+  <Tab title="Python">
+    ```python
+    set_global_textmap(CompositePropagator([
+        TraceContextTextMapPropagator(),
+        W3CBaggagePropagator(),
+    ]))
+    ```
+  </Tab>
+  <Tab title="TypeScript">
+    ```typescript
+    propagation.setGlobalPropagator(new W3CTraceContextPropagator());
+    ```
+  </Tab>
+  <Tab title="Java">
+    ```java
+    // OTel SDK uses W3C TraceContext by default when registered globally
+    // via TraceAI.initFromEnvironment() or OpenTelemetrySdk.buildAndRegisterGlobal()
+    ```
+  </Tab>
+  <Tab title="C#">
+    ```csharp
+    Sdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(
+        new TextMapPropagator[] {
+            new TraceContextPropagator(),
+            new BaggagePropagator()
+        }));
+    ```
+  </Tab>
+</Tabs>
+
+### 2. Gateway injects context (outgoing call)
+
+<Tabs>
+  <Tab title="Python (manual)">
+    ```python
+    headers = {}
+    inject(headers)  # writes traceparent: 00-<traceId>-<spanId>-01
+    response = requests.post(url, headers=headers)
+    ```
+  </Tab>
+  <Tab title="TypeScript (manual)">
+    ```typescript
+    const headers: Record<string, string> = {};
+    propagation.inject(context.active(), headers, {
+      set: (carrier, key, value) => { carrier[key] = String(value); }
+    });
+    const response = await fetch(url, { headers });
+    ```
+  </Tab>
+  <Tab title="Java (manual)">
+    ```java
+    Map<String, String> headers = new HashMap<>();
+    GlobalOpenTelemetry.getPropagators().getTextMapPropagator()
+        .inject(Context.current(), headers, Map::put);
+    // Add headers to your HTTP request
+    ```
+  </Tab>
+  <Tab title="C# (automatic)">
+    ```csharp
+    // AddHttpClientInstrumentation() does this automatically.
+    // Just make the HTTP call:
+    var response = await client.SendAsync(request);
+    ```
+  </Tab>
+</Tabs>
+
+### 3. Backend extracts context (incoming call)
+
+<Tabs>
+  <Tab title="Python (manual)">
+    ```python
+    ctx = extract(request.headers)
+    token = context.attach(ctx)
+    try:
+        response = llm.generate(...)  # child of gateway's span
+    finally:
+        context.detach(token)  # always detach - Flask reuses threads
+    ```
+  </Tab>
+  <Tab title="TypeScript (manual)">
+    ```typescript
+    const extractedCtx = propagation.extract(context.active(), req.headers, {
+      get: (carrier, key) => carrier[key.toLowerCase()]
+    });
+    await context.with(extractedCtx, async () => {
+      // spans here are children of gateway's span
+    });
+    ```
+  </Tab>
+  <Tab title="Java (manual)">
+    ```java
+    Context extractedCtx = GlobalOpenTelemetry.getPropagators()
+        .getTextMapPropagator()
+        .extract(Context.current(), headers, Map::get);
+    try (Scope scope = extractedCtx.makeCurrent()) {
+        // spans here are children of gateway's span
+    }
+    ```
+  </Tab>
+  <Tab title="C# (automatic)">
+    ```csharp
+    // AddAspNetCoreInstrumentation() extracts automatically.
+    // The middleware runs before your handler, so Activity.Current
+    // already has the gateway's TraceId when your code executes.
+    using var activity = activitySource.StartActivity("Backend.Work");
+    // This span is automatically a child of the gateway's span
+    ```
+  </Tab>
+</Tabs>
+
+## Cross-Language Propagation
+
+The W3C `traceparent` header is language-agnostic. You can mix languages freely:
+
+- Python gateway -> C# backend
+- TypeScript gateway -> Java backend
+- Any combination works
+
+As long as both services use W3C TraceContext propagation and export to the same FutureAGI project, spans are stitched into one trace.
+
+## Checklist
+
+Before you ship:
+
+- [ ] Both services set the same W3C propagator
+- [ ] Both services use the same `project_name`
+- [ ] Gateway injects `traceparent` header (manually or via HTTP instrumentation)
+- [ ] Backend extracts `traceparent` header (manually or via framework instrumentation)
+- [ ] Both services have `FI_API_KEY` and `FI_SECRET_KEY` set
+- [ ] Backend is started before gateway (or gateway handles connection errors gracefully)
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Tracing SDK Reference" icon="code" href="/docs/sdk/tracing">
+    Full API reference for register(), FITracer, context helpers, and TraceConfig.
+  </Card>
+  <Card title="Manual Tracing Cookbook" icon="book" href="/docs/cookbook/quickstart/manual-tracing">
+    Add custom spans to any application without auto-instrumentation.
+  </Card>
+  <Card title="Auto-Instrumentation" icon="plug" href="/docs/tracing/auto">
+    Setup guides for 45+ supported frameworks.
+  </Card>
+  <Card title="Session Observability" icon="eye" href="/docs/cookbook/quickstart/session-observability">
+    Track multi-turn conversations with session IDs.
+  </Card>
+</CardGroup>

--- a/src/pages/docs/tracing/auto/index.mdx
+++ b/src/pages/docs/tracing/auto/index.mdx
@@ -89,6 +89,14 @@ Auto-instrumentation allows you to add tracing to your LLM applications with min
   </Card>
 </CardGroup>
 
+## Java / Spring
+
+<CardGroup cols={3}>
+  <Card title="Spring Boot" icon="leaf" href="/docs/tracing/auto/spring-boot">
+    `traceai-spring-boot-starter`
+  </Card>
+</CardGroup>
+
 ## Other
 
 <CardGroup cols={3}>

--- a/src/pages/docs/tracing/auto/spring-boot.mdx
+++ b/src/pages/docs/tracing/auto/spring-boot.mdx
@@ -1,0 +1,339 @@
+---
+title: "Spring Boot"
+description: "Add tracing to Spring Boot apps with Spring AI. Configure application.yml, wrap your ChatModel and EmbeddingModel, and traces are collected automatically."
+---
+
+<TLDR>
+- `traceai-spring-boot-starter` auto-configures `FITracer` from `application.yml`
+- Wrap `ChatModel` with `TracedChatModel`, `EmbeddingModel` with `TracedEmbeddingModel`
+- Captures messages, token counts, model info, latency, and errors
+- Streaming support built in - works with `Flux<ChatResponse>`
+- Distributed via JitPack (no Maven Central publish yet)
+</TLDR>
+
+## How it works
+
+`traceai-spring-boot-starter` is the Spring Boot auto-configuration for TraceAI. When you add it to your project:
+
+1. `TraceAIAutoConfiguration` reads your `traceai.*` properties and creates an `FITracer` bean
+2. You wrap your Spring AI models with `TracedChatModel` or `TracedEmbeddingModel`
+3. Every call and stream through those wrappers creates an OpenTelemetry span with LLM metadata attached
+
+The wrappers delegate to the underlying model and add span instrumentation around each call. You pick which models get traced by wrapping them explicitly - the starter doesn't auto-wrap beans because that could break apps with multiple providers or custom bean ordering.
+
+## 1. Add dependencies
+
+Add the JitPack repository and the starter to your `pom.xml`. This assumes you're using the Spring Boot parent POM:
+
+```xml
+<parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.2.1</version>
+</parent>
+
+<properties>
+    <java.version>17</java.version>
+    <spring-ai.version>1.0.0-M4</spring-ai.version>
+</properties>
+
+<repositories>
+    <!-- Spring Milestones (for spring-ai milestone releases) -->
+    <repository>
+        <id>spring-milestones</id>
+        <url>https://repo.spring.io/milestone</url>
+    </repository>
+
+    <!-- JitPack - pulls TraceAI directly from GitHub -->
+    <repository>
+        <id>jitpack.io</id>
+        <url>https://jitpack.io</url>
+    </repository>
+</repositories>
+
+<dependencies>
+    <!-- Spring Boot Web -->
+    <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+
+    <!-- TraceAI Spring Boot Starter -->
+    <dependency>
+        <groupId>com.github.future-agi.traceAI</groupId>
+        <artifactId>traceai-spring-boot-starter</artifactId>
+        <version>main-SNAPSHOT</version>
+    </dependency>
+
+    <!-- Spring AI - pick your provider -->
+    <dependency>
+        <groupId>org.springframework.ai</groupId>
+        <artifactId>spring-ai-openai-spring-boot-starter</artifactId>
+        <version>${spring-ai.version}</version>
+    </dependency>
+</dependencies>
+```
+
+For Gradle:
+
+```groovy
+ext {
+    springAiVersion = '1.0.0-M4'
+}
+
+repositories {
+    maven { url 'https://repo.spring.io/milestone' }
+    maven { url 'https://jitpack.io' }
+}
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'com.github.future-agi.traceAI:traceai-spring-boot-starter:main-SNAPSHOT'
+    implementation "org.springframework.ai:spring-ai-openai-spring-boot-starter:${springAiVersion}"
+}
+```
+
+**Requirements:** Java 17+, Spring Boot 3.2+, Spring AI 1.0.0-M4+
+
+---
+
+## 2. Configure application.yml
+
+```yaml
+spring:
+  application:
+    name: my-spring-ai-app
+  ai:
+    openai:
+      api-key: ${OPENAI_API_KEY}
+      chat:
+        options:
+          model: gpt-4o-mini
+          temperature: 0.7
+
+traceai:
+  enabled: true
+  base-url: https://api.futureagi.com
+  api-key: ${FI_API_KEY}
+  secret-key: ${FI_SECRET_KEY}
+  project-name: my-spring-ai-app
+```
+
+### All configuration properties
+
+| Property | Type | Default | What it does |
+|----------|------|---------|-------------|
+| `traceai.enabled` | boolean | `true` | Disables all TraceAI instrumentation when set to `false` |
+| `traceai.base-url` | string | - | FutureAGI API endpoint |
+| `traceai.api-key` | string | - | Your FI_API_KEY |
+| `traceai.secret-key` | string | - | Your FI_SECRET_KEY |
+| `traceai.project-name` | string | - | Project name in FutureAGI dashboard |
+| `traceai.service-name` | string | `spring.application.name` | Service name in traces (falls back to app name) |
+| `traceai.hide-inputs` | boolean | `false` | Redact all input values from spans |
+| `traceai.hide-outputs` | boolean | `false` | Redact all output values from spans |
+| `traceai.hide-input-messages` | boolean | `false` | Redact input messages specifically |
+| `traceai.hide-output-messages` | boolean | `false` | Redact output messages specifically |
+| `traceai.enable-console-exporter` | boolean | `false` | Print spans to console (useful for debugging) |
+| `traceai.batch-size` | int | `512` | Spans per export batch |
+| `traceai.export-interval-ms` | long | `5000` | How often to flush spans (ms) |
+
+---
+
+## 3. Wrap your models
+
+The starter auto-creates the `FITracer` bean. You just need to wrap your Spring AI models.
+
+### Chat model
+
+```java
+import ai.traceai.FITracer;
+import ai.traceai.spring.TracedChatModel;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TraceAIConfig {
+
+    @Bean
+    public TracedChatModel tracedChatModel(ChatModel chatModel, FITracer tracer) {
+        // "openai" = provider name, used in span attributes
+        return new TracedChatModel(chatModel, tracer, "openai");
+    }
+}
+```
+
+`TracedChatModel` implements `ChatModel`, so you can inject it anywhere you'd use a regular `ChatModel`.
+
+### Embedding model
+
+Add this to the same `@Configuration` class:
+
+```java
+import ai.traceai.spring.TracedEmbeddingModel;
+import org.springframework.ai.embedding.EmbeddingModel;
+
+@Bean
+public TracedEmbeddingModel tracedEmbeddingModel(EmbeddingModel embeddingModel, FITracer tracer) {
+    return new TracedEmbeddingModel(embeddingModel, tracer, "openai");
+}
+```
+
+### Using the global tracer
+
+Both wrappers have a two-arg constructor that uses the global tracer instead of injecting `FITracer`. This only works after the auto-configuration has run (i.e., inside Spring-managed beans, not in static initializers or tests):
+
+```java
+// Uses TraceAI.getTracer() internally - requires TraceAI.init() to have been called
+TracedChatModel traced = new TracedChatModel(chatModel, "openai");
+TracedEmbeddingModel tracedEmbed = new TracedEmbeddingModel(embeddingModel, "openai");
+```
+
+---
+
+## 4. Use it
+
+Once wrapped, use your models normally. Tracing is automatic.
+
+### Basic chat
+
+```java
+import ai.traceai.spring.TracedChatModel;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/chat")
+public class ChatController {
+
+    private final TracedChatModel chatModel;
+
+    @Autowired
+    public ChatController(TracedChatModel chatModel) {
+        this.chatModel = chatModel;
+    }
+
+    @GetMapping
+    public String chat(@RequestParam String message) {
+        var response = chatModel.call(new Prompt(message));
+        return response.getResult().getOutput().getContent();
+    }
+
+    @PostMapping
+    public String chatPost(@RequestBody ChatRequest request) {
+        var response = chatModel.call(new Prompt(request.message()));
+        return response.getResult().getOutput().getContent();
+    }
+
+    record ChatRequest(String message) {}
+}
+```
+
+### Streaming
+
+Streaming requires `spring-boot-starter-webflux` on the classpath alongside `spring-boot-starter-web`.
+
+```java
+import org.springframework.ai.chat.prompt.Prompt;
+import reactor.core.publisher.Flux;
+
+@GetMapping(value = "/stream", produces = "text/event-stream")
+public Flux<String> stream(@RequestParam String message) {
+    return chatModel.stream(new Prompt(message))
+        .map(response -> response.getResult().getOutput().getContent());
+}
+```
+
+The streaming wrapper accumulates chunks and records the full output in the span when the stream completes.
+
+---
+
+## What gets captured
+
+Every `TracedChatModel.call()` creates a span with:
+
+| Attribute | Example value |
+|-----------|--------------|
+| `llm.system` | `spring-ai` |
+| `llm.provider` | `openai` |
+| `llm.request.model` | `gpt-4o-mini` |
+| `llm.response.model` | `gpt-4o-mini-2024-07-18` |
+| `llm.request.temperature` | `0.7` |
+| `llm.request.top_p` | `1.0` |
+| `llm.token_count.prompt` | `15` |
+| `llm.token_count.completion` | `42` |
+| `llm.token_count.total` | `57` |
+| `input.value` | Full prompt text |
+| `output.value` | Full response text |
+| Input/output messages | Structured role + content pairs |
+
+`TracedEmbeddingModel.call()` spans capture the same `llm.system`, `llm.provider`, and model attributes, plus embedding-specific ones: `embedding.vector_count`, `embedding.dimensions`, `embedding.model_name`, and token counts (`llm.token_count.prompt`, `llm.token_count.total`).
+
+Errors on both wrappers are captured with full stack traces and set the span status to `ERROR`.
+
+---
+
+## Disabling tracing
+
+Set `traceai.enabled: false` in your `application.yml`. The auto-configuration won't create any beans, and your app runs without any TraceAI overhead.
+
+For per-environment control:
+
+```yaml
+# application-prod.yml
+traceai:
+  enabled: true
+  hide-inputs: true
+  hide-outputs: true
+
+# application-dev.yml
+traceai:
+  enabled: true
+  enable-console-exporter: true
+
+# application-test.yml
+traceai:
+  enabled: false
+```
+
+---
+
+## Debugging
+
+Enable console export and DEBUG logging to see spans printed to stdout:
+
+```yaml
+traceai:
+  enable-console-exporter: true
+
+logging:
+  level:
+    ai.traceai: DEBUG
+```
+
+Check that `TraceAI` initialized:
+
+```java
+if (ai.traceai.TraceAI.isInitialized()) {
+    System.out.println("TraceAI version: " + ai.traceai.TraceAI.getVersion());
+}
+```
+
+---
+
+## Supported providers
+
+The `provider` string you pass to `TracedChatModel` / `TracedEmbeddingModel` is just a label in span attributes. You can use any Spring AI provider:
+
+| Spring AI starter | Provider string |
+|-------------------|----------------|
+| `spring-ai-openai-spring-boot-starter` | `"openai"` |
+| `spring-ai-anthropic-spring-boot-starter` | `"anthropic"` |
+| `spring-ai-azure-openai-spring-boot-starter` | `"azure-openai"` |
+| `spring-ai-vertex-ai-gemini-spring-boot-starter` | `"vertex-ai"` |
+| `spring-ai-bedrock-ai-spring-boot-starter` | `"bedrock"` |
+| `spring-ai-ollama-spring-boot-starter` | `"ollama"` |
+| `spring-ai-mistral-ai-spring-boot-starter` | `"mistral"` |
+
+Just swap the Spring AI dependency and change the provider string. The tracing wrapper doesn't care which provider is underneath.


### PR DESCRIPTION
## Summary
- New docs page for `traceai-spring-boot-starter` Spring AI integration at `/docs/tracing/auto/spring-boot`
- Covers: Maven/Gradle setup, `application.yml` config, `TracedChatModel` and `TracedEmbeddingModel` wrappers, streaming, span attributes, per-environment config, debugging
- Added "Java / Spring" section to the integrations index page
- Added nav entry alphabetically in auto-instrumentation sidebar

## Test plan
- [ ] Verify page renders at `/docs/tracing/auto/spring-boot`
- [ ] Verify nav entry appears between Smol Agents and Together AI
- [ ] Verify integrations index shows Java / Spring section
- [ ] Check all code examples match actual SDK API (`TracedChatModel`, `TracedEmbeddingModel`, `TraceAIProperties`)