### PR TITLE
Fix FAQ (full rewrite) and Prism configuration duplicates

### DIFF
--- a/src/pages/docs/faq.mdx
+++ b/src/pages/docs/faq.mdx
@@ -3,100 +3,210 @@ title: "FAQs"
 description: "Find answers to common questions about Future AGI products."
 ---
 
+## About
+
+Answers to common questions about the Future AGI platform. If you can't find what you're looking for, reach out via [support](https://futureagi.com/contact-us).
+
+---
+
 ## General
 
 **What is Future AGI?**
 
-*  Future AGI is an AI lifecycle platform designed to support enterprises throughout their AI journey. It combines rapid prototyping, rigorous evaluation, continuous observability, and reliable deployment to help build, monitor, optimize, and secure generative AI applications.
+Future AGI is an AI lifecycle platform that helps teams build, evaluate, monitor, and improve AI applications. It covers evaluation, observability, simulation, optimization, prompt management, safety guardrails, and an AI gateway.
 
 **How do I get started?**
 
-*   You can get started by following our [Quickstart Guide](/docs). 
+Start with the [Installation](/docs/installation) page to set up the SDK, then follow one of the [Quickstart guides](/docs/quickstart/setup-observability) to get your first integration running.
+
+**What languages and SDKs are supported?**
+
+Future AGI provides Python and TypeScript SDKs. The Prism AI Gateway also supports direct REST API calls via cURL or any HTTP client.
+
+---
 
 ## Evaluation
 
 **What types of evaluations can I perform?**
 
-*   Future AGI supports a wide range of evaluations including Hallucination, Guardrails, RAG, etc. See the [Evaluation Overview](/docs/cookbook/quickstart/first-eval) for more details.
+Future AGI has 70+ built-in evaluation templates covering quality, safety, factuality, RAG retrieval, format, bias, audio, and image evaluation. You can also create custom evaluations. See [Built-in Evals](/docs/evaluation/builtin) for the full list.
+
+**How do I run my first evaluation?**
+
+See [Evaluate via Platform & SDK](/docs/evaluation/features/evaluate) for step-by-step instructions using the UI or Python SDK.
 
 **How do I evaluate RAG applications?**
 
-*   Refer to the guide on [Evaluating RAG Applications](/docs/cookbook/evaluate-rag).
+Use retrieval-specific evals like context_adherence, chunk_attribution, and recall_score. See the [RAG Evaluation cookbook](/docs/cookbook/evaluate-rag) for a walkthrough.
 
-## Knowledge Base
-
-**How do I add documents to a Knowledge Base?**
-
-*   You can add documents via the UI or using the SDK. See [Create KB using UI](/docs/knowledge-base/features/ui) and [Create KB using SDK](/docs/knowledge-base/features/sdk).
-
-**What file types are supported?**
-
-*   PDF, DOCX, TXT, RTF, CSV, JSON, and more. Refer to the [Knowledge Base Concepts](/docs/knowledge-base).
+---
 
 ## Dataset
 
 **How can I import data?**
 
-*   Data can be added manually, via file upload, SDK, or imported from Hugging Face. See the [Adding Dataset](/docs/dataset/features/create) section.
+Data can be added manually, via file upload, SDK, or imported from Hugging Face. See [Create New Dataset](/docs/dataset/features/create).
 
 **What are dynamic columns?**
 
-*   Dynamic columns allow you to generate new data based on existing columns using prompts, API calls, code execution, etc. Learn more in [Create Dynamic Column](/docs/dataset/features/run-prompt).
+Dynamic columns generate data automatically by running prompts, evaluations, API calls, or code against your dataset rows. See [Dynamic Columns](/docs/dataset/concept/dynamic-column).
 
-## Experimentation
+**Can I generate synthetic data?**
 
-**What is an Experiment in Future AGI?**
+Yes. Define a schema (columns, types, constraints) and the platform generates realistic rows. See [Synthetic Data](/docs/dataset/concept/synthetic-data).
 
-*   Experiments allow you to systematically compare different prompts, models, or parameters. See the [Experimentation Overview](/docs/experimentation).
+---
 
-**How do I compare different models or prompts?**
+## Simulation
 
-*   You can set up experiments to run different configurations against your datasets and compare results using evaluations. See [How To Experiment](/docs/experimentation/how-to).
+**What is Simulation?**
 
-## Prototype
+Simulation lets you test voice and chat AI agents against simulated customers in controlled scenarios before going live. See [Simulation Overview](/docs/simulation).
 
-**What is the purpose of the Prototype section?**
+**How do I run a voice simulation?**
 
-*   Prototyping helps you iterate quickly on different versions of your AI application or prompt. See the [Prototype Overview](/docs/prototype).
+Create an agent definition, scenarios, and personas, then run a test from the platform. See [Run Voice Simulation](/docs/simulation/features/run-simulation).
 
-**How do I choose a winning prototype?**
+**Can I run chat simulations from code?**
 
-*   You can compare prototypes based on evaluations and select the best performing one. See [Choose Winner](/docs/prototype/features/choose-winner).
+Yes, using the Python SDK. See [Chat Simulation Using SDK](/docs/simulation/features/simulation-using-sdk).
 
-## Observe
+---
 
-**What can I monitor with Observe?**
+## Annotations
 
-*   Observe helps monitor key metrics like latency, cost, token usage, and evaluation results over time. See the [Observe Overview](/docs/observe/features/quickstart).
+**What are annotations?**
 
-**How do I set up alerts?**
+Annotations are human labels applied to AI outputs (traces, spans, sessions, dataset rows). Use them for quality control, fine-tuning data, and safety review. See [Annotations Overview](/docs/annotations).
 
-*   Alerts can be configured to notify you about anomalies or issues based on defined thresholds. See [Alerts and Monitors](/docs/observe/features/evals).
+**What's the difference between inline and queue-based annotations?**
 
-## Tracing (Observability)
+Inline annotations are quick, ad-hoc labels from detail views. Queue-based annotations use managed campaigns with assignment, progress tracking, and agreement metrics. See [Inline Annotations](/docs/annotations/features/inline).
 
-**What is tracing used for?**
-
-*   Tracing provides detailed visibility into the execution flow of your AI applications, helping debug issues and understand performance. See the [Tracing Overview](/docs/tracing/manual/set-session-user-id).
-
-**Which frameworks support auto-instrumentation?**
-
-*   We support auto-instrumentation for frameworks like OpenAI, Langchain, LlamaIndex, and more. See [Auto Instrumentation](/docs/tracing/auto/experiment).
-
-## Optimization
-
-**How does Future AGI help optimize prompts or models?**
-
-*  Optimization provides a structured, iterative approach to refining AI-generated outputs by systematically improving prompts. Unlike experimentation, which focuses on testing multiple prompt variations, optimization enhances prompt by adjusting its structure based on evaluation-driven feedback. See the [Optimization Overview](/docs/optimization).
+---
 
 ## Prompt Workbench
 
-**How can the Prompt Workbench help me engineer prompts?**
+**How can the Prompt Workbench help me?**
 
-*   The workbench provides tools to write, generate, and improve prompts. See the [Prompt Workbench Overview](/docs/prompt-workbench).
+The Workbench is where you create, version, test, and manage prompts. You can build from scratch, use templates, or generate with AI. See [Prompt Overview](/docs/prompt).
+
+**How do I version and deploy prompts?**
+
+Every edit creates a new version. Assign labels (Production, Staging) to versions and fetch them at runtime via the SDK. See [Versions and Labels](/docs/prompt/concepts/versions-and-labels).
+
+---
+
+## Prototype
+
+**What is Prototype?**
+
+Prototype is a pre-production testing environment. You run multiple versions of your application side by side and compare eval scores, cost, and latency. See [Prototype Overview](/docs/prototype).
+
+**How do I choose a winning version?**
+
+Use the Choose Winner flow to weight metrics and rank versions. See [Choose Winner](/docs/prototype/features/choose-winner).
+
+---
+
+## Optimization
+
+**How does optimization work?**
+
+Optimization takes a prompt, runs it against your data, scores the outputs with evaluations, and iteratively generates better versions using algorithms like Bayesian Search, Meta-Prompt, ProTeGi, GEPA, PromptWizard, or Random Search. See [Optimization Overview](/docs/optimization).
+
+**Can I optimize from the UI without code?**
+
+Yes. See [Using the Platform](/docs/optimization/features/using-platform).
+
+---
+
+## Observability
+
+**What can I monitor with Observe?**
+
+Observe captures every LLM call, tool use, and agent decision as a trace. You can monitor latency, cost, token usage, and evaluation results. See [Setup Observability](/docs/quickstart/setup-observability).
+
+**How do I set up alerts?**
+
+Configure alerts to notify you about anomalies based on defined thresholds. See [Alerts & Monitors](/docs/observe/features/alerts).
+
+---
 
 ## Protect
 
-**What does the Protect feature guard against?**
+**What does Protect guard against?**
 
-*   Protect helps enforce safety rules like toxicity, PII detection, prompt injection, etc., in real-time. See the [Protect Overview](/docs/protect). 
+Protect screens inputs and outputs in real time across four dimensions: Content Moderation, Bias Detection, Security (prompt injection), and Data Privacy Compliance. See [Protect Overview](/docs/protect).
+
+**Can I use Protect with text, images, and audio?**
+
+Yes. Protect works across all three modalities. See [Run Protect via SDK](/docs/protect/features/run-protect).
+
+---
+
+## Prism AI Gateway
+
+**What is Prism?**
+
+Prism is Future AGI's AI Gateway. It sits between your application and 100+ LLM providers, handling routing, guardrails, caching, cost tracking, and observability through a single API. See [Prism Overview](/docs/prism).
+
+**Do I need to change my code to use Prism?**
+
+No. If you use the OpenAI SDK, just change `base_url` to `https://gateway.futureagi.com` and swap your API key. See the [Prism Quickstart](/docs/prism/quickstart).
+
+**Can I self-host Prism?**
+
+Yes. See [Self-Hosted Deployment](/docs/prism/deployment/self-hosted).
+
+---
+
+## Error Feed
+
+**What is Error Feed?**
+
+Error Feed automatically analyzes traces from your Observe projects, identifies agent errors, groups them into clusters, and provides fix recommendations. No configuration needed. See [Error Feed Overview](/docs/error-feed).
+
+---
+
+## Knowledge Base
+
+**How do I add documents to a Knowledge Base?**
+
+Upload files via the [UI](/docs/knowledge-base/features/ui) or programmatically via the [SDK](/docs/knowledge-base/features/sdk).
+
+**What file types are supported?**
+
+PDF, DOCX, DOC, TXT, and RTF. Maximum 5MB per file. See [Understanding Knowledge Base](/docs/knowledge-base/concepts/concept).
+
+---
+
+## Admin & Settings
+
+**Where do I find my API keys?**
+
+Go to Settings > API Keys. See [API Keys](/docs/admin-settings/api-keys).
+
+**How do I manage team members?**
+
+See [User Management](/docs/admin-settings/user-management) and [Roles & Permissions](/docs/roles-and-permissions).
+
+**How do I set up billing?**
+
+See [Billing & Pricing](/docs/admin-settings/billing-pricing).
+
+---
+
+## Troubleshooting
+
+**My traces aren't appearing in Observe.**
+
+Check that `FI_API_KEY` and `FI_SECRET_KEY` are set correctly. Verify the instrumentor is initialized before your first LLM call. See [Setup Observability](/docs/quickstart/setup-observability).
+
+**Evaluations are failing with "model_name required".**
+
+Some built-in evaluations require a judge model. Pass `model_name="turing_flash"` (or another judge model) in your evaluate call. See [Judge Models](/docs/evaluation/concepts/judge-models).
+
+**I can't find my API keys.**
+
+Go to [Settings > API Keys](https://app.futureagi.com/dashboard/settings/api_keys). You need the Owner role. See [API Keys](/docs/admin-settings/api-keys).

--- a/src/pages/docs/prism/concepts/configuration.mdx
+++ b/src/pages/docs/prism/concepts/configuration.mdx
@@ -83,10 +83,6 @@ A minimal organization configuration that sets up two providers with weighted ro
 Changes to organization configuration are pushed to the gateway in real time. No restart or redeployment needed.
 </Note>
 
-<Note>
-Changes to organization configuration are pushed to the gateway in real time. No restart or redeployment needed.
-</Note>
-
 ---
 
 ## SDK configuration
@@ -183,13 +179,7 @@ client = OpenAI(
 
 ### Override precedence
 
-When the same setting appears in multiple places, the most specific one wins:
-
-```
-Request headers > API key config > Org config > Gateway defaults
-```
-
-For example: a `x-prism-cache-ttl` header on a specific request overrides the TTL set in the org config.
+Per-request headers override client-level config, which overrides org config. See [Configuration Hierarchy](#configuration-hierarchy) above.
 
 ---
 


### PR DESCRIPTION
## Summary

### FAQ (full rewrite)
- Added `## About` with support link
- Fixed all broken links (circular `/docs`, wrong cookbook paths, wrong observe path)
- Added missing sections: Simulation, Annotations, Prism AI Gateway, Error Feed, Admin & Settings
- Added Troubleshooting section with 3 common issues
- Rewrote all answers to be concise with correct links
- All links now point to verified page paths

### Prism configuration
- Removed duplicate Note block (identical text appeared twice)
- Replaced duplicate hierarchy section with link to existing one

## Test plan
- [ ] Verify /docs/faq renders with all new sections
- [ ] Verify all FAQ links resolve
- [ ] Verify /docs/prism/concepts/configuration no longer has duplicates

🤖 Generated with [Claude Code](https://claude.com/claude-code)