### PR TITLE
Fix broken and circular links

### DIFF
--- a/src/pages/docs/admin-settings/workspace-management.mdx
+++ b/src/pages/docs/admin-settings/workspace-management.mdx
@@ -35,7 +35,7 @@ Each workspace has its own settings page with these sections:
 3. Add or remove members, and set their workspace-level role (`workspace_admin`, `workspace_member`, `workspace_viewer`)
 
 <Note>
-Organization-level roles and workspace-level roles are separate. A user can be a "Member" at the org level but a "workspace_admin" in a specific workspace. See [Roles & Permissions](/docs/admin-settings/roles-and-permissions) for how these interact.
+Organization-level roles and workspace-level roles are separate. A user can be a "Member" at the org level but a "workspace_admin" in a specific workspace. See [Roles & Permissions](/docs/roles-and-permissions) for how these interact.
 </Note>
 
 ## Next Steps

--- a/src/pages/docs/installation.mdx
+++ b/src/pages/docs/installation.mdx
@@ -85,5 +85,5 @@ print(client.health())  # Should print: {'status': 'ok'}
 ```
 
 <Callout type="success">
-  You're all set! Head to the [Quickstart Guide](/docs) to run your first evaluation.
+  You're all set! Head to [Setup Observability](/docs/quickstart/setup-observability) to start tracing, or [Running Evals in Simulation](/docs/quickstart/running-evals-in-simulation) to test your agent.
 </Callout>

--- a/src/pages/docs/simulation/concepts/scenarios.mdx
+++ b/src/pages/docs/simulation/concepts/scenarios.mdx
@@ -77,7 +77,7 @@ Navigate to **Simulate** → **Scenarios** → **Add scenario**, then choose how
         Map columns to scenario variables if needed. Save to create the scenario.
       </Step>
     </Steps>
-    <Tip>Learn how to create [synthetic datasets](https://docs.futureagi.com/docs/dataset/concept/synthetic-data).</Tip>
+    <Tip>Learn how to create [synthetic datasets](/docs/dataset/concept/synthetic-data).</Tip>
   </Tab>
   <Tab title="Upload Script" icon="code">
     **What it is:** Paste or upload a call script (customer and agent lines). The system builds a graph and generates personas, situations, and outcomes from the script. Ideal for compliance or specific dialogue tests.


### PR DESCRIPTION
## Summary
- **scenarios.mdx**: Hardcoded absolute URL `https://docs.futureagi.com/docs/dataset/concept/synthetic-data` → relative `/docs/dataset/concept/synthetic-data`
- **workspace-management.mdx**: Wrong path `/docs/admin-settings/roles-and-permissions` → correct `/docs/roles-and-permissions`
- **installation.mdx**: Circular link `/docs` → specific quickstart links

## Test plan
- [ ] Verify all 3 links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)