### PR TITLE
Fix breadcrumb: non-clickable intermediate segments

### DIFF
--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -44,9 +44,23 @@ try {
 
 // Build breadcrumb data from URL path
 const pathSegments = currentPath.replace(/^\/|\/$/g, '').split('/');
+
+// Check if a breadcrumb segment has a corresponding page
+function breadcrumbHasPage(segments: string[], upTo: number): boolean {
+  const relPath = segments.slice(0, upTo + 1).join('/');
+  const pagesDir = path.resolve('src/pages');
+  return (
+    fs.existsSync(path.join(pagesDir, relPath + '.mdx')) ||
+    fs.existsSync(path.join(pagesDir, relPath + '.astro')) ||
+    fs.existsSync(path.join(pagesDir, relPath, 'index.mdx')) ||
+    fs.existsSync(path.join(pagesDir, relPath, 'index.astro'))
+  );
+}
+
 const breadcrumbs = pathSegments.map((segment, i) => ({
   name: segment.replace(/-/g, ' ').replace(/\b\w/g, (c: string) => c.toUpperCase()),
-  url: `https://docs.futureagi.com/${pathSegments.slice(0, i + 1).join('/')}`
+  url: `https://docs.futureagi.com/${pathSegments.slice(0, i + 1).join('/')}`,
+  hasPage: breadcrumbHasPage(pathSegments, i),
 }));
 // Override last breadcrumb with actual page title
 if (breadcrumbs.length > 0) {
@@ -84,7 +98,11 @@ if (breadcrumbs.length > 0) {
                     <li class="flex items-center gap-1.5">
                       {i > 0 && <span class="text-[var(--color-text-muted)]">/</span>}
                       {i < breadcrumbs.length - 1 ? (
-                        <a href={crumb.url.replace('https://docs.futureagi.com', '')} class="hover:text-[var(--color-text-primary)] transition-colors">{crumb.name}</a>
+                        crumb.hasPage ? (
+                          <a href={crumb.url.replace('https://docs.futureagi.com', '')} class="hover:text-[var(--color-text-primary)] transition-colors">{crumb.name}</a>
+                        ) : (
+                          <span>{crumb.name}</span>
+                        )
                       ) : (
                         <span class="text-[var(--color-text-secondary)]">{crumb.name}</span>
                       )}


### PR DESCRIPTION
## Summary
Breadcrumb segments like "Features" and "Concepts" were clickable links pointing to `/docs/dataset/features` which doesn't exist (404). Now intermediate segments without a corresponding page render as plain text instead of links.

Uses `fs.existsSync` at build time to check if each breadcrumb segment resolves to a `.mdx`, `.astro`, or `index.mdx`/`index.astro` file.

## Test plan
- [ ] Go to /docs/dataset/features/experiments - "Features" should be plain text, "Dataset" should be a link
- [ ] Go to /docs/evaluation/concepts/eval-types - "Concepts" should be plain text
- [ ] Go to /docs/prism/features/routing - "Features" should be plain text, "Prism" should be a link
- [ ] Go to /docs/tracing/concepts/spans - "Concepts" should be a link (tracing/concepts has index.mdx)

🤖 Generated with [Claude Code](https://claude.com/claude-code)