### PR TITLE
fix: sidebar dropdown navigation broken on FastNav cross-section swaps

### DIFF
--- a/src/components/FastNav.astro
+++ b/src/components/FastNav.astro
@@ -132,6 +132,8 @@
 
     // Dispatch event for other scripts that need to know about navigation
     window.dispatchEvent(new CustomEvent('fastnav', { detail: { href: href } }));
+    // Trigger astro:page-load so all components re-initialize (copy buttons, sidebar, etc.)
+    document.dispatchEvent(new Event('astro:page-load'));
 
     // Update meta description
     var newDesc = doc.querySelector('meta[name="description"]');

--- a/src/components/FastNav.astro
+++ b/src/components/FastNav.astro
@@ -115,21 +115,12 @@
     var newTitle = doc.querySelector('title');
     if (newTitle) document.title = newTitle.textContent;
 
-    // Update active sidebar link
-    document.querySelectorAll(SIDEBAR_LINK_SELECTOR).forEach(function(link) {
-      var linkHref = link.getAttribute('href');
-      var isActive = linkHref === href || linkHref === href.replace(/\/$/, '');
-      var item = link.closest('a');
-      if (item) {
-        if (isActive) {
-          item.classList.add('text-[var(--color-text-primary)]', 'bg-[var(--color-bg-hover)]', 'font-medium');
-          item.classList.remove('text-[var(--color-text-secondary)]');
-        } else {
-          item.classList.remove('text-[var(--color-text-primary)]', 'bg-[var(--color-bg-hover)]', 'font-medium');
-          item.classList.add('text-[var(--color-text-secondary)]');
-        }
-      }
-    });
+    // Swap sidebar — handles both within-section (active link update) and cross-section (full sidebar swap)
+    var newSidebar = doc.querySelector('#sidebar');
+    var oldSidebar = document.querySelector('#sidebar');
+    if (newSidebar && oldSidebar) {
+      oldSidebar.innerHTML = newSidebar.innerHTML;
+    }
 
     // Scroll content to top
     var main = document.querySelector('main');

--- a/src/components/Sidebar.astro
+++ b/src/components/Sidebar.astro
@@ -272,11 +272,12 @@ function getIconPath(icon?: string): string {
 <script is:inline>
   (function() {
     function setupSidebar() {
+      // Abort previous document-level listeners to prevent accumulation across FastNav swaps
+      if (window.__sidebarDropdownAC) window.__sidebarDropdownAC.abort();
+      var ac = window.__sidebarDropdownAC = new AbortController();
+
       // Section switcher dropdown
       document.querySelectorAll('[data-section-switcher]').forEach(function(switcher) {
-        if (switcher._hasListener) return;
-        switcher._hasListener = true;
-
         var trigger = switcher.querySelector('[data-section-trigger]');
         var dropdown = switcher.querySelector('[data-section-dropdown]');
         var chevron = switcher.querySelector('[data-section-chevron]');
@@ -309,11 +310,11 @@ function getIconPath(icon?: string): string {
 
         document.addEventListener('click', function(e) {
           if (!switcher.contains(e.target)) close();
-        });
+        }, { signal: ac.signal });
 
         document.addEventListener('keydown', function(e) {
           if (e.key === 'Escape') close();
-        });
+        }, { signal: ac.signal });
       });
 
       // Collapsible sidebar items (e.g., Built-in Evals > Audio, Image, etc.)
@@ -387,12 +388,22 @@ function getIconPath(icon?: string): string {
     setupSidebar();
     restoreScroll();
 
-    // Save scroll position before the DOM is swapped (View Transitions)
-    document.addEventListener('astro:before-swap', saveScroll);
+    // Register global listeners only once (script re-executes on view transitions)
+    if (!window.__sidebarListenersReady) {
+      window.__sidebarListenersReady = true;
 
-    document.addEventListener('astro:page-load', function() {
-      setupSidebar();
-      restoreScroll();
-    });
+      document.addEventListener('astro:before-swap', saveScroll);
+
+      document.addEventListener('astro:page-load', function() {
+        setupSidebar();
+        restoreScroll();
+      });
+
+      // Re-init after FastNav swaps sidebar innerHTML
+      window.addEventListener('fastnav', function() {
+        setupSidebar();
+      });
+    }
+
   })();
 </script>


### PR DESCRIPTION
## Summary

Fixes [TH-3757](https://linear.app/future-agi/issue/TH-3757/sidebar-dropdown-navigation-broken-on-fastnav-cross-section-swaps)

- **Sidebar stale after FastNav navigation**: FastNav intercepted sidebar dropdown link clicks and only swapped article + TOC content, leaving the sidebar title, nav items, and active states stale on cross-section navigation. Fixed by swapping full sidebar innerHTML from the fetched page HTML, with proper AbortController cleanup to prevent listener accumulation across swaps.
- **Components dead after FastNav swap**: Copy buttons, code block copy, and other components relying on `astro:page-load` for initialization were non-functional after FastNav navigation. Fixed by dispatching `astro:page-load` after swap to re-initialize all components.

## Test plan

- [ ] Navigate between different sidebar sections using dropdown — sidebar title, nav items, and active states should update correctly
- [ ] Verify copy buttons and code block copy work after FastNav navigation
- [ ] Verify no listener accumulation on repeated navigation (check devtools)
- [ ] Test view transitions don't cause duplicate global listeners