### PR TITLE
Restore Dashboards nav entry from PR #548

### DIFF
--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -224,6 +224,7 @@ export const tabNavigation: NavTab[] = [
               { title: 'Users', href: '/docs/observe/features/users' },
               { title: 'Alerts & Monitors', href: '/docs/observe/features/alerts' },
               { title: 'Voice Observability', href: '/docs/observe/features/voice' },
+              { title: 'Dashboards', href: '/docs/observe/features/dashboard' },
               {
                 title: 'Manual Tracing',
                 items: [


### PR DESCRIPTION
## Summary
- PR #548 (observability dashboard page) was merged on Apr 4, but the nav entry was dropped by a later commit (`3137b1e` — "Revamp Observability docs") that restructured the Observe navigation
- The dashboard page and screenshots still exist — this just restores the missing navigation link

## Test plan
- [ ] Verify "Dashboards" appears in the Observe > Features sidebar
- [ ] Verify clicking it loads `/docs/observe/features/dashboard` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)