### PR TITLE
Nav cleanup: reorder quickstarts, move Release Notes

### DIFF
--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -45,13 +45,19 @@ export const tabNavigation: NavTab[] = [
             icon: 'rocket',
             href: '/docs',
             items: [
-              { title: 'Setup Observability', href: '/docs/quickstart/setup-observability' },
-              { title: 'Running Evals in Simulation', href: '/docs/quickstart/running-evals-in-simulation' },
-              { title: 'Generate Synthetic Data', href: '/docs/quickstart/generate-synthetic-data' },
               { title: 'Create Prompts', href: '/docs/quickstart/prompts' },
+              { title: 'Generate Synthetic Data', href: '/docs/quickstart/generate-synthetic-data' },
+              { title: 'Running Evals in Simulation', href: '/docs/quickstart/running-evals-in-simulation' },
+              { title: 'Prism AI Gateway', href: '/docs/quickstart/prism-ai-gateway' },
+              { title: 'Setup Observability', href: '/docs/quickstart/setup-observability' },
+              { title: 'Annotations', href: '/docs/quickstart/annotations' },
               { title: 'Setup MCP Server', href: '/docs/quickstart/setup-mcp-server' },
-              { title: 'Annotations Quickstart', href: '/docs/annotations/quickstart' },
-              { title: 'Prism AI Gateway Quickstart', href: '/docs/prism/quickstart' },
+            ]
+          },
+          {
+            title: 'Release Notes',
+            items: [
+              { title: 'Release Notes', href: '/docs/release-notes' },
             ]
           },
         ]
@@ -550,7 +556,6 @@ export const tabNavigation: NavTab[] = [
           { title: 'Roles & Permissions', href: '/docs/roles-and-permissions' },
           { title: 'Installation', href: '/docs/installation' },
           { title: 'FAQ', href: '/docs/faq' },
-          { title: 'Release Notes', href: '/docs/release-notes' },
         ]
       },
       {

--- a/src/pages/docs/quickstart/annotations.mdx
+++ b/src/pages/docs/quickstart/annotations.mdx
@@ -1,0 +1,94 @@
+---
+title: "Quickstart"
+description: "Get started with annotations in 5 minutes -- create a label, set up a queue, add items, and start annotating."
+---
+
+## What you will do
+
+In this walkthrough you will create an annotation label, set up a queue, add traces to it, and annotate your first item. The entire flow takes about 5 minutes.
+
+<Steps>
+  <Step title="Create an annotation label">
+    Navigate to **Annotations** in the left sidebar, then open the **Labels** tab. Click **Create Label**.
+
+    ![Labels page](/images/docs/annotations/labels-list.png)
+
+    Fill in the form:
+
+    | Field | Value |
+    |-------|-------|
+    | Name | `Sentiment` |
+    | Type | Categorical |
+    | Options | `Positive`, `Negative`, `Neutral` |
+    | Allow Notes | Enabled |
+
+    Click **Create** to save.
+
+    ![Create label](/images/docs/annotations/create-label-categorical.png)
+  </Step>
+
+  <Step title="Create a queue">
+    Switch to the **Queues** tab and click **Create Queue**.
+
+    | Field | Value |
+    |-------|-------|
+    | Name | `Review Queue` |
+    | Labels | Select the `Sentiment` label you just created |
+    | Assignment Strategy | Round Robin |
+    | Annotators | Add yourself |
+    | Annotations Required | 1 |
+
+    Click **Create** to save the queue.
+
+    ![Create queue](/images/docs/annotations/create-queue.png)
+  </Step>
+
+  <Step title="Add items to the queue">
+    Go to your **Observe** project and open the **LLM Tracing** view. Select one or more traces using the checkboxes, then click the **Add to Queue** button in the toolbar.
+
+    In the dialog, choose **Review Queue** and confirm. The selected traces are now queue items with a **Pending** status.
+  </Step>
+
+  <Step title="Start annotating">
+    Go back to **Annotations > Queues** and click on **Review Queue** to open its detail page. Click **Start Annotating**.
+
+    The annotation workspace loads the first pending item. You will see:
+
+    - The trace content on the left.
+    - The annotation panel on the right with your `Sentiment` label.
+
+    Select an option (e.g. **Positive**), optionally add a note, and click **Submit**.
+
+    ![Annotation workspace](/images/docs/annotations/annotate-workspace.png)
+
+    The workspace automatically advances to the next item. You can also click **Skip** to move past an item you cannot annotate.
+  </Step>
+
+  <Step title="Review progress">
+    Click the **Analytics** tab on the queue detail page to see completion rates, annotator activity, and label distribution.
+
+    ![Analytics](/images/docs/annotations/queue-detail-analytics.png)
+  </Step>
+</Steps>
+
+<Tip>
+**Keyboard shortcuts** speed up annotation significantly:
+
+- **Ctrl+Enter** (or Cmd+Enter) -- Submit the current annotation
+- **1-9** -- Select a categorical option by its position
+- **S** -- Skip the current item
+</Tip>
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Annotation Labels" icon="tags" href="/docs/annotations/features/labels">
+    Explore all five label types and their configuration options.
+  </Card>
+  <Card title="Queues & Workflow" icon="list-check" href="/docs/annotations/features/queues">
+    Configure assignment strategies, multi-annotator requirements, and review workflows.
+  </Card>
+  <Card title="Scores" icon="chart-simple" href="/docs/annotations/concepts/scores">
+    Understand how annotation data is stored and queried via the Score model.
+  </Card>
+</CardGroup>

--- a/src/pages/docs/quickstart/prism-ai-gateway.mdx
+++ b/src/pages/docs/quickstart/prism-ai-gateway.mdx
@@ -1,0 +1,286 @@
+---
+title: "Quickstart"
+description: "Make your first LLM request through Prism in under 5 minutes."
+---
+
+## About
+
+Point your existing OpenAI SDK at Prism by changing two lines: `base_url` and `api_key`. All providers work through the same API. No new SDK required.
+
+## Prerequisites
+
+1. **Future AGI account** - sign up at [app.futureagi.com](https://app.futureagi.com)
+2. **Prism API key** - found in your dashboard under **Settings > API Keys**. Keys start with `sk-prism-`.
+3. **At least one provider configured** - add a provider (OpenAI, Anthropic, Google, etc.) in [Prism > Providers](/docs/prism/features/providers)
+
+---
+
+<Steps>
+
+<Step title="Make your first request">
+
+If you already use the OpenAI SDK, change two lines and you're done:
+
+<Tabs items={["Python (Prism SDK)", "Python (OpenAI SDK)", "LiteLLM", "cURL"]}>
+
+<Tab title="Python (Prism SDK)">
+
+```bash
+pip install prism-ai
+```
+
+```python
+from prism import Prism
+
+client = Prism(
+    api_key="sk-prism-your-api-key-here",
+    base_url="https://gateway.futureagi.com",
+)
+
+response = client.chat.completions.create(
+    model="gpt-4o-mini",
+    messages=[{"role": "user", "content": "What is the capital of France?"}],
+)
+
+print(response.choices[0].message.content)
+# Output: Paris
+```
+
+</Tab>
+
+<Tab title="Python (OpenAI SDK)">
+
+```python
+from openai import OpenAI
+
+# Already using OpenAI? Just swap base_url and api_key
+client = OpenAI(
+    base_url="https://gateway.futureagi.com/v1",
+    api_key="sk-prism-your-api-key-here",
+)
+
+response = client.chat.completions.create(
+    model="gpt-4o-mini",
+    messages=[{"role": "user", "content": "What is the capital of France?"}],
+)
+
+print(response.choices[0].message.content)
+# Output: Paris
+```
+
+</Tab>
+
+<Tab title="LiteLLM">
+
+```python
+import litellm
+
+response = litellm.completion(
+    model="openai/gpt-4o-mini",
+    messages=[{"role": "user", "content": "What is the capital of France?"}],
+    api_key="sk-prism-your-api-key-here",
+    base_url="https://gateway.futureagi.com/v1",
+)
+
+print(response.choices[0].message.content)
+# Output: Paris
+```
+
+</Tab>
+
+<Tab title="cURL">
+
+```bash
+curl -X POST https://gateway.futureagi.com/v1/chat/completions \
+  -H "Authorization: Bearer sk-prism-your-api-key-here" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-4o-mini",
+    "messages": [
+      {"role": "user", "content": "What is the capital of France?"}
+    ]
+  }'
+```
+
+</Tab>
+
+</Tabs>
+
+That's it. Your existing code works with Prism. Every request now gets routing, caching, guardrails, and cost tracking automatically.
+
+</Step>
+
+<Step title="Check response headers">
+
+Prism adds metadata to every response so you can see what happened. Using the client from Step 1:
+
+```python
+# Using the OpenAI SDK client from Step 1
+response = client.chat.completions.with_raw_response.create(
+    model="gpt-4o-mini",
+    messages=[{"role": "user", "content": "Hello"}],
+)
+
+print(f"Provider:  {response.headers.get('x-prism-provider')}")
+print(f"Latency:   {response.headers.get('x-prism-latency-ms')}ms")
+print(f"Cost:      ${response.headers.get('x-prism-cost')}")
+print(f"Cache:     {response.headers.get('x-prism-cache')}")
+print(f"Model:     {response.headers.get('x-prism-model-used')}")
+
+# Parse the actual response
+completion = response.parse()
+print(f"Response:  {completion.choices[0].message.content}")
+```
+
+Example output:
+
+```
+Provider:  openai
+Latency:   423ms
+Cost:      $0.000045
+Cache:     miss
+Model:     gpt-4o-mini
+Response:  Hello! How can I help you today?
+```
+
+</Step>
+
+<Step title="Switch providers">
+
+Change the model name to route to a different provider. Using the same client from Step 1:
+
+```python
+# OpenAI
+response = client.chat.completions.create(
+    model="gpt-4o-mini",
+    messages=[{"role": "user", "content": "Hello"}]
+)
+
+# Anthropic
+response = client.chat.completions.create(
+    model="claude-sonnet-4-6",
+    messages=[{"role": "user", "content": "Hello"}]
+)
+
+# Google Gemini
+response = client.chat.completions.create(
+    model="gemini-2.0-flash",
+    messages=[{"role": "user", "content": "Hello"}]
+)
+```
+
+Prism translates the request to each provider's native format. Your code doesn't change.
+
+</Step>
+
+<Step title="Try streaming">
+
+Stream responses to show output as it arrives:
+
+<Tabs items={["Python (Prism SDK)", "Python (OpenAI SDK)", "LiteLLM", "cURL"]}>
+
+<Tab title="Python (Prism SDK)">
+
+```python
+stream = client.chat.completions.create(
+    model="gpt-4o-mini",
+    messages=[{"role": "user", "content": "Write a short poem about AI"}],
+    stream=True,
+)
+
+for chunk in stream:
+    if chunk.choices[0].delta.content:
+        print(chunk.choices[0].delta.content, end="", flush=True)
+```
+
+</Tab>
+
+<Tab title="Python (OpenAI SDK)">
+
+```python
+stream = client.chat.completions.create(
+    model="gpt-4o-mini",
+    messages=[{"role": "user", "content": "Write a short poem about AI"}],
+    stream=True,
+)
+
+for chunk in stream:
+    if chunk.choices[0].delta.content:
+        print(chunk.choices[0].delta.content, end="", flush=True)
+```
+
+</Tab>
+
+<Tab title="LiteLLM">
+
+```python
+import litellm
+
+stream = litellm.completion(
+    model="openai/gpt-4o-mini",
+    messages=[{"role": "user", "content": "Write a short poem about AI"}],
+    api_key="sk-prism-your-api-key-here",
+    base_url="https://gateway.futureagi.com/v1",
+    stream=True,
+)
+
+for chunk in stream:
+    if chunk.choices[0].delta.content:
+        print(chunk.choices[0].delta.content, end="", flush=True)
+```
+
+</Tab>
+
+<Tab title="cURL">
+
+```bash
+curl -X POST https://gateway.futureagi.com/v1/chat/completions \
+  -H "Authorization: Bearer sk-prism-your-api-key-here" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-4o-mini",
+    "messages": [
+      {"role": "user", "content": "Write a short poem about AI"}
+    ],
+    "stream": true
+  }'
+```
+
+</Tab>
+
+</Tabs>
+
+</Step>
+
+</Steps>
+
+---
+
+## Using a framework?
+
+Prism works with any OpenAI-compatible client. If you use LangChain, LlamaIndex, or any other framework that supports custom base URLs, just point it at `https://gateway.futureagi.com/v1` with your Prism key.
+
+---
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="How it works" href="/docs/prism/concepts/core">
+    Understand the request pipeline and plugin architecture
+  </Card>
+  <Card title="Supported providers" href="/docs/prism/features/providers">
+    Add and configure LLM providers
+  </Card>
+  <Card title="Guardrails" href="/docs/prism/features/guardrails">
+    Add safety checks to requests and responses
+  </Card>
+  <Card title="Routing" href="/docs/prism/features/routing">
+    Set up load balancing and failover
+  </Card>
+  <Card title="Chat completions" href="/docs/prism/api/chat">
+    Full endpoint reference with function calling and vision
+  </Card>
+  <Card title="All endpoints" href="/docs/prism/api/endpoints">
+    See every API endpoint available
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## Summary
- Reorder quickstart pages: Create Prompts → Generate Synthetic Data → Running Evals → Prism AI Gateway → Setup Observability → Annotations → Setup MCP Server
- Move `prism/quickstart.mdx` and `annotations/quickstart.mdx` to `quickstart/` folder with consistent naming (`prism-ai-gateway`, `annotations`)
- Move Release Notes from Resources to Get Started section as a collapsible folder after Quickstart

## Test plan
- [ ] Verify quickstart order in sidebar matches new order
- [ ] Confirm `/docs/quickstart/prism-ai-gateway` and `/docs/quickstart/annotations` load correctly
- [ ] Verify Release Notes appears in Get Started section
- [ ] Verify Release Notes is removed from Resources section

🤖 Generated with [Claude Code](https://claude.com/claude-code)