### PR TITLE
Rewrite docs homepage to match website structure

### DIFF
--- a/src/pages/docs/index.mdx
+++ b/src/pages/docs/index.mdx
@@ -1,66 +1,120 @@
 ---
-title: "What is Future AGI?"
-description: "Future AGI is an AI lifecycle platform designed to support enterprises throughout their AI journey. It combines rapid prototyping, rigorous evaluation, continuous observability, and reliable deployment to help build, monitor, optimize, and secure generative AI applications."
+title: "Future AGI Documentation"
+description: "The complete platform to test, guard, and monitor AI agents. Build self-improving agents that ship smarter with every version."
 ---
 
-Future AGI is a complete AI lifecycle platform. It helps teams build, evaluate, monitor, and improve their AI applications from first prototype to production at scale.
+Future AGI helps teams build self-improving AI agents. Detect what broke, learn why, and feed the fix back so every version ships smarter.
 
 ![Future AGI platform](/images/agi2.webp)
 
-Whether you’re building a chatbot, a RAG pipeline, an AI agent, or a voice assistant, Future AGI gives you the tools to answer three critical questions:
+The platform covers the full agent lifecycle across three stages: simulate and iterate on your agent before deployment, evaluate outputs and catch issues with 70+ metrics, then optimize and observe performance in production. All stages feed into each other: production traces inform evaluations, evaluations surface issues, and issues drive the next iteration.
 
-- **Is my AI working correctly?** Evaluate outputs with 70+ built-in metrics for quality, safety, hallucination detection, and more.
-- **What’s happening in production?** Trace every LLM call, track costs, monitor latency, and replay user sessions.
-- **How do I make it better?** Optimize prompts automatically, test with simulated users, and run experiments to compare approaches.
+Future AGI integrates with OpenAI, Anthropic, LangChain, LlamaIndex, CrewAI, Vercel AI SDK, and 30+ more frameworks. You can start with a single line of code.
 
-Future AGI integrates with the frameworks you already use. OpenAI, Anthropic, LangChain, LlamaIndex, CrewAI, Vercel AI SDK, and 30+ more. You can start with a single line of code.
+---
 
-## Products
+## Simulate & Iterate
 
-Future AGI provides everything you need to design, test, improve and monitor GenAI applications with speed and confidence. 
+Go from idea to production-ready agent faster. Simulate thousands of scenarios, iterate with the Agent IDE, and run structured experiments.
 
-<CardGroup>
-  <Card title="Evaluation" icon="chart-mixed" href="/docs/evaluation">
-    Build reliable AI applications with comprehensive evaluation frameworks for accuracy, compliance, and performance.
-  </Card>
+- **Simulation**: Run thousands of multi-turn conversations with synthetic users, personas, and branching scenarios. Test voice agents and chat agents before they reach real users.
+- **Prototype**: Build AI application variants in the Agent IDE. Compare models, prompts, and configurations side by side with built-in evaluation.
+- **Dataset**: Create golden datasets manually, import from files, or generate synthetic data. Use them across evaluations, simulations, and experiments.
+- **Prompt**: Version prompts, deploy to environments via labels, and track how changes affect quality across traces.
+- **Knowledge Base**: Upload documents that ground evaluations, power RAG testing, and provide context for synthetic data generation.
 
+<CardGroup cols={3}>
   <Card title="Simulation" icon="robot" href="/docs/simulation">
-    Create, run, and analyze AI agent simulations to test and improve your applications.
+    Scenarios, personas, synthetic users
   </Card>
-
-  <Card title="Dataset" icon="database" href="/docs/dataset">
-    Create, import, and structure data efficiently for your AI workflows.
-  </Card>
-
-  <Card title="Prompt" icon="wand-magic-sparkles" href="/docs/prompt">
-    Design, execute, and optimize prompts for high-quality, reliable AI responses.
-  </Card>
-
   <Card title="Prototype" icon="flask" href="/docs/prototype">
-    Build, test, and iterate on your AI applications with ease.
+    Agent IDE, experiments, comparison
   </Card>
-
-  <Card title="Observe" icon="chart-line" href="/docs/observe">
-    Track model behavior, detect anomalies, and monitor real-time performance of your AI applications.
+  <Card title="Dataset" icon="database" href="/docs/dataset">
+    Golden datasets, import, synthetic generation
   </Card>
-
-  <Card title="Error Feed" icon="compass" href="/docs/error-feed">
-    Intelligent error analysis system that points AI agent development teams in the right direction
+  <Card title="Prompt" icon="wand-magic-sparkles" href="/docs/prompt">
+    Versioning, labels, environments
   </Card>
-
-  <Card title="Optimization" icon="arrows-rotate" href="/docs/optimization">
-    Refine and improve prompts systematically using evaluation-driven feedback loops.
-  </Card>
-
-  <Card title="Protect" icon="shield" href="/docs/protect">
-    Screen and filter requests in real-time to ensure safety and reliability in production.
-  </Card>
-
   <Card title="Knowledge Base" icon="brain" href="/docs/knowledge-base">
-    Create foundation for grounded, context-aware synthetic data generation and accurate evaluations.
+    Document upload, RAG grounding
   </Card>
 </CardGroup>
 
-<Tip>
-Start using Future Platform today <a href="https://app.futureagi.com">here</a>
-</Tip>
+---
+
+## Evaluate
+
+Catch issues early. Run comprehensive evaluations across datasets, detect hallucinations, and protect your agents with real-time guardrails.
+
+- **Error Feed**: Sentry-style error tracking for AI agents. Errors are automatically surfaced, grouped, and triaged. See exactly where and why your agent failed, which traces are affected, and how many users were impacted.
+- **Evaluation**: 70+ built-in metrics covering quality, safety, hallucination, faithfulness, toxicity, PII detection, and more. Create custom evals for domain-specific checks. Run on datasets in development or on production traces continuously.
+- **Protect**: Real-time guardrails that intercept requests and responses before they reach users. Block hallucinations, PII leaks, and policy violations in production.
+
+<CardGroup cols={3}>
+  <Card title="Error Feed" icon="compass" href="/docs/error-feed">
+    Error tracking, triage, root cause
+  </Card>
+  <Card title="Evaluation" icon="chart-mixed" href="/docs/evaluation">
+    70+ metrics, custom evals, CI/CD
+  </Card>
+  <Card title="Protect" icon="shield" href="/docs/protect">
+    Real-time guardrails, PII blocking
+  </Card>
+</CardGroup>
+
+---
+
+## Optimize & Observe
+
+Use production data to continuously improve your agents. Track performance in real-time, trace requests end-to-end, and get alerted before users complain.
+
+- **Optimization**: Apply reinforcement learning from human feedback to automatically improve agent responses. The optimizer uses evaluation scores as reward signals to refine prompts without manual tuning.
+- **Observability**: End-to-end tracing for every LLM call, retrieval, and tool invocation. Track costs by model, monitor latency percentiles, replay user sessions, and set up alerts for anomalies. Based on OpenTelemetry.
+- **Prism AI Gateway**: Unified API gateway across 25+ LLM providers. Route requests with fallbacks, cache responses, enforce rate limits and budgets, and run shadow experiments. Drop-in replacement for the OpenAI SDK.
+- **Falcon AI**: AI copilot with 300+ tools built into the dashboard. Analyze evaluation results, debug traces, create datasets, and chain multi-step workflows through natural language.
+- **Annotations**: Human-in-the-loop labeling with annotation queues, custom scoring labels, and inter-annotator agreement tracking. Feed human judgments back into evaluations and optimization.
+
+<CardGroup cols={3}>
+  <Card title="Optimization" icon="arrows-rotate" href="/docs/optimization">
+    RL from human feedback, auto-tuning
+  </Card>
+  <Card title="Observability" icon="chart-line" href="/docs/observe">
+    Tracing, costs, latency, alerts
+  </Card>
+  <Card title="Prism AI Gateway" icon="server" href="/docs/prism">
+    Routing, caching, rate limits, 25+ providers
+  </Card>
+  <Card title="Falcon AI" icon="message-circle" href="/docs/falcon-ai">
+    AI copilot, 300+ tools, natural language
+  </Card>
+  <Card title="Annotations" icon="pen" href="/docs/annotations">
+    Labeling queues, scoring, agreement
+  </Card>
+</CardGroup>
+
+---
+
+## Where to start
+
+Setting up tracing, evaluation, and simulation can be done independently. Pick the path that matches where you are.
+
+| Starting point | You want to... | Start here |
+|---|---|---|
+| **New to Future AGI** | Get a quick overview and make your first call | [Quickstart](/docs/quickstart/prompts) |
+| **Building an agent** | Test with simulated users before deploying | [Simulation](/docs/simulation) |
+| **Already in production** | See what's happening with your LLM calls | [Observability](/docs/observe) |
+| **Evaluating quality** | Run evals on outputs and catch regressions | [Evaluation](/docs/evaluation) |
+| **Managing multiple LLM providers** | Unify routing, caching, and cost controls behind one API | [Prism AI Gateway](/docs/prism) |
+
+<CardGroup cols={3}>
+  <Card title="Quickstart" icon="rocket" href="/docs/quickstart/prompts">
+    Make your first API call in under 5 minutes.
+  </Card>
+  <Card title="Integrations" icon="plug" href="/docs/integrations">
+    Connect OpenAI, LangChain, LlamaIndex, and 30+ more.
+  </Card>
+  <Card title="API Reference" icon="code" href="/docs/api">
+    Full API documentation for programmatic access.
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## Summary
- Align homepage with website's 3-pillar structure: Simulate & Iterate, Evaluate, Optimize & Observe
- Each product now has a substantive bullet description (2-3 sentences) above the navigation cards
- Removed redundant intro paragraphs that repeated the same info
- Added "Where to start" routing table for different user personas (new user, building agent, in production, evaluating quality, managing providers)
- Matched website voice and copy

## Test plan
- [ ] Verify page renders at /docs
- [ ] Check all card links resolve
- [ ] Check "Where to start" table links work
- [ ] Compare against futureagi.com for voice consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)