### PR TITLE
Add deprecation notice for Prism SDK packages

### DIFF
--- a/src/pages/docs/prism/index.mdx
+++ b/src/pages/docs/prism/index.mdx
@@ -3,6 +3,10 @@ title: "Prism AI Gateway"
 description: "A unified API gateway for 100+ LLM providers with built-in guardrails, intelligent routing, caching, cost controls, and full observability."
 ---
 
+<Warning>
+The `prism-ai` Python package and `@futureagi/prism` TypeScript package are being renamed. The current packages will continue to work but are deprecated. Watch for the updated package names in an upcoming release.
+</Warning>
+
 ## About
 
 Prism is Future AGI's AI Gateway. It sits between your application and LLM providers, giving you a single API that handles routing across 100+ providers, safety guardrails, response caching, cost tracking, and full observability.

--- a/src/pages/docs/prism/quickstart.mdx
+++ b/src/pages/docs/prism/quickstart.mdx
@@ -3,6 +3,10 @@ title: "Quickstart"
 description: "Make your first LLM request through Prism in under 5 minutes."
 ---
 
+<Warning>
+The `prism-ai` Python package and `@futureagi/prism` TypeScript package are being renamed. The current packages will continue to work but are deprecated. Watch for the updated package names in an upcoming release.
+</Warning>
+
 ## About
 
 Point your existing OpenAI SDK at Prism by changing two lines: `base_url` and `api_key`. All providers work through the same API. No new SDK required.


### PR DESCRIPTION
## Summary
- Added deprecation `<Warning>` banners to the Prism Gateway overview and quickstart pages
- Notifies users that `prism-ai` (Python) and `@futureagi/prism` (TypeScript) packages are being renamed

## Test plan
- [ ] Verify the warning renders correctly on the overview page
- [ ] Verify the warning renders correctly on the quickstart page