### PR TITLE
[feat] Add Agent Playground card to homepage Tools & Advanced section

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -108,6 +108,17 @@ const sections = [
     ]
   },
   {
+    title: "Agent Playground",
+    description: "Build and test multi-step AI workflows visually on a drag-and-drop canvas.",
+    icon: "workflow",
+    color: "rose",
+    href: "/docs/agent-playground",
+    links: [
+      { title: "Understanding Agent Playground", href: "/docs/agent-playground/concepts/understanding-agent-playground" },
+      { title: "Build workflow", href: "/docs/agent-playground/features/build-workflow" },
+    ]
+  },
+  {
     title: "Knowledge Base",
     description: "Upload documents and connect knowledge sources for RAG.",
     icon: "brain",
@@ -132,6 +143,7 @@ const iconSvgs: Record<string, string> = {
   zap: '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M13 10V3L4 14h7v7l9-11h-7z" />',
   brain: '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />',
   gateway: '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01" />',
+  workflow: '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 5a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1H5a1 1 0 01-1-1V5zm10 0a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1h-4a1 1 0 01-1-1V5zM9 15a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1h-4a1 1 0 01-1-1v-4zm-2-5v4m0 0l3 3m6-7v4m0 0l-3 3" />',
   plug: '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />',
   code: '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" />',
   sdk: '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />',
@@ -173,6 +185,7 @@ const colorMap: Record<string, { bg: string, text: string, border: string }> = {
   yellow: { bg: 'rgba(234,179,8,0.1)', text: '#eab308', border: 'rgba(234,179,8,0.2)' },
   teal: { bg: 'rgba(20,184,166,0.1)', text: '#14b8a6', border: 'rgba(20,184,166,0.2)' },
   indigo: { bg: 'rgba(99,102,241,0.1)', text: '#6366f1', border: 'rgba(99,102,241,0.2)' },
+  rose: { bg: 'rgba(244,63,94,0.1)', text: '#f43f5e', border: 'rgba(244,63,94,0.2)' },
 };
 ---
 
@@ -288,7 +301,7 @@ const colorMap: Record<string, { bg: string, text: string, border: string }> = {
               <span class="text-xs font-medium text-[var(--color-text-muted)] uppercase tracking-wider">Tools & Advanced</span>
               <div class="flex-1 h-px bg-[var(--color-border-subtle)]"></div>
             </div>
-            <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-3">
+            <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-6 gap-3">
               {sections.slice(5).map((section, i) => {
                 const colors = colorMap[section.color];
                 return (


### PR DESCRIPTION
## Description
  - Added Agent Playground card to the Tools & Advanced grid on the homepage, beside Prompt Management
  - Updated grid from 5 to 6 columns to fit all cards in one row

## Checklist
- [x] Code compiles correctly.
- [ ] Created/updated tests.
- [ ] Linting and formatting applied.
- [ ] Documentation updated.
