### PR TITLE
docs: apply /docs overview page feedback

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -87,6 +87,18 @@ const currentPath = Astro.url.pathname;
       <!-- Right Actions -->
       <div class="flex items-center gap-3 flex-shrink-0">
         <a
+          href="https://github.com/future-agi"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="GitHub"
+          class="hidden sm:inline-flex items-center p-1.5 text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors"
+        >
+          <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.02 10.02 0 0022 12.017C22 6.484 17.522 2 12 2z"/>
+          </svg>
+        </a>
+
+        <a
           href="https://meetings.hubspot.com/salil-kolhe/help-futureagi-app"
           target="_blank"
           rel="noopener noreferrer"

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -48,7 +48,7 @@ export const tabNavigation: NavTab[] = [
               { title: 'Create Prompts', href: '/docs/quickstart/prompts' },
               { title: 'Generate Synthetic Data', href: '/docs/quickstart/generate-synthetic-data' },
               { title: 'Running Evals in Simulation', href: '/docs/quickstart/running-evals-in-simulation' },
-              { title: 'Prism AI Gateway', href: '/docs/quickstart/prism-ai-gateway' },
+              { title: 'Command Center', href: '/docs/quickstart/prism-ai-gateway' },
               { title: 'Setup Observability', href: '/docs/quickstart/setup-observability' },
               { title: 'Annotations', href: '/docs/quickstart/annotations' },
               { title: 'Setup MCP Server', href: '/docs/quickstart/setup-mcp-server' },
@@ -353,7 +353,7 @@ export const tabNavigation: NavTab[] = [
         ]
       },
       {
-        group: 'Prism AI Gateway',
+        group: 'Command Center',
         icon: 'server',
         items: [
           { title: 'Overview', href: '/docs/prism' },

--- a/src/pages/docs/index.mdx
+++ b/src/pages/docs/index.mdx
@@ -1,9 +1,7 @@
 ---
-title: "Future AGI Documentation"
+title: "Overview"
 description: "The complete platform to test, guard, and monitor AI agents. Build self-improving agents that ship smarter with every version."
 ---
-
-Future AGI helps teams build self-improving AI agents. Detect what broke, learn why, and feed the fix back so every version ships smarter.
 
 ![Future AGI platform](/images/agi2.webp)
 
@@ -71,7 +69,7 @@ Use production data to continuously improve your agents. Track performance in re
 
 - **Optimization**: Apply reinforcement learning from human feedback to automatically improve agent responses. The optimizer uses evaluation scores as reward signals to refine prompts without manual tuning.
 - **Observability**: End-to-end tracing for every LLM call, retrieval, and tool invocation. Track costs by model, monitor latency percentiles, replay user sessions, and set up alerts for anomalies. Based on OpenTelemetry.
-- **Prism AI Gateway**: Unified API gateway across 25+ LLM providers. Route requests with fallbacks, cache responses, enforce rate limits and budgets, and run shadow experiments. Drop-in replacement for the OpenAI SDK.
+- **Command Center**: Unified API gateway across 25+ LLM providers. Route requests with fallbacks, cache responses, enforce rate limits and budgets, and run shadow experiments. Drop-in replacement for the OpenAI SDK.
 - **Falcon AI**: AI copilot with 300+ tools built into the dashboard. Analyze evaluation results, debug traces, create datasets, and chain multi-step workflows through natural language.
 - **Annotations**: Human-in-the-loop labeling with annotation queues, custom scoring labels, and inter-annotator agreement tracking. Feed human judgments back into evaluations and optimization.
 
@@ -82,7 +80,7 @@ Use production data to continuously improve your agents. Track performance in re
   <Card title="Observability" icon="chart-line" href="/docs/observe">
     Tracing, costs, latency, alerts
   </Card>
-  <Card title="Prism AI Gateway" icon="server" href="/docs/prism">
+  <Card title="Command Center" icon="server" href="/docs/prism">
     Routing, caching, rate limits, 25+ providers
   </Card>
   <Card title="Falcon AI" icon="message-circle" href="/docs/falcon-ai">
@@ -105,7 +103,7 @@ Setting up tracing, evaluation, and simulation can be done independently. Pick t
 | **Building an agent** | Test with simulated users before deploying | [Simulation](/docs/simulation) |
 | **Already in production** | See what's happening with your LLM calls | [Observability](/docs/observe) |
 | **Evaluating quality** | Run evals on outputs and catch regressions | [Evaluation](/docs/evaluation) |
-| **Managing multiple LLM providers** | Unify routing, caching, and cost controls behind one API | [Prism AI Gateway](/docs/prism) |
+| **Managing multiple LLM providers** | Unify routing, caching, and cost controls behind one API | [Command Center](/docs/prism) |
 
 <CardGroup cols={3}>
   <Card title="Quickstart" icon="rocket" href="/docs/quickstart/prompts">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -52,7 +52,7 @@ const sections = [
     ]
   },
   {
-    title: "Prism AI Gateway",
+    title: "Command Center",
     description: "Single API for 100+ LLM providers with routing, guardrails, and caching.",
     icon: "gateway",
     color: "indigo",


### PR DESCRIPTION
## Summary
- Rename docs landing title from **"Future AGI Documentation"** to **"Overview"**
- Remove the redundant intro paragraph on `/docs` so the lead description and body text no longer render at two different sizes
- Rename **"Prism AI Gateway"** to **"Command Center"** in the overview copy, homepage card, and the Docs sidebar group/quickstart item (URL paths under `/docs/prism/*` are unchanged to avoid breaking deep links)
- Add a **GitHub icon + link** to the site header (links to `https://github.com/future-agi` — update if a specific repo is preferred)

### Scope note
Subpages under `/docs/prism/**` still contain "Prism" in body copy. They were left as-is because the feedback was scoped to the `/docs` overview page. Happy to follow up with a sweep of those pages if desired.

## Test plan
- [ ] `npm run dev` and open http://localhost:4322/docs — title reads "Overview"
- [ ] Confirm the description and following body paragraphs no longer look mismatched in size
- [ ] Confirm the overview cards, homepage card, and sidebar group all read "Command Center"
- [ ] Confirm the GitHub icon appears in the header, is keyboard-focusable, and opens the correct repo/org in a new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)