### PR TITLE
docs: alphabetize Docs-tab sidebar groups

### DIFF
--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -63,6 +63,28 @@ export const tabNavigation: NavTab[] = [
         ]
       },
       {
+        group: 'Agent Playground',
+        icon: 'play-circle',
+        items: [
+          { title: 'Overview', href: '/docs/agent-playground' },
+          {
+            title: 'Concepts',
+            items: [
+              { title: 'Understanding Agent Playground', href: '/docs/agent-playground/concepts/understanding-agent-playground' },
+              { title: 'Versions & Execution', href: '/docs/agent-playground/concepts/versions-and-execution' },
+            ]
+          },
+          {
+            title: 'Features',
+            items: [
+              { title: 'Create a Graph', href: '/docs/agent-playground/features/create-graph' },
+              { title: 'Build a Workflow', href: '/docs/agent-playground/features/build-workflow' },
+              { title: 'Run & Monitor', href: '/docs/agent-playground/features/run-and-monitor' },
+            ]
+          },
+        ]
+      },
+      {
         group: 'Annotations',
         icon: 'pen',
         items: [
@@ -238,21 +260,6 @@ export const tabNavigation: NavTab[] = [
         ]
       },
       {
-        group: 'Falcon AI',
-        icon: 'rocket',
-        items: [
-          { title: 'Overview', href: '/docs/falcon-ai' },
-          {
-            title: 'Features',
-            items: [
-              { title: 'Using Falcon AI', href: '/docs/falcon-ai/features/chat' },
-              { title: 'Skill Builder', href: '/docs/falcon-ai/features/skills' },
-              { title: 'MCP Connectors', href: '/docs/falcon-ai/features/mcp-connectors' },
-            ]
-          },
-        ]
-      },
-      {
         group: 'Evaluation',
         icon: 'chart',
         items: [
@@ -277,6 +284,21 @@ export const tabNavigation: NavTab[] = [
               { title: 'Use Custom Models', href: '/docs/evaluation/features/custom-models' },
               { title: 'Future AGI Models', href: '/docs/evaluation/features/futureagi-models' },
               { title: 'Evaluate CI/CD Pipeline', href: '/docs/evaluation/features/cicd' },
+            ]
+          },
+        ]
+      },
+      {
+        group: 'Falcon AI',
+        icon: 'rocket',
+        items: [
+          { title: 'Overview', href: '/docs/falcon-ai' },
+          {
+            title: 'Features',
+            items: [
+              { title: 'Using Falcon AI', href: '/docs/falcon-ai/features/chat' },
+              { title: 'Skill Builder', href: '/docs/falcon-ai/features/skills' },
+              { title: 'MCP Connectors', href: '/docs/falcon-ai/features/mcp-connectors' },
             ]
           },
         ]
@@ -488,28 +510,6 @@ export const tabNavigation: NavTab[] = [
             title: 'Features',
             items: [
               { title: 'Run Protect via SDK', href: '/docs/protect/features/run-protect' },
-            ]
-          },
-        ]
-      },
-      {
-        group: 'Agent Playground',
-        icon: 'play-circle',
-        items: [
-          { title: 'Overview', href: '/docs/agent-playground' },
-          {
-            title: 'Concepts',
-            items: [
-              { title: 'Understanding Agent Playground', href: '/docs/agent-playground/concepts/understanding-agent-playground' },
-              { title: 'Versions & Execution', href: '/docs/agent-playground/concepts/versions-and-execution' },
-            ]
-          },
-          {
-            title: 'Features',
-            items: [
-              { title: 'Create a Graph', href: '/docs/agent-playground/features/create-graph' },
-              { title: 'Build a Workflow', href: '/docs/agent-playground/features/build-workflow' },
-              { title: 'Run & Monitor', href: '/docs/agent-playground/features/run-and-monitor' },
             ]
           },
         ]


### PR DESCRIPTION
## Summary

Clean-up of the Docs-tab sidebar ordering. Based on [#603](https://github.com/future-agi/docs/pull/603); will auto-retarget to `dev` when that merges.

Two groups were out of alphabetical position:

- **Agent Playground** — was below Protect; moved above Annotations (A-g before A-n).
- **Evaluation** — was below Falcon AI; moved above Falcon AI (E-v before F).

Final Docs tab order (Get Started pinned first, rest alphabetical):

`Get Started → Agent Playground → Annotations → Command Center → Dataset → Error Feed → Evaluation → Falcon AI → Knowledge Base → Observability → Optimization → Prompt → Protect → Prototype → Resources → Simulation`

No content changes — only two blocks repositioned within `src/lib/navigation.ts`.

## Test plan

- [ ] `yarn dev` — open any page in the Docs tab and verify sidebar order matches the list above.
- [ ] Click each moved group (Agent Playground, Evaluation) to confirm routes still resolve.