### PR TITLE
Standardize personas API docs against style conventions

### DIFF
--- a/src/pages/docs/api/personas/createpersona.mdx
+++ b/src/pages/docs/api/personas/createpersona.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Create persona"
-description: "Creates a new workspace-level persona with configurable attributes for voice or text simulation testing."
+description: "Creates a new workspace-level persona for voice or text simulation."
 ---
 
 <ApiPlayground
@@ -37,112 +37,108 @@ description: "Creates a new workspace-level persona with configurable attributes
 />
 
 <ApiSection title="Authentication">
-  <ParamField name="X-Api-Key" type="string" required>
+  <ParamField name="X-Api-Key" type="API Key" required>
     Your Future AGI API key used to authenticate requests. You can find and manage your API keys in the [Dashboard](https://app.futureagi.com) under Settings.
   </ParamField>
-  <ParamField name="X-Secret-Key" type="string" required>
+  <ParamField name="X-Secret-Key" type="Secret Key" required>
     Your Future AGI secret key, used alongside the API key for request authentication. This is generated when you create an API key in the [Dashboard](https://app.futureagi.com).
   </ParamField>
 </ApiSection>
 
 <ApiSection title="Request body">
   <ParamField body="name" type="string" required>
-    A human-readable name for the persona. Must be unique within your workspace and must not conflict with any system-level persona names. The comparison is case-insensitive, so `"Friendly Agent"` and `"friendly agent"` are treated as duplicates. Maximum 255 characters.
+    Name for the persona. Must be unique within the workspace (case-insensitive). Max 255 characters.
   </ParamField>
   <ParamField body="description" type="string" required>
-    A non-empty description that explains the persona's role, behavior, and characteristics. This description helps team members understand the persona's purpose and is displayed in the dashboard when browsing personas.
+    Non-empty description of the persona's role and characteristics.
   </ParamField>
   <ParamField body="simulationType" type="string" optional>
-    The type of simulation this persona is designed for. Accepted values: `voice` or `text`. Defaults to `voice`. This determines whether the persona will be used in voice-based call simulations or text-based simulations, and influences which attributes (such as `accent` and `conversationSpeed`) are relevant.
+    Values: `voice`, `text`. Defaults to `voice`.
   </ParamField>
   <ParamField body="gender" type="array of string" optional>
-    An array specifying the gender characteristics of the persona. Accepted values: `male`, `female`. You can include one or both values to create a persona that can operate with either gender in simulations.
+    Values: `male`, `female`.
   </ParamField>
   <ParamField body="ageGroup" type="array of string" optional>
-    An array of age range brackets that define the persona's demographic. Accepted values: `18-25`, `25-32`, `32-40`, `40-50`, `50-60`, `60+`. Multiple values can be provided to represent a persona that spans multiple age groups.
+    Values: `18-25`, `25-32`, `32-40`, `40-50`, `50-60`, `60+`.
   </ParamField>
   <ParamField body="location" type="array of string" optional>
-    An array of geographic locations associated with the persona. Accepted values: `United States`, `Canada`, `United Kingdom`, `Australia`, `India`. These influence the persona's cultural context and regional speech patterns during simulation.
+    Values: `United States`, `Canada`, `United Kingdom`, `Australia`, `India`.
   </ParamField>
   <ParamField body="profession" type="array of string" optional>
-    An array of professional roles that define the persona's occupational background. Accepted values: `Student`, `Teacher`, `Engineer`, `Doctor`, `Nurse`, `Business Owner`, `Manager`, `Sales Representative`, `Customer Service`, `Technician`, `Consultant`, `Accountant`, `Marketing Professional`, `Retired`, `Homemaker`, `Freelancer`, `Other`. The profession influences the persona's vocabulary, expectations, and communication patterns.
+    Values: `Student`, `Teacher`, `Engineer`, `Doctor`, `Nurse`, `Business Owner`, `Manager`, `Sales Representative`, `Customer Service`, `Technician`, `Consultant`, `Accountant`, `Marketing Professional`, `Retired`, `Homemaker`, `Freelancer`, `Other`.
   </ParamField>
   <ParamField body="personality" type="array of string" optional>
-    An array of personality traits that shape how the persona behaves during conversations. Accepted values: `Friendly and cooperative`, `Professional and formal`, `Cautious and skeptical`, `Impatient and direct`, `Detail-oriented`, `Easy-going`, `Anxious`, `Confident`, `Analytical`, `Emotional`, `Reserved`, `Talkative`. Multiple traits can be combined to create nuanced persona behaviors.
+    Values: `Friendly and cooperative`, `Professional and formal`, `Cautious and skeptical`, `Impatient and direct`, `Detail-oriented`, `Easy-going`, `Anxious`, `Confident`, `Analytical`, `Emotional`, `Reserved`, `Talkative`.
   </ParamField>
   <ParamField body="communicationStyle" type="array of string" optional>
-    An array of communication style descriptors that control how the persona expresses itself. Accepted values: `Direct and concise`, `Detailed and elaborate`, `Casual and friendly`, `Formal and polite`, `Technical`, `Simple and clear`, `Questioning`, `Assertive`, `Passive`, `Collaborative`. These styles affect sentence structure, word choice, and conversational flow.
+    Values: `Direct and concise`, `Detailed and elaborate`, `Casual and friendly`, `Formal and polite`, `Technical`, `Simple and clear`, `Questioning`, `Assertive`, `Passive`, `Collaborative`.
   </ParamField>
   <ParamField body="accent" type="array of string" optional>
-    An array of accent options for voice simulations. Accepted values: `American`, `Australian`, `Indian`, `Canadian`, `Neutral`. This field is primarily relevant when `simulationType` is `voice` and controls the speech accent used during call simulations.
+    Values: `American`, `Australian`, `Indian`, `Canadian`, `Neutral`. Voice simulation only.
   </ParamField>
   <ParamField body="multilingual" type="boolean" optional>
-    Enables multi-language support for the persona. When set to `true`, the `language` field becomes required and the persona can switch between the specified languages during simulation. Defaults to `false`.
+    Enables multi-language support. Requires `language` when `true`. Defaults to `false`.
   </ParamField>
   <ParamField body="language" type="array of string" optional>
-    An array of languages the persona can communicate in. Accepted values: `English`, `Hindi`. This field is required when `multilingual` is set to `true`. If `multilingual` is `false` or omitted, this field is ignored.
+    Values: `English`, `Hindi`. Required when `multilingual` is `true`.
   </ParamField>
   <ParamField body="conversationSpeed" type="array of string" optional>
-    An array of conversation speed multipliers that control the pace of the persona's speech. Accepted values: `0.5`, `0.75`, `1.0`, `1.25`, `1.5`. A value of `1.0` represents normal speed, values below `1.0` are slower, and values above `1.0` are faster. Primarily relevant for voice simulations.
+    Speech pace multipliers. Values: `0.5`, `0.75`, `1.0`, `1.25`, `1.5`. Voice simulation only.
   </ParamField>
   <ParamField body="backgroundSound" type="boolean" optional>
-    Controls whether background sounds are included during voice simulations with this persona. When enabled, ambient noise is added to create a more realistic simulation environment.
+    Add ambient noise during voice simulations.
   </ParamField>
   <ParamField body="finishedSpeakingSensitivity" type="array of integer" optional>
-    An array of integer values from `1` to `10` that control how sensitive the system is to detecting when the persona has finished speaking. Higher values make the system more responsive to pauses, while lower values require longer silence before the agent responds. Relevant for voice simulations.
+    End-of-speech sensitivity, `1`–`10`. Voice simulation only.
   </ParamField>
   <ParamField body="interruptSensitivity" type="array of integer" optional>
-    An array of integer values from `1` to `10` that control how easily the persona can be interrupted during speech. Higher values make the persona easier to interrupt, simulating more natural conversational dynamics. Relevant for voice simulations.
+    Interruptibility, `1`–`10`. Voice simulation only.
   </ParamField>
   <ParamField body="keywords" type="array of string" optional>
-    An array of keywords or tags associated with the persona. These keywords are searchable and help categorize and discover personas when browsing or filtering in the dashboard.
+    Searchable tags for filtering personas.
   </ParamField>
   <ParamField body="customProperties" type="object" optional>
-    A key-value object for attaching arbitrary metadata to the persona. Both keys and values must be non-empty strings. Use this to store custom attributes that are not covered by the standard fields, such as internal identifiers or domain-specific labels.
+    Key-value metadata. Keys and values must be non-empty strings.
   </ParamField>
   <ParamField body="additionalInstruction" type="string" optional>
-    Free-form text providing extra behavioral instructions for the persona. Use this field to specify nuanced behaviors, edge cases, or specific conversational patterns that are not captured by the predefined attribute fields. These instructions are passed directly to the simulation engine.
+    Free-form behavioral instructions passed to the simulation engine.
   </ParamField>
   <ParamField body="tone" type="string" optional>
-    The overall tone of the persona's communication. Accepted values: `formal`, `casual`, `neutral`. Defaults to `casual`. This influences word choice, sentence structure, and the general register of the persona's language.
+    Values: `formal`, `casual`, `neutral`. Defaults to `casual`.
   </ParamField>
   <ParamField body="punctuation" type="string" optional>
-    The punctuation style used in the persona's text output. Accepted values: `clean` (standard punctuation), `minimal` (reduced punctuation), `expressive` (heavy use of exclamation marks, ellipses, etc.), `erratic` (inconsistent punctuation). Defaults to `clean`. Primarily relevant for chat simulations.
+    Values: `clean`, `minimal`, `expressive`, `erratic`. Defaults to `clean`.
   </ParamField>
   <ParamField body="slangUsage" type="string" optional>
-    Controls the degree of slang and informal language the persona uses. Accepted values: `none`, `moderate`, `heavy`, `light`. Defaults to `light`. Higher levels of slang create a more casual, colloquial persona.
+    Values: `none`, `light`, `moderate`, `heavy`. Defaults to `light`.
   </ParamField>
   <ParamField body="typosFrequency" type="string" optional>
-    Controls how often the persona introduces typographical errors into text output. Accepted values: `none`, `rare`, `occasional`, `frequent`. Defaults to `rare`. This creates more realistic user-like behavior in chat simulations.
+    Values: `none`, `rare`, `occasional`, `frequent`. Defaults to `rare`.
   </ParamField>
   <ParamField body="regionalMix" type="string" optional>
-    Controls the degree of regional language variation in the persona's output. Accepted values: `none`, `moderate`, `heavy`, `light`. Defaults to `light`. Higher values introduce more region-specific vocabulary, idioms, and phrasing.
+    Values: `none`, `light`, `moderate`, `heavy`. Defaults to `light`.
   </ParamField>
   <ParamField body="emojiUsage" type="string" optional>
-    Controls how frequently the persona uses emojis in text output. Accepted values: `never`, `light`, `regular`, `heavy`. Defaults to `light`. Primarily relevant for chat simulations where emoji usage affects the perceived personality.
+    Values: `never`, `light`, `regular`, `heavy`. Defaults to `light`.
   </ParamField>
   <ParamField body="verbosity" type="string" optional>
-    Controls the length and detail level of the persona's responses. Accepted values: `brief` (short, concise responses), `balanced` (moderate detail), `detailed` (longer, more elaborate responses). Defaults to `balanced`.
+    Values: `brief`, `balanced`, `detailed`. Defaults to `balanced`.
   </ParamField>
 </ApiSection>
 
 <ApiSection title="Response" status={201} statusText="Created">
-  <ResponseField name="status" type="string">
-    Indicates the outcome of the request. Returns `"success"` when the persona is created successfully.
-  </ResponseField>
-  <ResponseField name="result" type="object">
-    The full persona object including the server-generated `id` (UUID), `persona_type` set to `"workspace"`, and all attributes provided in the request body along with `created_at` and `updated_at` timestamps.
-  </ResponseField>
+  <ResponseField name="status" type="string">`"success"` on creation.</ResponseField>
+  <ResponseField name="result" type="object">The created persona object, including `id`, `persona_type` (`workspace`), all submitted attributes, and `created_at` / `updated_at` timestamps.</ResponseField>
 </ApiSection>
 
 <ApiSection title="Errors">
   <ParamField name="400" type="Bad Request">
-    The request payload is invalid. This can occur when required fields (`name`, `description`) are missing or empty, when the persona name already exists in your workspace or conflicts with a system persona name (case-insensitive), when `multilingual` is set to `true` but no `language` array is provided, or when any field contains a value outside the allowed choices. Review the response body for specific field-level validation errors.
+    Missing required fields, duplicate name, or invalid field values.
   </ParamField>
   <ParamField name="401" type="Unauthorized">
-    Authentication credentials were not provided or are invalid. Ensure that both `X-Api-Key` and `X-Secret-Key` headers are included in your request and contain valid, non-expired keys. Verify your API keys in the [Dashboard](https://app.futureagi.com) under Settings.
+    Invalid or missing API credentials.
   </ParamField>
   <ParamField name="500" type="Internal Server Error">
-    An unexpected error occurred on the server while processing the request. This is not caused by your input. If this error persists, contact Future AGI support with the request details and timestamp for investigation.
+    Unexpected server error.
   </ParamField>
 </ApiSection>

--- a/src/pages/docs/api/personas/deletepersona.mdx
+++ b/src/pages/docs/api/personas/deletepersona.mdx
@@ -21,40 +21,36 @@ description: "Soft-deletes a workspace-level persona. System personas cannot be 
 />
 
 <ApiSection title="Authentication">
-  <ParamField name="X-Api-Key" type="string" required>
+  <ParamField name="X-Api-Key" type="API Key" required>
     Your Future AGI API key used to authenticate requests. You can find and manage your API keys in the [Dashboard](https://app.futureagi.com) under Settings.
   </ParamField>
-  <ParamField name="X-Secret-Key" type="string" required>
+  <ParamField name="X-Secret-Key" type="Secret Key" required>
     Your Future AGI secret key, used alongside the API key for request authentication. This is generated when you create an API key in the [Dashboard](https://app.futureagi.com).
   </ParamField>
 </ApiSection>
 
 <ApiSection title="Path parameters">
-  <ParamField path="persona_id" type="string" required>
-    The UUID of the persona to delete. The persona must be a workspace-level (custom) persona that belongs to your organization. System (prebuilt) personas cannot be deleted. The persona is soft-deleted, meaning it is marked as deleted and excluded from future listings but is not permanently removed from the database. You can retrieve persona IDs from the [List personas](/docs/api/personas/listpersonas) endpoint.
+  <ParamField path="persona_id" type="UUID" required>
+    The persona ID. Must be a workspace-level persona; system personas cannot be deleted.
   </ParamField>
 </ApiSection>
 
 <ApiSection title="Response" status={204} statusText="No Content">
-  <ResponseField name="status" type="string">
-    Indicates the outcome of the request. Returns `"success"` when the persona is soft-deleted successfully.
-  </ResponseField>
-  <ResponseField name="result" type="object">
-    An object containing a `message` field with a confirmation string such as `"Persona deleted successfully"`.
-  </ResponseField>
+  <ResponseField name="status" type="string">`"success"` on deletion.</ResponseField>
+  <ResponseField name="result" type="object">Object with a `message` confirmation string.</ResponseField>
 </ApiSection>
 
 <ApiSection title="Errors">
   <ParamField name="401" type="Unauthorized">
-    Authentication credentials were not provided or are invalid. Ensure that both `X-Api-Key` and `X-Secret-Key` headers are included in your request and contain valid, non-expired keys. Verify your API keys in the [Dashboard](https://app.futureagi.com) under Settings.
+    Invalid or missing API credentials.
   </ParamField>
   <ParamField name="403" type="Forbidden">
-    The specified persona is a system-level (prebuilt) persona and cannot be deleted. System personas are managed by Future AGI and are available to all workspaces. Only workspace-level personas created by your team can be deleted.
+    Persona is a system-level persona and cannot be deleted.
   </ParamField>
   <ParamField name="404" type="Not Found">
-    The persona with the specified UUID could not be found. Verify that the `persona_id` is correct and that the persona has not already been deleted. You can retrieve valid persona IDs from the [List personas](/docs/api/personas/listpersonas) endpoint.
+    Persona not found.
   </ParamField>
   <ParamField name="500" type="Internal Server Error">
-    An unexpected error occurred on the server while processing the request. This is not caused by your input. If this error persists, contact Future AGI support with the request details and timestamp for investigation.
+    Unexpected server error.
   </ParamField>
 </ApiSection>

--- a/src/pages/docs/api/personas/duplicatepersona.mdx
+++ b/src/pages/docs/api/personas/duplicatepersona.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Duplicate persona"
-description: "Creates a copy of an existing persona as a new workspace-level persona with a custom name."
+description: "Copies an existing persona as a new workspace-level persona."
 ---
 
 <ApiPlayground
@@ -33,46 +33,42 @@ description: "Creates a copy of an existing persona as a new workspace-level per
 />
 
 <ApiSection title="Authentication">
-  <ParamField name="X-Api-Key" type="string" required>
+  <ParamField name="X-Api-Key" type="API Key" required>
     Your Future AGI API key used to authenticate requests. You can find and manage your API keys in the [Dashboard](https://app.futureagi.com) under Settings.
   </ParamField>
-  <ParamField name="X-Secret-Key" type="string" required>
+  <ParamField name="X-Secret-Key" type="Secret Key" required>
     Your Future AGI secret key, used alongside the API key for request authentication. This is generated when you create an API key in the [Dashboard](https://app.futureagi.com).
   </ParamField>
 </ApiSection>
 
 <ApiSection title="Path parameters">
-  <ParamField path="persona_id" type="string" required>
-    The UUID of the source persona to duplicate. This can be either a system-level (prebuilt) persona or a workspace-level (custom) persona. All attributes from the source persona are copied to the new persona except the name, which must be provided in the request body. The new persona is always created as a workspace-level persona regardless of the source persona's type.
+  <ParamField path="persona_id" type="UUID" required>
+    The source persona ID. Can be system or workspace persona. The copy is always created as workspace-level.
   </ParamField>
 </ApiSection>
 
 <ApiSection title="Request body">
   <ParamField body="name" type="string" required>
-    The name for the duplicated persona. Must be unique within your workspace and must not conflict with any existing system or workspace persona names. The comparison is case-insensitive. Maximum 255 characters. Choose a descriptive name that distinguishes this copy from the original persona.
+    Name for the new persona. Must be unique within the workspace (case-insensitive). Max 255 characters.
   </ParamField>
 </ApiSection>
 
 <ApiSection title="Response" status={201} statusText="Created">
-  <ResponseField name="status" type="string">
-    Indicates the outcome of the request. Returns `"success"` when the persona is duplicated successfully.
-  </ResponseField>
-  <ResponseField name="result" type="object">
-    The full persona object of the newly created copy. All attributes are inherited from the source persona except `name` (set to the provided value), `id` (a new UUID), and `persona_type` (always set to `"workspace"`). Includes `created_at` and `updated_at` timestamps reflecting the creation time of the copy.
-  </ResponseField>
+  <ResponseField name="status" type="string">`"success"` on creation.</ResponseField>
+  <ResponseField name="result" type="object">The newly created persona, inheriting all attributes from the source except `name`, `id`, and `persona_type` (set to `workspace`).</ResponseField>
 </ApiSection>
 
 <ApiSection title="Errors">
   <ParamField name="400" type="Bad Request">
-    The request payload is invalid. This can occur when the `name` field is missing or empty, when the provided name already exists as a persona in your workspace (case-insensitive), or when the organization context could not be determined from the request. Review the response body for specific validation error details.
+    Missing or duplicate name.
   </ParamField>
   <ParamField name="401" type="Unauthorized">
-    Authentication credentials were not provided or are invalid. Ensure that both `X-Api-Key` and `X-Secret-Key` headers are included in your request and contain valid, non-expired keys. Verify your API keys in the [Dashboard](https://app.futureagi.com) under Settings.
+    Invalid or missing API credentials.
   </ParamField>
   <ParamField name="404" type="Not Found">
-    The source persona with the specified UUID could not be found. Verify that the `persona_id` is correct and that the source persona has not been deleted. You can retrieve valid persona IDs from the [List personas](/docs/api/personas/listpersonas) endpoint.
+    Source persona not found.
   </ParamField>
   <ParamField name="500" type="Internal Server Error">
-    An unexpected error occurred on the server while processing the request. This is not caused by your input. If this error persists, contact Future AGI support with the request details and timestamp for investigation.
+    Unexpected server error.
   </ParamField>
 </ApiSection>

--- a/src/pages/docs/api/personas/listpersonas.mdx
+++ b/src/pages/docs/api/personas/listpersonas.mdx
@@ -1,6 +1,6 @@
 ---
 title: "List personas"
-description: "Retrieves a paginated list of personas, including system-level and workspace-level personas, with optional filtering by type, search, and simulation type."
+description: "Returns a paginated list of system and workspace personas."
 ---
 
 <ApiPlayground
@@ -43,105 +43,66 @@ description: "Retrieves a paginated list of personas, including system-level and
 />
 
 <ApiSection title="Authentication">
-  <ParamField name="X-Api-Key" type="string" required>
+  <ParamField name="X-Api-Key" type="API Key" required>
     Your Future AGI API key used to authenticate requests. You can find and manage your API keys in the [Dashboard](https://app.futureagi.com) under Settings.
   </ParamField>
-  <ParamField name="X-Secret-Key" type="string" required>
+  <ParamField name="X-Secret-Key" type="Secret Key" required>
     Your Future AGI secret key, used alongside the API key for request authentication. This is generated when you create an API key in the [Dashboard](https://app.futureagi.com).
   </ParamField>
 </ApiSection>
 
 <ApiSection title="Query parameters">
   <ParamField query="type" type="string" optional>
-    Filter personas by their origin type. Accepted values: `prebuilt` (returns system-level personas that are pre-configured and available to all workspaces) or `custom` (returns workspace-level personas that were created by your team). When omitted, both types are returned.
+    Values: `prebuilt`, `custom`.
   </ParamField>
   <ParamField query="search" type="string" optional>
-    A case-insensitive search query that matches against the persona's name, description, and keywords. For example, searching `"skeptical"` returns personas named `"Skeptical Customer"`, personas with `"skeptical"` in their description, etc.
+    Case-insensitive search across name, description, and keywords.
   </ParamField>
   <ParamField query="simulation_type" type="string" optional>
-    Filter personas by the type of simulation they are designed for. Accepted values: `voice` (returns personas configured for voice call simulations) or `text` (returns personas configured for text-based simulations). When omitted, personas of both simulation types are returned.
+    Values: `voice`, `text`.
   </ParamField>
   <ParamField query="limit" type="integer" optional>
-    The number of personas to return per page. Defaults to `10`. Use this in combination with `page` to paginate through large result sets.
+    Results per page. Defaults to `10`.
   </ParamField>
   <ParamField query="page" type="integer" optional>
-    The page number to retrieve, starting from `1`. Defaults to `1`. Use in conjunction with `limit` to navigate through paginated results.
+    Page number, starting from `1`. Defaults to `1`.
   </ParamField>
 </ApiSection>
 
 <ApiSection title="Response" status={200} statusText="OK">
-  <ResponseField name="count" type="integer">
-    The total number of personas matching the applied filters across all pages. Use this value to calculate the total number of pages in combination with the `limit` parameter.
-  </ResponseField>
-  <ResponseField name="next" type="string">
-    The full URL of the next page of results. Returns `null` if the current page is the last page.
-  </ResponseField>
-  <ResponseField name="previous" type="string">
-    The full URL of the previous page of results. Returns `null` if the current page is the first page.
-  </ResponseField>
-  <ResponseField name="total_pages" type="integer">
-    The total number of pages available based on the current `limit` setting and the total `count` of matching personas.
-  </ResponseField>
-  <ResponseField name="current_page" type="integer">
-    The current page number being returned in this response.
-  </ResponseField>
+  <ResponseField name="count" type="integer">Total matching personas across all pages.</ResponseField>
+  <ResponseField name="next" type="string">URL of the next page, or `null`.</ResponseField>
+  <ResponseField name="previous" type="string">URL of the previous page, or `null`.</ResponseField>
+  <ResponseField name="total_pages" type="integer">Total number of pages.</ResponseField>
+  <ResponseField name="current_page" type="integer">Current page number.</ResponseField>
   <ResponseField name="results" type="array of object">
-    An array of persona objects for the current page.
+    Array of persona objects.
+
+    <ApiCollapsible title="Show 15 properties">
+      <ResponseField name="id" type="string">UUID of the persona.</ResponseField>
+      <ResponseField name="name" type="string">Persona name.</ResponseField>
+      <ResponseField name="description" type="string">Persona description.</ResponseField>
+      <ResponseField name="persona_type" type="string">Origin type: `system` or `workspace`.</ResponseField>
+      <ResponseField name="persona_type_display" type="string">Display label, e.g. `Prebuilt` or `Custom`.</ResponseField>
+      <ResponseField name="gender" type="array">Gender attributes.</ResponseField>
+      <ResponseField name="age_group" type="array">Age group ranges.</ResponseField>
+      <ResponseField name="occupation" type="array">Occupation descriptors.</ResponseField>
+      <ResponseField name="location" type="array">Location descriptors.</ResponseField>
+      <ResponseField name="personality" type="array">Personality traits.</ResponseField>
+      <ResponseField name="communication_style" type="array">Communication style descriptors.</ResponseField>
+      <ResponseField name="simulation_type" type="string">`voice` or `text`.</ResponseField>
+      <ResponseField name="is_default" type="boolean">Whether this is a default persona.</ResponseField>
+      <ResponseField name="created_at" type="string">ISO 8601 creation timestamp.</ResponseField>
+      <ResponseField name="updated_at" type="string">ISO 8601 last-modified timestamp.</ResponseField>
+    </ApiCollapsible>
   </ResponseField>
-  <ApiCollapsible title="Show 15 properties">
-    <ResponseField name="id" type="string">
-      The unique identifier (UUID) of the persona.
-    </ResponseField>
-    <ResponseField name="name" type="string">
-      The display name of the persona.
-    </ResponseField>
-    <ResponseField name="description" type="string">
-      A text description of the persona's characteristics and behavior.
-    </ResponseField>
-    <ResponseField name="persona_type" type="string">
-      The origin type of the persona: `system` (pre-configured, available to all workspaces) or `workspace` (custom, created by your team).
-    </ResponseField>
-    <ResponseField name="persona_type_display" type="string">
-      A human-readable label for the persona type (e.g., "Prebuilt" or "Custom").
-    </ResponseField>
-    <ResponseField name="gender" type="array">
-      An array of gender attributes assigned to the persona.
-    </ResponseField>
-    <ResponseField name="age_group" type="array">
-      An array of age group ranges assigned to the persona.
-    </ResponseField>
-    <ResponseField name="occupation" type="array">
-      An array of occupation descriptors assigned to the persona.
-    </ResponseField>
-    <ResponseField name="location" type="array">
-      An array of location descriptors assigned to the persona.
-    </ResponseField>
-    <ResponseField name="personality" type="array">
-      An array of personality trait descriptors for the persona.
-    </ResponseField>
-    <ResponseField name="communication_style" type="array">
-      An array of communication style descriptors for the persona.
-    </ResponseField>
-    <ResponseField name="simulation_type" type="string">
-      The type of simulation the persona is designed for: `voice` or `text`.
-    </ResponseField>
-    <ResponseField name="is_default" type="boolean">
-      Whether this is a default persona that is automatically selected when no specific persona is chosen.
-    </ResponseField>
-    <ResponseField name="created_at" type="string">
-      ISO 8601 timestamp of when the persona was created.
-    </ResponseField>
-    <ResponseField name="updated_at" type="string">
-      ISO 8601 timestamp of the most recent modification to the persona.
-    </ResponseField>
-  </ApiCollapsible>
 </ApiSection>
 
 <ApiSection title="Errors">
   <ParamField name="401" type="Unauthorized">
-    Authentication credentials were not provided or are invalid. Ensure that both `X-Api-Key` and `X-Secret-Key` headers are included in your request and contain valid, non-expired keys. Verify your API keys in the [Dashboard](https://app.futureagi.com) under Settings.
+    Invalid or missing API credentials.
   </ParamField>
   <ParamField name="500" type="Internal Server Error">
-    An unexpected error occurred on the server while processing the request. This is not caused by your input. If this error persists, contact Future AGI support with the request details and timestamp for investigation.
+    Unexpected server error.
   </ParamField>
 </ApiSection>

--- a/src/pages/docs/api/personas/updatepersona.mdx
+++ b/src/pages/docs/api/personas/updatepersona.mdx
@@ -32,106 +32,104 @@ description: "Partially updates a workspace-level persona. System personas canno
 />
 
 <ApiSection title="Authentication">
-  <ParamField name="X-Api-Key" type="string" required>
+  <ParamField name="X-Api-Key" type="API Key" required>
     Your Future AGI API key used to authenticate requests. You can find and manage your API keys in the [Dashboard](https://app.futureagi.com) under Settings.
   </ParamField>
-  <ParamField name="X-Secret-Key" type="string" required>
+  <ParamField name="X-Secret-Key" type="Secret Key" required>
     Your Future AGI secret key, used alongside the API key for request authentication. This is generated when you create an API key in the [Dashboard](https://app.futureagi.com).
   </ParamField>
 </ApiSection>
 
 <ApiSection title="Path parameters">
-  <ParamField path="persona_id" type="string" required>
-    The UUID of the persona to update. The persona must be a workspace-level (custom) persona that belongs to your organization. System (prebuilt) personas cannot be modified through this endpoint. You can retrieve persona IDs from the [List personas](/docs/api/personas/listpersonas) endpoint.
+  <ParamField path="persona_id" type="UUID" required>
+    The persona ID. Must be a workspace-level persona; system personas cannot be modified.
   </ParamField>
 </ApiSection>
 
 <ApiSection title="Request body">
+  Only fields included in the request are updated. Array fields replace the existing list entirely.
+
   <ParamField body="name" type="string" optional>
-    A new name for the persona. Must be unique within your workspace and must not conflict with system persona names (case-insensitive comparison). Maximum 255 characters. Only the fields you include in the request body will be updated; omitted fields retain their current values.
+    New name. Must be unique within the workspace (case-insensitive). Max 255 characters.
   </ParamField>
   <ParamField body="description" type="string" optional>
-    An updated description explaining the persona's role, behavior, and characteristics. Must be a non-empty string if provided.
+    Non-empty description.
   </ParamField>
   <ParamField body="gender" type="array of string" optional>
-    Updated gender characteristics. Accepted values: `male`, `female`. Replaces the existing gender list entirely when provided.
+    Values: `male`, `female`.
   </ParamField>
   <ParamField body="ageGroup" type="array of string" optional>
-    Updated age range brackets. Accepted values: `18-25`, `25-32`, `32-40`, `40-50`, `50-60`, `60+`. Replaces the existing age group list entirely when provided.
+    Values: `18-25`, `25-32`, `32-40`, `40-50`, `50-60`, `60+`.
   </ParamField>
   <ParamField body="location" type="array of string" optional>
-    Updated geographic locations. Accepted values: `United States`, `Canada`, `United Kingdom`, `Australia`, `India`. Replaces the existing location list entirely when provided.
+    Values: `United States`, `Canada`, `United Kingdom`, `Australia`, `India`.
   </ParamField>
   <ParamField body="personality" type="array of string" optional>
-    Updated personality traits. Accepted values: `Friendly and cooperative`, `Professional and formal`, `Cautious and skeptical`, `Impatient and direct`, `Detail-oriented`, `Easy-going`, `Anxious`, `Confident`, `Analytical`, `Emotional`, `Reserved`, `Talkative`. Replaces the existing personality list entirely when provided.
+    Values: `Friendly and cooperative`, `Professional and formal`, `Cautious and skeptical`, `Impatient and direct`, `Detail-oriented`, `Easy-going`, `Anxious`, `Confident`, `Analytical`, `Emotional`, `Reserved`, `Talkative`.
   </ParamField>
   <ParamField body="communicationStyle" type="array of string" optional>
-    Updated communication style descriptors. Accepted values: `Direct and concise`, `Detailed and elaborate`, `Casual and friendly`, `Formal and polite`, `Technical`, `Simple and clear`, `Questioning`, `Assertive`, `Passive`, `Collaborative`. Replaces the existing communication style list entirely when provided.
+    Values: `Direct and concise`, `Detailed and elaborate`, `Casual and friendly`, `Formal and polite`, `Technical`, `Simple and clear`, `Questioning`, `Assertive`, `Passive`, `Collaborative`.
   </ParamField>
   <ParamField body="accent" type="array of string" optional>
-    Updated accent options for voice simulations. Accepted values: `American`, `Australian`, `Indian`, `Canadian`, `Neutral`. Replaces the existing accent list entirely when provided.
+    Values: `American`, `Australian`, `Indian`, `Canadian`, `Neutral`.
   </ParamField>
   <ParamField body="multilingual" type="boolean" optional>
-    Enables or disables multi-language support. When set to `true`, the `language` field must also be provided with at least one language.
+    Requires `language` when `true`.
   </ParamField>
   <ParamField body="language" type="array of string" optional>
-    Updated language options. Accepted values: `English`, `Hindi`. Required when `multilingual` is `true`.
+    Values: `English`, `Hindi`. Required when `multilingual` is `true`.
   </ParamField>
   <ParamField body="keywords" type="array of string" optional>
-    Updated keywords or tags for the persona. Used for search and categorization in the dashboard. Replaces the existing keywords list entirely when provided.
+    Searchable tags.
   </ParamField>
   <ParamField body="customProperties" type="object" optional>
-    Updated key-value metadata. Both keys and values must be non-empty strings. Replaces the existing custom properties object entirely when provided.
+    Key-value metadata. Keys and values must be non-empty strings.
   </ParamField>
   <ParamField body="additionalInstruction" type="string" optional>
-    Updated free-form behavioral instructions passed to the simulation engine.
+    Free-form behavioral instructions.
   </ParamField>
   <ParamField body="tone" type="string" optional>
-    Updated tone setting. Accepted values: `formal`, `casual`, `neutral`.
+    Values: `formal`, `casual`, `neutral`.
   </ParamField>
   <ParamField body="punctuation" type="string" optional>
-    Updated punctuation style. Accepted values: `clean`, `minimal`, `expressive`, `erratic`.
+    Values: `clean`, `minimal`, `expressive`, `erratic`.
   </ParamField>
   <ParamField body="slangUsage" type="string" optional>
-    Updated slang usage level. Accepted values: `none`, `moderate`, `heavy`, `light`.
+    Values: `none`, `light`, `moderate`, `heavy`.
   </ParamField>
   <ParamField body="typosFrequency" type="string" optional>
-    Updated typo frequency. Accepted values: `none`, `rare`, `occasional`, `frequent`.
+    Values: `none`, `rare`, `occasional`, `frequent`.
   </ParamField>
   <ParamField body="regionalMix" type="string" optional>
-    Updated regional language mix level. Accepted values: `none`, `moderate`, `heavy`, `light`.
+    Values: `none`, `light`, `moderate`, `heavy`.
   </ParamField>
   <ParamField body="emojiUsage" type="string" optional>
-    Updated emoji usage frequency. Accepted values: `never`, `light`, `regular`, `heavy`.
+    Values: `never`, `light`, `regular`, `heavy`.
   </ParamField>
   <ParamField body="verbosity" type="string" optional>
-    Updated response length preference. Accepted values: `brief`, `balanced`, `detailed`.
+    Values: `brief`, `balanced`, `detailed`.
   </ParamField>
 </ApiSection>
 
 <ApiSection title="Response" status={200} statusText="OK">
-  <ResponseField name="status" type="string">
-    Indicates the outcome of the request. Returns `"success"` when the persona is updated successfully.
-  </ResponseField>
-  <ResponseField name="result" type="object">
-    The full updated persona object, including all current attribute values (both changed and unchanged fields), along with the `id`, `persona_type`, `created_at`, and `updated_at` timestamps reflecting the update.
-  </ResponseField>
+  <ResponseField name="status" type="string">`"success"` on update.</ResponseField>
+  <ResponseField name="result" type="object">The updated persona object with all current attribute values.</ResponseField>
 </ApiSection>
 
 <ApiSection title="Errors">
   <ParamField name="400" type="Bad Request">
-    The request payload contains invalid field values. This can occur when the `name` conflicts with an existing persona in your workspace or a system persona, when field values are outside the allowed choices, or when `multilingual` is `true` but `language` is missing. Review the response body for specific validation errors.
+    Invalid field values, duplicate name, or missing `language` when `multilingual` is `true`.
   </ParamField>
   <ParamField name="401" type="Unauthorized">
-    Authentication credentials were not provided or are invalid. Ensure that both `X-Api-Key` and `X-Secret-Key` headers are included in your request and contain valid, non-expired keys. Verify your API keys in the [Dashboard](https://app.futureagi.com) under Settings.
+    Invalid or missing API credentials.
   </ParamField>
   <ParamField name="403" type="Forbidden">
-    The specified persona is a system-level (prebuilt) persona and cannot be modified. Only workspace-level personas created by your team can be updated through this endpoint. To customize a system persona, use the [Duplicate persona](/docs/api/personas/duplicatepersona) endpoint to create a workspace-level copy first.
+    Persona is a system-level persona and cannot be modified.
   </ParamField>
   <ParamField name="404" type="Not Found">
-    The persona with the specified UUID could not be found. Verify that the `persona_id` is correct and that the persona has not been deleted. You can retrieve valid persona IDs from the [List personas](/docs/api/personas/listpersonas) endpoint.
+    Persona not found.
   </ParamField>
   <ParamField name="500" type="Internal Server Error">
-    An unexpected error occurred on the server while processing the request. This is not caused by your input. If this error persists, contact Future AGI support with the request details and timestamp for investigation.
+    Unexpected server error.
   </ParamField>
 </ApiSection>


### PR DESCRIPTION
## Summary

Personas were excluded from the earlier API standardization passes (PRs #571 and #573) and still had the verbose pre-cleanup style. This brings the 5 persona endpoints in line with every other API category in the docs.

**Replaces PR #590**, which only fixed the auth `type="string"` issue. This PR fixes that plus everything else (path param types, terse descriptions, terse errors, malformed component nesting).

## Changes per file

- Auth fields: `type="string"` → `type="API Key"` / `type="Secret Key"`
- Path params: `type="string"` → `type="UUID"`
- Frontmatter descriptions trimmed to one short sentence
- Param descriptions: terse OpenAI-style, enum values listed inline
- Error descriptions: one-liners (no remediation paragraphs or dashboard links)
- Response field descriptions: single-line fragments
- Removed guidance language and cross-links from param bodies
- Fixed malformed `<ApiCollapsible>` nesting in `listpersonas.mdx` (was sibling of the `results` ResponseField, now nested inside it)

## Files changed

- `src/pages/docs/api/personas/createpersona.mdx`
- `src/pages/docs/api/personas/deletepersona.mdx`
- `src/pages/docs/api/personas/duplicatepersona.mdx`
- `src/pages/docs/api/personas/listpersonas.mdx`
- `src/pages/docs/api/personas/updatepersona.mdx`

## Test plan

- [ ] All 5 pages render and auth fields show `API Key` / `Secret Key` badges
- [ ] Path param chips show `UUID` instead of `string`
- [ ] Errors sections render as one-liners
- [ ] `listpersonas.mdx` Show 15 properties collapsible appears nested under `results`

🤖 Generated with [Claude Code](https://claude.com/claude-code)