### PR TITLE
feat(analytics): add GA4 + Google Ads tracking to docs subdomain

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -13,6 +13,11 @@ const { title, description = 'Future AGI Documentation - Build, evaluate, and op
 const posthogKey = import.meta.env.PUBLIC_POSTHOG_KEY || '';
 const posthogHost = import.meta.env.PUBLIC_POSTHOG_HOST || '';
 const canonicalURL = new URL(Astro.url.pathname, Astro.site || 'https://docs.futureagi.com');
+
+// Analytics ID — same property as apex landing-page Layout.astro / BlogPostLayout.astro.
+// Cross-domain linker stitches sessions across futureagi.com / docs.futureagi.com / app.futureagi.com
+// so a user reading docs that signs up on app gets attributed to the originating ad click.
+const GA_ID = import.meta.env.PUBLIC_GA_ID || 'G-BFBK89532X';
 ---
 
 <!DOCTYPE html>
@@ -127,6 +132,25 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site || 'https://docs.fut
             cookie_domain: '.futureagi.com',
           });
         }, 0);
+      });
+    </script>
+
+    <!-- Google Analytics + Google Ads (single gtag.js load) -->
+    <!-- Cross-domain linker stitches sessions across futureagi.com /
+         docs.futureagi.com / app.futureagi.com so docs → signup attribution
+         flows correctly. Mirrors src/layouts/Layout.astro on the apex repo. -->
+    <script is:inline async src="https://www.googletagmanager.com/gtag/js?id=AW-18081760643"></script>
+    <script define:vars={{ GA_ID }}>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      window.gtag = gtag;
+      gtag('js', new Date());
+      gtag('config', 'AW-18081760643', {
+        linker: { domains: ['futureagi.com', 'docs.futureagi.com', 'app.futureagi.com'], accept_incoming: true }
+      });
+      if (GA_ID) gtag('config', GA_ID, {
+        send_page_view: true,
+        linker: { domains: ['futureagi.com', 'docs.futureagi.com', 'app.futureagi.com'], accept_incoming: true }
       });
     </script>
   </head>


### PR DESCRIPTION
## Summary
- Add gtag.js snippet to `BaseLayout.astro` (configures `AW-18081760643` + GA4 `G-BFBK89532X`).
- Enable cross-domain linker for `futureagi.com` / `docs.futureagi.com` / `app.futureagi.com` so a user reading docs that signs up on app keeps the originating ad-click attribution.
- Mirrors the snippet already in apex `Layout.astro` / `BlogPostLayout.astro` (paired PR: future-agi/landing-page).

## Why
Docs subdomain has been dark in GA4 — 605 indexed URLs firing zero pageviews. PostHog stays as-is; this is purely additive.

## Test plan
- [x] `pnpm build` passes (607 pages indexed by pagefind, exit 0)
- [x] Built `dist/docs/index.html` contains `googletagmanager.com/gtag/js?id=AW-18081760643` and `G-BFBK89532X`
- [ ] After deploy: `curl -s https://docs.futureagi.com/docs/ | grep -c googletagmanager` → ≥1
- [ ] After deploy: confirm pageviews in GA4 Realtime when browsing docs
- [ ] After deploy: navigate blog → docs → app and confirm a single GA4 client ID is preserved (cross-domain linker working)

🤖 Generated with [Claude Code](https://claude.com/claude-code)