### PR TITLE
docs(tracing): add ChromaDB tracing pages

### DIFF
--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -443,6 +443,12 @@ export const tabNavigation: NavTab[] = [
                 ]
               },
               {
+                title: 'Vector Databases',
+                items: [
+                  { title: 'ChromaDB', href: '/docs/tracing/auto/chromadb' },
+                ]
+              },
+              {
                 title: 'Java',
                 items: [
                   { title: 'Overview', href: '/docs/tracing/auto/java' },
@@ -672,6 +678,12 @@ export const tabNavigation: NavTab[] = [
             items: [
               { title: 'LiveKit', href: '/docs/integrations/traceai/livekit' },
               { title: 'Pipecat', href: '/docs/integrations/traceai/pipecat' },
+            ]
+          },
+          {
+            title: 'Vector Databases',
+            items: [
+              { title: 'ChromaDB', href: '/docs/integrations/traceai/chromadb' },
             ]
           },
           {

--- a/src/pages/docs/integrations/index.mdx
+++ b/src/pages/docs/integrations/index.mdx
@@ -59,6 +59,12 @@ The Langfuse card above is for SDK-level tracing integration (sending new traces
   <Card title="Retell" href="/docs/observe/features/voice" />
 </CardGroup>
 
+### Vector Databases
+
+<CardGroup cols={2}>
+  <Card title="ChromaDB" href="/docs/integrations/traceai/chromadb" />
+</CardGroup>
+
 ### Other
 
 <CardGroup cols={2}>

--- a/src/pages/docs/integrations/traceai/chromadb.mdx
+++ b/src/pages/docs/integrations/traceai/chromadb.mdx
@@ -1,0 +1,75 @@
+---
+title: "ChromaDB Integration with Future AGI for Vector DB Observability"
+description: "Integrate ChromaDB with Future AGI observability. Trace add, query, get, update, upsert, and delete operations automatically using traceAI-chromadb."
+---
+
+## 1. Installation
+Install the traceAI and other necessary packages.
+
+```bash
+pip install traceAI-chromadb 
+```
+
+---
+
+## 2. Set Environment Variables
+Set up your environment variables to authenticate with FutureAGI.
+
+```python
+import os
+
+os.environ["FI_API_KEY"] = "your-futureagi-api-key"
+os.environ["FI_SECRET_KEY"] = "your-futureagi-secret-key"
+```
+
+---
+
+## 3. Initialize Trace Provider
+Set up the trace provider to create a new project in FutureAGI, establish telemetry data pipelines .
+
+```python
+from fi_instrumentation import register
+from fi_instrumentation.fi_types import ProjectType
+
+trace_provider = register(
+    project_type=ProjectType.OBSERVE,
+    project_name="CHROMADB_APP",
+)
+```
+
+---
+
+## 4. Instrument your Project
+Use the ChromaDB Instrumentor to instrument your project.
+
+```python
+from traceai_chromadb import ChromaDBInstrumentor
+
+ChromaDBInstrumentor().instrument(tracer_provider=trace_provider)
+```
+
+---
+
+## 5. Run your ChromaDB application.
+Run your ChromaDB application as you normally would. Our Instrumentor will automatically trace and send the telemetry data to our platform.
+
+```python
+import chromadb
+
+client = chromadb.Client()
+collection = client.create_collection("my-collection")
+
+# Add documents
+collection.add(
+    ids=["id1", "id2"],
+    documents=["Hello world", "Goodbye world"],
+    metadatas=[{"source": "doc1"}, {"source": "doc2"}]
+)
+
+# Query
+results = collection.query(
+    query_texts=["Hello"],
+    n_results=5
+)
+print(results)
+```

--- a/src/pages/docs/tracing/auto/chromadb.mdx
+++ b/src/pages/docs/tracing/auto/chromadb.mdx
@@ -1,0 +1,75 @@
+---
+title: "ChromaDB Tracing with Future AGI: Auto-Instrumentation"
+description: "Set up auto-instrumentation for ChromaDB with Future AGI tracing. Install traceAI-chromadb to capture add, query, get, update, upsert, and delete operations."
+---
+
+## 1. Installation
+Install the traceAI and other necessary packages.
+
+```bash
+pip install traceAI-chromadb 
+```
+
+---
+
+## 2. Set Environment Variables
+Set up your environment variables to authenticate with FutureAGI.
+
+```python
+import os
+
+os.environ["FI_API_KEY"] = "your-futureagi-api-key"
+os.environ["FI_SECRET_KEY"] = "your-futureagi-secret-key"
+```
+
+---
+
+## 3. Initialize Trace Provider
+Set up the trace provider to create a new project in FutureAGI, establish telemetry data pipelines .
+
+```python
+from fi_instrumentation import register
+from fi_instrumentation.fi_types import ProjectType
+
+trace_provider = register(
+    project_type=ProjectType.OBSERVE,
+    project_name="CHROMADB_APP",
+)
+```
+
+---
+
+## 4. Instrument your Project
+Use the ChromaDB Instrumentor to instrument your project.
+
+```python
+from traceai_chromadb import ChromaDBInstrumentor
+
+ChromaDBInstrumentor().instrument(tracer_provider=trace_provider)
+```
+
+---
+
+## 5. Run your ChromaDB application.
+Run your ChromaDB application as you normally would. Our Instrumentor will automatically trace and send the telemetry data to our platform.
+
+```python
+import chromadb
+
+client = chromadb.Client()
+collection = client.create_collection("my-collection")
+
+# Add documents
+collection.add(
+    ids=["id1", "id2"],
+    documents=["Hello world", "Goodbye world"],
+    metadatas=[{"source": "doc1"}, {"source": "doc2"}]
+)
+
+# Query
+results = collection.query(
+    query_texts=["Hello"],
+    n_results=5
+)
+print(results)
+```

--- a/src/pages/docs/tracing/auto/index.mdx
+++ b/src/pages/docs/tracing/auto/index.mdx
@@ -114,6 +114,14 @@ Python and JS/TS integrations use instrumentors that patch client libraries. Jav
   </Card>
 </CardGroup>
 
+## Vector Databases
+
+<CardGroup cols={3}>
+  <Card title="ChromaDB" icon="plug" href="/docs/tracing/auto/chromadb">
+    `traceAI-chromadb`
+  </Card>
+</CardGroup>
+
 ## Java
 
 The Java SDK uses explicit `Traced*` wrappers instead of instrumentors. Add a Maven/Gradle dependency, wrap your client, and traces flow to FutureAGI. See the [Java overview](/docs/tracing/auto/java) for core setup.


### PR DESCRIPTION
## Summary
- Adds TraceAI ChromaDB pages on both docs surfaces, following the 5-section sibling template (Install → Env vars → register → instrument → run).
- Introduces a new **Vector Databases** group in both sidebars and both overview grids. ChromaDB is the first entry; the group is structured so other Python vector-DB instrumentors (`pinecone`, `qdrant`, `weaviate`, `milvus`, `lancedb`, `pgvector`, `redis-vector`, `mongodb-vector`) can be added incrementally.
- Code example mirrors the runtime portion of the upstream README at `traceAI/python/frameworks/chromadb/README.md` verbatim (collection setup, `add(...)`, `query(...)` with `n_results=5`), keeping a trailing `print(results)` for sibling-style consistency.

## What changed
| File | Change |
| --- | --- |
| `src/pages/docs/tracing/auto/chromadb.mdx` | New auto-instrumentation page |
| `src/pages/docs/integrations/traceai/chromadb.mdx` | New integrations page (mirrors content, distinct title/description) |
| `src/lib/navigation.ts` | +1 \`Vector Databases\` group with ChromaDB in each of the Tracing and Integrations sidebars |
| `src/pages/docs/integrations/index.mdx` | +1 \`Vector Databases\` card group |
| `src/pages/docs/tracing/auto/index.mdx` | +1 \`Vector Databases\` card group |

## Verification
- ` astro dev ` compiled both new MDX pages with **zero errors / zero browser console errors**. Routes \`/docs/tracing/auto/chromadb\` and \`/docs/integrations/traceai/chromadb\` both return \`200\`. Both overview grids and both sidebars resolve to the surface-appropriate URL.
- **Live runtime smoke test** against \`api.futureagi.com\`: ran the literal Step 2-5 code with \`FI_API_KEY\`/\`FI_SECRET_KEY\` from env. \`register()\` succeeded, \`ChromaDBInstrumentor\` instrumented, \`collection.add(...)\` + \`collection.query(...)\` ran, and **2 spans landed in the \`CHROMADB_APP\` project** in the FAGI dashboard with the full documented \`db.vector.*\` attribute set (\`db.system\`, \`db.namespace\`, \`db.operation.name\`, \`db.vector.query.top_k\`, \`db.vector.query.type\`, \`db.vector.query.include\`, \`db.vector.results.count\`, \`db.vector.results.ids\`, \`db.vector.results.scores\`).

## Heads-up (upstream-package bug, not a docs bug)
The \`traceai-chromadb\` instrumentor imports \`wrap_function_wrapper\` from \`wrapt\` and calls it with kwargs (\`module=\`, \`name=\`, \`wrapper=\`). That kwarg signature was removed in \`wrapt\` 2.0, so a fresh \`pip install traceAI-chromadb\` against today's PyPI wrapt (2.x) crashes with \`TypeError: wrap_function_wrapper() got an unexpected keyword argument 'module'\`. Pinning \`wrapt<2\` works around it. The right fix is in the upstream \`traceAI\` repo (either pin \`wrapt<2\` in \`traceai-chromadb\`'s \`pyproject.toml\` or switch the calls to positional form). Docs intentionally kept clean of the pin so they age well once the upstream is fixed.

## Test plan
- [x] \`astro dev\` and confirm \`/docs/tracing/auto/chromadb\` and \`/docs/integrations/traceai/chromadb\` both render with the 5 sections.
- [x] Confirm a **Vector Databases** group with a **ChromaDB** entry appears in both sidebars (Tracing and Integrations), between Voice & Realtime and Java.
- [x] Confirm the **Vector Databases** card group with a **ChromaDB** card appears on both overview grids.
- [x] Optional: copy-paste the Step 2-5 code with real keys and confirm a trace lands in your FAGI workspace.