### PR TITLE
docs(command-center): add overview video to the Agent Command Center page

### DIFF
--- a/src/pages/docs/command-center/index.mdx
+++ b/src/pages/docs/command-center/index.mdx
@@ -7,6 +7,10 @@ description: "A unified API gateway for 100+ LLM providers with built-in guardra
 The `prism-ai` Python package and `@futureagi/prism` TypeScript package are being renamed. The current packages will continue to work but are deprecated. Watch for the updated package names in an upcoming release.
 </Warning>
 
+<div style={{ position: 'relative', paddingBottom: '56.25%', height: 0, margin: '1.5rem 0 2rem', borderRadius: '12px', overflow: 'hidden' }}>
+  <iframe src="https://www.youtube-nocookie.com/embed/Xr2RmZAVcoo?rel=0&modestbranding=1&playsinline=1" title="Agent Command Center overview" style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%', border: 0 }} allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowFullScreen></iframe>
+</div>
+
 ## About
 
 Agent Command Center is Future AGI's AI Gateway. It sits between your application and LLM providers, giving you a single API that handles routing across 100+ providers, safety guardrails, response caching, cost tracking, and full observability.


### PR DESCRIPTION
## Summary

Adds the Agent Command Center product overview video to the top of the `/docs/command-center` overview page.

## Changes

- Embed the overview video as a privacy-mode, inline-playable YouTube iframe (`youtube-nocookie.com` with `rel=0&modestbranding=1&playsinline=1`), placed directly under the deprecation notice and above the About section.
- Responsive 16:9 wrapper; plays in-page without redirecting to YouTube.

## Testing

- Served HTML confirms the iframe is positioned above the About heading with the correct embed src; YouTube oEmbed confirms the video is public and embeddable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)