### PR TITLE
docs(command-center): autoplay overview video on #watch links

### DIFF
--- a/src/pages/docs/command-center/index.mdx
+++ b/src/pages/docs/command-center/index.mdx
@@ -7,9 +7,25 @@ description: "A unified API gateway for 100+ LLM providers with built-in guardra
 The `prism-ai` Python package and `@futureagi/prism` TypeScript package are being renamed. The current packages will continue to work but are deprecated. Watch for the updated package names in an upcoming release.
 </Warning>
 
-<div style={{ position: 'relative', paddingBottom: '56.25%', height: 0, margin: '1.5rem 0 2rem', borderRadius: '12px', overflow: 'hidden' }}>
-  <iframe src="https://www.youtube-nocookie.com/embed/Xr2RmZAVcoo?rel=0&modestbranding=1&playsinline=1" title="Agent Command Center overview" style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%', border: 0 }} allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowFullScreen></iframe>
+<div id="acc-overview-video-wrap" style={{ position: 'relative', paddingBottom: '56.25%', height: 0, margin: '1.5rem 0 2rem', borderRadius: '12px', overflow: 'hidden' }}>
+  <iframe id="acc-overview-video" data-embed="https://www.youtube-nocookie.com/embed/Xr2RmZAVcoo?rel=0&modestbranding=1&playsinline=1" src="https://www.youtube-nocookie.com/embed/Xr2RmZAVcoo?rel=0&modestbranding=1&playsinline=1" title="Agent Command Center overview" style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%', border: 0 }} allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowFullScreen></iframe>
 </div>
+
+<script>{`
+(function(){
+  function playAccVideoFromLink(){
+    if (location.hash !== '#watch') return;
+    var f = document.getElementById('acc-overview-video');
+    if (!f) return;
+    var base = f.getAttribute('data-embed');
+    if (base && f.src.indexOf('autoplay=1') === -1) { f.src = base + '&autoplay=1&mute=1'; }
+    var wrap = document.getElementById('acc-overview-video-wrap') || f;
+    if (wrap.scrollIntoView) wrap.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  }
+  playAccVideoFromLink();
+  document.addEventListener('astro:page-load', playAccVideoFromLink);
+})();
+`}</script>
 
 ## About
 


### PR DESCRIPTION
## Summary

Follow-up to #688 / #689. Makes the Agent Command Center overview video **autoplay when a visitor arrives via `/docs/command-center#watch`**, so email/newsletter traffic lands on the docs and the video starts playing immediately.

## Changes

- Add an `id` + `data-embed` to the overview iframe and a small inline handler: when the URL hash is `#watch`, the embed reloads with `autoplay=1&mute=1` (browsers require muted autoplay) and scrolls into view.
- Normal visitors are unaffected — the video stays click-to-play.

## Testing

- Page builds (HTTP 200); the iframe carries the `autoplay` permission and `data-embed`; handler is present in the rendered HTML. (The external iframe hangs the headless test browser, so autoplay was not auto-verified — confirm by opening `…/command-center#watch`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)