### PR TITLE
docs: add self-hosting system configuration page

### DIFF
--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -66,7 +66,7 @@ export const tabNavigation: NavTab[] = [
                 title: 'Configuration',
                 items: [
                   { title: 'Environment variables', href: '/docs/self-hosting/environment' },
-                  { title: 'System configuration', href: '/docs/self-hosting/configuration' },
+                  { title: 'System configuration', href: '/docs/self-hosting/configuration/system' },
                 ]
               },
               {

--- a/src/pages/docs/self-hosting.mdx
+++ b/src/pages/docs/self-hosting.mdx
@@ -36,7 +36,7 @@ postgres ──── PeerDB CDC ──── clickhouse   (continuous replicati
 - **Workflow**: `temporal`
 - **CDC**: PeerDB (continuous Postgres → ClickHouse replication)
 
-Everything runs on your machines; nothing leaves your network. The full service-by-service breakdown lives in [Configure](/docs/self-hosting/configure)
+Everything runs on your machines; nothing leaves your network. The full service-by-service breakdown lives in [Configure](/docs/self-hosting/configuration).
 
 ## Deployment options
 
@@ -49,7 +49,7 @@ Everything runs on your machines; nothing leaves your network. The full service-
 ## Where to go next
 
 <CardGroup cols={3}>
-  <Card title="Configure" icon="gear" href="/docs/self-hosting/configure">
+  <Card title="Configure" icon="gear" href="/docs/self-hosting/configuration">
     System requirements, prerequisites, environment variables, and setup
   </Card>
   <Card title="Troubleshooting & FAQs" icon="wrench" href="/docs/self-hosting/troubleshooting">

--- a/src/pages/docs/self-hosting/configuration/system.mdx
+++ b/src/pages/docs/self-hosting/configuration/system.mdx
@@ -118,7 +118,7 @@ Temporal runs the platform's background jobs and evaluation pipelines. How those
 
 **All-queue (default).** One worker polls every task queue. Controlled by `TEMPORAL_ALL_QUEUES=true` in `.env`. This is the right setup for most self-hosted deployments.
 
-**Per-queue (dev overlay).** Six dedicated workers, one per queue, brought up by the [dev overlay](/docs/self-hosting/install#dev-overlay):
+**Per-queue (dev overlay).** Six dedicated workers, one per queue, brought up by the [dev overlay](/docs/self-hosting/installation#other-ways-to-run-it):
 
 | Service | Queue | Typical concurrency |
 |---|---|---|

--- a/src/pages/docs/self-hosting/configuration/system.mdx
+++ b/src/pages/docs/self-hosting/configuration/system.mdx
@@ -3,28 +3,28 @@ title: "System configuration"
 description: "Configure the LLM gateway, PeerDB replication, and Temporal workers for your self-hosted instance."
 ---
 
-## Introduction
+## In this page
 
-A few parts of the stack are configured outside `.env`: the LLM gateway needs a `config.yaml` listing its providers, PeerDB needs its replication mirrors running, and Temporal workers can be tuned for throughput. This page covers all three. Set your secrets and provider keys in [Environment Variables](/docs/self-hosting/configuration/environment) first — the config here references them.
+A few parts of the stack are configured outside `.env`: the LLM gateway needs a `config.yaml` listing its providers, PeerDB needs its replication mirrors running, and Temporal workers can be tuned for throughput. This page covers all three. Set your secrets and provider keys in [Environment Variables](/docs/self-hosting/configuration/environment) first, since the config here references them.
 
 ## LLM Gateway
 
 The gateway is a Go proxy that routes every model call the platform makes. It reads a `config.yaml` that lists which providers it may use and which models each exposes.
 
 <Warning>
-Model calls fail until this file exists. The gateway ships with `config.example.yaml` (OpenAI enabled) but **not** a live `config.yaml` — you create one in the steps below.
+Model calls fail until this file exists. The gateway ships with `config.example.yaml` (OpenAI enabled) but **not** a live `config.yaml`. You create one in the steps below.
 </Warning>
 
 <Steps>
 <Step title="Copy the Example Config">
 ```bash
-cp futureagi/agentcc-gateway/config.example.yaml \
-   futureagi/agentcc-gateway/config.yaml
+cp agentcc-gateway/config.example.yaml \
+   agentcc-gateway/config.yaml
 ```
 </Step>
 
 <Step title="Add Providers and Keys">
-Edit `config.yaml` — uncomment the providers you want and reference their keys with `${VAR}` interpolation. Set the matching keys (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, …) in `.env`. See the provider examples below.
+Edit `config.yaml`: uncomment the providers you want and reference their keys with `${VAR}` interpolation. Set the matching keys (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, …) in `.env`. See the provider examples below.
 </Step>
 
 <Step title="Mount the Config and Restart">
@@ -32,7 +32,7 @@ Point the gateway volume at your `config.yaml` in `docker-compose.yml`:
 
 ```yaml
 volumes:
-  - ./futureagi/agentcc-gateway/config.yaml:/app/config.yaml:ro
+  - ./agentcc-gateway/config.yaml:/app/config.yaml:ro
 ```
 
 ```bash
@@ -42,7 +42,7 @@ docker compose up -d --force-recreate gateway
 </Steps>
 
 <Warning>
-`config.yaml` is gitignored and holds live API keys. Treat it as a secret — never commit it.
+`config.yaml` is gitignored and holds live API keys. Treat it as a secret. Never commit it.
 </Warning>
 
 ### Provider Examples
@@ -99,7 +99,7 @@ For routing rules, rate limits, caching, and the full config reference, see [Age
 
 ## PeerDB Replication
 
-PeerDB continuously replicates Postgres tables into ClickHouse (change-data-capture) so trace and eval analytics stay fast. It runs on its own — the only thing you typically touch is a first-boot timing fix.
+PeerDB continuously replicates Postgres tables into ClickHouse (change-data-capture) so trace and eval analytics stay fast. It runs on its own. The only thing you typically touch is a first-boot timing fix.
 
 <Warning>
 **First-boot timing.** `peerdb-init` runs the moment the stack starts, sometimes before Django has finished its migrations. If mirrors show "not started" in the PeerDB UI, re-run init once the backend is up:
@@ -110,7 +110,7 @@ docker compose run --rm peerdb-init bash /setup.sh   # re-run init
 ```
 </Warning>
 
-Verify at [http://localhost:3001](http://localhost:3001) — mirrors should move to `running` within seconds. Re-run the same init command after any upgrade that changes replicated tables.
+Verify at [http://localhost:3001](http://localhost:3001). Mirrors should move to `running` within seconds. Re-run the same init command after any upgrade that changes replicated tables.
 
 ## Temporal Workers
 

--- a/src/pages/docs/self-hosting/configuration/system.mdx
+++ b/src/pages/docs/self-hosting/configuration/system.mdx
@@ -1,0 +1,143 @@
+---
+title: "System Configuration"
+description: "Configure the moving parts beyond .env — the LLM gateway config.yaml with provider keys, PeerDB Postgres-to-ClickHouse replication mirrors, and Temporal worker concurrency."
+---
+
+## Introduction
+
+A few parts of the stack are configured outside `.env`: the LLM gateway needs a `config.yaml` listing its providers, PeerDB needs its replication mirrors running, and Temporal workers can be tuned for throughput. This page covers all three. Set your secrets and provider keys in [Environment Variables](/docs/self-hosting/configuration/environment) first — the config here references them.
+
+## LLM Gateway
+
+The gateway is a Go proxy that routes every model call the platform makes. It reads a `config.yaml` that lists which providers it may use and which models each exposes.
+
+<Warning>
+Model calls fail until this file exists. The gateway ships with `config.example.yaml` (OpenAI enabled) but **not** a live `config.yaml` — you create one in the steps below.
+</Warning>
+
+<Steps>
+<Step title="Copy the Example Config">
+```bash
+cp futureagi/agentcc-gateway/config.example.yaml \
+   futureagi/agentcc-gateway/config.yaml
+```
+</Step>
+
+<Step title="Add Providers and Keys">
+Edit `config.yaml` — uncomment the providers you want and reference their keys with `${VAR}` interpolation. Set the matching keys (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, …) in `.env`. See the provider examples below.
+</Step>
+
+<Step title="Mount the Config and Restart">
+Point the gateway volume at your `config.yaml` in `docker-compose.yml`:
+
+```yaml
+volumes:
+  - ./futureagi/agentcc-gateway/config.yaml:/app/config.yaml:ro
+```
+
+```bash
+docker compose up -d --force-recreate gateway
+```
+</Step>
+</Steps>
+
+<Warning>
+`config.yaml` is gitignored and holds live API keys. Treat it as a secret — never commit it.
+</Warning>
+
+### Provider Examples
+
+<Tabs>
+<Tab title="OpenAI / Anthropic / Gemini">
+```yaml
+providers:
+  openai:
+    api_key: "${OPENAI_API_KEY}"
+    api_format: "openai"
+    models: [gpt-4o, gpt-4o-mini]
+
+  anthropic:
+    api_key: "${ANTHROPIC_API_KEY}"
+    api_format: "anthropic"
+    models: [claude-opus-4-5, claude-sonnet-4-5]
+
+  gemini:
+    api_key: "${GOOGLE_API_KEY}"
+    api_format: "gemini"
+    models: [gemini-2.0-flash, gemini-1.5-pro]
+```
+</Tab>
+<Tab title="AWS Bedrock">
+```yaml
+providers:
+  bedrock:
+    api_key: "${AWS_SECRET_ACCESS_KEY}"
+    api_format: "bedrock"
+    region: "${AWS_REGION}"
+    access_key: "${AWS_ACCESS_KEY_ID}"
+    models: [anthropic.claude-3-5-sonnet-20241022-v2:0]
+```
+</Tab>
+<Tab title="Vertex AI">
+```yaml
+providers:
+  vertex:
+    base_url: "https://us-central1-aiplatform.googleapis.com"
+    api_key: "${GOOGLE_ACCESS_TOKEN}"
+    api_format: "gemini"
+    headers:
+      x-gcp-project: "${GCP_PROJECT_ID}"
+      x-gcp-location: "us-central1"
+    models: [gemini-2.0-flash-001]
+```
+
+Vertex uses a Bearer token, not a static API key. Rotate `GOOGLE_ACCESS_TOKEN` with a sidecar that calls `gcloud auth print-access-token`.
+</Tab>
+</Tabs>
+
+For routing rules, rate limits, caching, and the full config reference, see [Agent Command Center → Self-Hosted](/docs/command-center/deployment/self-hosted).
+
+## PeerDB Replication
+
+PeerDB continuously replicates Postgres tables into ClickHouse (change-data-capture) so trace and eval analytics stay fast. It runs on its own — the only thing you typically touch is a first-boot timing fix.
+
+<Warning>
+**First-boot timing.** `peerdb-init` runs the moment the stack starts, sometimes before Django has finished its migrations. If mirrors show "not started" in the PeerDB UI, re-run init once the backend is up:
+
+```bash
+docker compose logs -f backend                       # wait for "Application startup complete"
+docker compose run --rm peerdb-init bash /setup.sh   # re-run init
+```
+</Warning>
+
+Verify at [http://localhost:3001](http://localhost:3001) — mirrors should move to `running` within seconds. Re-run the same init command after any upgrade that changes replicated tables.
+
+## Temporal Workers
+
+Temporal runs the platform's background jobs and evaluation pipelines. How those jobs are distributed across workers depends on one flag.
+
+**All-queue (default).** One worker polls every task queue. Controlled by `TEMPORAL_ALL_QUEUES=true` in `.env`. This is the right setup for most self-hosted deployments.
+
+**Per-queue (dev overlay).** Six dedicated workers, one per queue, brought up by the [dev overlay](/docs/self-hosting/install#dev-overlay):
+
+| Service | Queue | Typical concurrency |
+|---|---|---|
+| `worker-default` | `default` | 100 |
+| `worker-tasks-s` | `tasks_s` | 200 |
+| `worker-tasks-l` | `tasks_l` | 50 |
+| `worker-tasks-xl` | `tasks_xl` | 10 |
+| `worker-trace-ingestion` | `trace_ingestion` | 100 |
+| `worker-agent-compass` | `agent_compass` | 50 |
+
+Tune throughput with `TEMPORAL_MAX_CONCURRENT_ACTIVITIES` and `TEMPORAL_MAX_CONCURRENT_WORKFLOW_TASKS` in `.env`. The Temporal UI is available in dev mode at [http://localhost:8085](http://localhost:8085).
+
+## Dive Deeper
+
+<CardGroup cols={2}>
+  <Card title="Production Checklist" icon="shield" href="/docs/self-hosting/production/checklist">
+    Hardening, backups, and monitoring before going live.
+  </Card>
+  <Card title="Troubleshooting" icon="wrench" href="/docs/self-hosting/troubleshooting">
+    Fixes for gateway, PeerDB, and Temporal errors.
+  </Card>
+</CardGroup>

--- a/src/pages/docs/self-hosting/configuration/system.mdx
+++ b/src/pages/docs/self-hosting/configuration/system.mdx
@@ -1,6 +1,6 @@
 ---
-title: "System Configuration"
-description: "Configure the moving parts beyond .env — the LLM gateway config.yaml with provider keys, PeerDB Postgres-to-ClickHouse replication mirrors, and Temporal worker concurrency."
+title: "System configuration"
+description: "Configure the LLM gateway, PeerDB replication, and Temporal workers for your self-hosted instance."
 ---
 
 ## Introduction


### PR DESCRIPTION
## What

Adds the System Configuration reference page for self-hosted FutureAGI.

## Pages added

- `src/pages/docs/self-hosting/configuration/system.mdx` — LLM gateway config.yaml setup (with Steps + Tabs for OpenAI/Bedrock/Vertex), PeerDB replication first-boot fix, Temporal Workers concurrency table

## Preview

```
npm run dev
```

Then visit: http://localhost:4444/docs/self-hosting/configuration/system

TH-6328