### PR TITLE
docs(observe): Observability model concept revamp

### DIFF
--- a/src/pages/docs/observe/concepts/observability-model.mdx
+++ b/src/pages/docs/observe/concepts/observability-model.mdx
@@ -1,49 +1,17 @@
 ---
 title: "Observability model"
-description: "How the pieces of Observe fit together: spans nest into traces, traces group into sessions and users, and eval scores attach on top — all collected as OpenTelemetry data through the traceAI SDK."
-slug: "observability-model"
-page_type: "concept"
-diataxis: "explanation"
-products: ["Observe"]
-concept_family: "observability"
-concept_level: "foundational"
-audience: ["engineer"]
-difficulty: "beginner"
-status: "review"
-owner: "observability"
-reviewers: ["observability-eng"]
-last_tested: "2026-06-18"
-last_diagram_reviewed: "2026-06-17"
-schema_type: "TechArticle"
-primary_question: "How do traces, spans, sessions, users, and evals relate in FutureAGI Observe?"
-direct_answer: "Observe is built on a hierarchy: a span is one operation, spans sharing a trace ID form a trace (one request), traces sharing a session ID form a session, and sessions belong to a user. Eval scores attach to spans or traces. All of it is captured as OpenTelemetry data via the traceAI SDK."
-seo:
-  title: "The FutureAGI Observe observability model"
-  description: "The entity hierarchy behind Observe — spans, traces, sessions, users, and eval scores — and how traceAI and OpenTelemetry collect it."
-  primary_keyword: "llm observability data model"
-  direct_answer: true
-geo:
-  answer_target: "How do traces, spans, sessions, and users relate in FutureAGI Observe?"
-  llm_summary: "Spans nest into traces by trace ID, traces group into sessions by session ID, sessions belong to users, and eval scores attach to spans or traces — all collected via traceAI over OpenTelemetry."
-canonical: "/docs/observe/concepts/observability-model"
-related:
-  - "/docs/observe/concepts/traces"
-  - "/docs/observe/concepts/spans"
-  - "/docs/observe/concepts/sessions"
-  - "https://opentelemetry.io/"
+description: "How spans, traces, sessions, and users fit together into one hierarchy."
 ---
 
-## About
+## A few objects that nest
 
-Observe doesn't have one data type — it has a small set of objects that nest. Understanding how they relate is the difference between knowing *where* to look and guessing. A **span** is a single operation. Spans that share a trace ID make up a **trace** — one full request. Traces that share a session ID make up a **session** — one multi-turn conversation. Sessions belong to a **user**. And **eval scores** attach on top, to a span or a whole trace. Every view in Observe — the trace list, the span detail drawer, sessions, dashboards, alerts — is a different lens on this one hierarchy.
+Observe is built on a small set of objects that nest: a [span](/docs/observe/concepts/spans) sits inside a [trace](/docs/observe/concepts/traces), a trace inside a [session](/docs/observe/concepts/sessions), and a session belongs to a [user](/docs/observe/concepts/users). Eval scores attach on top, to a span or a whole trace. Knowing how these relate is the difference between knowing where to look and guessing: every view in Observe, from the trace list to dashboards and alerts, is a different lens on this one **hierarchy**.
 
-All of it is collected the same way: your app emits spans through the [traceAI](/docs/observe/concepts/traceai) SDK, which is built on [OpenTelemetry](https://opentelemetry.io/), and Observe reads them.
-
----
+All of it is collected the same way: your app emits spans through the [traceAI](/docs/observe/concepts/traceai) SDK, built on [OpenTelemetry](https://opentelemetry.io/), and Observe reads them.
 
 ## Mental model
 
-The objects form a strict containment hierarchy. The ID on each span is what reconstructs it — you don't assemble traces or sessions by hand; shared IDs do that automatically.
+The objects form a strict containment hierarchy, and the ID on each span is what reconstructs it. You don't assemble traces or sessions by hand; shared IDs do that automatically.
 
 <Mermaid chart={`flowchart TD
   accTitle: The Observe object hierarchy
@@ -56,93 +24,57 @@ The objects form a strict containment hierarchy. The ID on each span is what rec
   SP1 --> EV["Eval score"]
   T1 --> EV2["Eval score"]`} />
 
-Read it bottom-up when debugging (a bad span → which trace → which session → which user) and top-down when analyzing (a user's sessions → their traces → the spans inside).
-
----
+Read it bottom-up when debugging (a bad span, up to its trace, its session, its user) and top-down when analyzing (a user's sessions, down to their traces and the spans inside).
 
 ## Key terms
 
 | Object | What it is | Identified by | Learn more |
 |---|---|---|---|
-| **Span** | One operation — an LLM call, tool call, retrieval, or agent step — with input, output, timing, and cost. | Span ID (+ parent span ID) | [Spans](/docs/observe/concepts/spans) |
-| **Trace** | One complete request, made of all the spans that share its trace ID. | Trace ID | [Traces](/docs/observe/concepts/traces) |
-| **Session** | A multi-turn conversation — the traces that share a session ID. | `session.id` | [Sessions](/docs/observe/concepts/sessions) |
-| **User** | One end user, across all their sessions and traces. | `user.id` | [Users](/docs/observe/concepts/users) |
-| **Eval score** | A quality score attached to a span or trace. | Attached to span/trace | [Trace evals](/docs/observe/features/evals) |
-| **OpenTelemetry** | The open standard the spans are emitted in. | — | [OpenTelemetry](https://opentelemetry.io/) |
-| **traceAI** | The SDK that produces the spans. | — | [traceAI SDK](/docs/observe/concepts/traceai) |
+| **Span** | One operation: an LLM call, tool call, retrieval, or agent step, with input, output, timing, and cost | Span ID (+ parent span ID) | [Spans](/docs/observe/concepts/spans) |
+| **Trace** | One complete request, made of the spans that share its trace ID | Trace ID | [Traces](/docs/observe/concepts/traces) |
+| **Session** | A multi-turn conversation: the traces that share a session ID | `session.id` | [Sessions](/docs/observe/concepts/sessions) |
+| **User** | One end customer, across all their sessions and traces | `user.id` | [Users](/docs/observe/concepts/users) |
+| **Eval score** | A quality score attached to a span or a trace | On a span or trace | [Trace evals](/docs/observe/features/evals) |
+| **OpenTelemetry** | The open standard the spans are emitted in | The standard itself | [OpenTelemetry](https://opentelemetry.io/) |
+| **traceAI** | The SDK that produces the spans | The SDK itself | [traceAI SDK](/docs/observe/concepts/traceai) |
 
----
+## How it works
 
-## How it works in FutureAGI
+Your app emits spans through traceAI (or OpenTelemetry directly). Each span carries a trace ID, so all spans from one request form a single trace. The backend receives them over OTLP (HTTP or gRPC) and stores them by project, and from there every Observe view runs on the same data.
 
-Your app emits **spans** through traceAI (or OpenTelemetry directly). Each span carries a trace ID, so all spans from one request form a single **trace**. The backend receives them over OTLP (HTTP or gRPC) and stores them by project — and from there every Observe view runs on the same data.
-
-<Mermaid chart={`flowchart LR
-  accTitle: The tracing pipeline
-  accDescr: An application emits spans via traceAI or OpenTelemetry, exported over OTLP to the FutureAGI backend and shown in the Observe dashboard.
-  A["Your app"] -->|traceAI / OTel SDK| B["OTLP: HTTP or gRPC"]
-  B --> C["FutureAGI backend"]
-  C --> D["Observe dashboard"]`} />
-
-To enrich the hierarchy — set a `session.id`, a `user.id`, or [tags](/docs/observe/features/tags) — you attach those attributes in code. Wrap the traced work in the context managers and every span inside picks them up:
-
-<CodeGroup titles={["Python"]}>
-```python
-from fi_instrumentation import using_session, using_user
-
-with using_session("session_123"), using_user("user_456"):
-    response = run_agent(prompt)
-```
-</CodeGroup>
-
-For the full set of attributes, see [add attributes and metadata](/docs/traceai/manual-instrumentation/add-attributes-metadata-tags).
-
----
+To enrich the hierarchy, attach a `session.id` and a `user.id` in code, and every span inside picks them up. See [set session and user IDs](/docs/observe/features/manual-tracing/set-session-user-id) and [add attributes and metadata](/docs/observe/features/manual-tracing/add-attributes-metadata-tags).
 
 ## Walking the hierarchy when debugging
 
 The hierarchy is most useful read bottom-up. A typical investigation starts at the smallest object and climbs:
 
-1. **Start at the span.** A user complained the assistant gave a wrong answer. You open the span that produced it and read its real input and output — the exact prompt and the exact completion, not a paraphrase.
-2. **Climb to the trace.** The span alone rarely explains the failure. You move up to its trace and read the other spans in order — the retrieval that fed bad context, the tool call that returned stale data, the agent step that chose the wrong path. The trace is where the *request* becomes legible.
-3. **Climb to the session.** If the request looked fine in isolation but the conversation still went wrong, you open its session and read the earlier turns. Multi-turn problems — the assistant losing track, contradicting itself — only show up here.
-4. **Climb to the user.** Finally, if the pattern repeats, you pivot to the user to see whether it's one customer's data or a systemic issue across everyone.
+1. **Start at the span.** A customer complained the assistant gave a wrong answer. You open the span that produced it and read its real input and output: the exact prompt and completion, not a paraphrase.
+2. **Climb to the trace.** The span alone rarely explains the failure. You move up to its trace and read the other spans in order: the retrieval that fed bad context, the tool call that returned stale data, the agent step that chose the wrong path. The trace is where the request becomes legible.
+3. **Climb to the session.** If the request looked fine in isolation but the conversation still went wrong, you open its session and read the earlier turns. Multi-turn problems, like the assistant losing track or contradicting itself, only show up here.
+4. **Climb to the user.** If the pattern repeats, you pivot to the user to see whether it is one customer's data or a systemic issue across everyone.
 
-Because the IDs link each level to the next, every climb is one click — you never reassemble context by hand. The same path runs top-down for analysis: start at a user, expand their sessions, then traces, then the spans inside.
-
----
+Because the IDs link each level to the next, every climb is one click, and you never reassemble context by hand. The same path runs top-down for analysis: start at a user, expand their sessions, then traces, then the spans inside.
 
 ## When to use this model
 
-- **Debugging a bad answer** — start at the span that produced it, then read the rest of the trace for context.
-- **Analyzing a conversation** — open the session to see every turn in order.
-- **Investigating a user** — pivot from a user to all their sessions and traces.
-- **Measuring quality** — read eval scores attached at the span or trace level.
-
----
+- **Debugging a bad answer**: start at the span that produced it, then read the rest of the trace for context
+- **Analyzing a conversation**: open the session to see every turn in order
+- **Investigating a customer**: pivot from a user to all their sessions and traces
+- **Measuring quality**: read eval scores attached at the span or trace level
 
 ## Common mistakes
 
-- **Confusing a span with a trace** — a slow *trace* tells you a request was slow; the *span* tells you which step was slow. They are different levels. See [Spans](/docs/observe/concepts/spans).
-- **Expecting sessions without a session ID** — traces only group into a session if they share a `session.id`. Set it in code.
-- **Looking for users you never tagged** — per-user views need `user.id` on the spans.
+- **Confusing a span with a trace**: a slow trace tells you a request was slow; the span tells you which step was slow. See [Spans](/docs/observe/concepts/spans)
+- **Expecting sessions without a session ID**: traces only group into a session if they share a `session.id`. Set it in code
+- **Looking for customers you never tagged**: per-user views need `user.id` on the spans
 
----
-
-## Next steps
+## Keep exploring
 
 <CardGroup cols={2}>
-  <Card title="Traces" icon="diagram-project" href="/docs/observe/concepts/traces">
-    The top-level unit: one request, one trace.
+  <Card title="Quickstart" icon="play-circle" href="/docs/observe/quickstart">
+    Send a trace and watch the model fill in
   </Card>
-  <Card title="Spans" icon="bars-staggered" href="/docs/observe/concepts/spans">
-    The operations that make up every trace.
-  </Card>
-  <Card title="Sessions" icon="comments" href="/docs/observe/concepts/sessions">
-    Grouping traces by conversation and end user.
-  </Card>
-  <Card title="Quick start" icon="rocket" href="/docs/observe/quickstart">
-    Send a trace and watch the model fill in.
+  <Card title="Run evals on traces" icon="chart-line" href="/docs/observe/features/evals">
+    Score spans and traces for quality and safety
   </Card>
 </CardGroup>


### PR DESCRIPTION
## What this is
Revamps the **Observability model** concept page (the synthesis page for Observe) for full compliance with the docs review checklist and one-read clarity.

## Changes
- **Frontmatter** stripped to `title` + `description`; **all 22 em-dashes removed.**
- `## About` → descriptive `## A few objects that nest`; footer `Next steps` → **`Keep exploring`**.
- **One Mermaid** (removed the pipeline diagram); **removed the inline `using_session` code** (setup is a how-to → linked to the `manual-tracing` guides).
- Sibling concepts **linked on first mention** (were bolded); **fixed a dead `manual-tracing` link**; **forward-only cards** with valid `Card.astro` icons.
- **Shape-first opener** so the `span → trace → session → user` hierarchy lands in one read; each object defined once (in Key terms), not twice.

## Checklist
Concept (Explanation) page: minimal frontmatter, no "About", one Diátaxis mode, one Mermaid, forward "Keep exploring" cards, no em-dashes, all links + icons valid, grounded in code.

**Diátaxis:** Explanation · **depth** 4 · **ease** medium.


