### PR TITLE
docs: restructure self-hosting sidebar; add Production subsection and Support

### DIFF
--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -72,6 +72,7 @@ export const tabNavigation: NavTab[] = [
               {
                 title: 'Production',
                 items: [
+                  { title: 'Overview', href: '/docs/self-hosting/production' },
                   { title: 'Checklist', href: '/docs/self-hosting/production/checklist' },
                   { title: 'Security & TLS', href: '/docs/self-hosting/production/security-tls' },
                   { title: 'Backups & restore', href: '/docs/self-hosting/production/backups-restore' },

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -62,12 +62,25 @@ export const tabNavigation: NavTab[] = [
               { title: 'Overview', href: '/docs/self-hosting' },
               { title: 'Requirements', href: '/docs/self-hosting/requirements' },
               { title: 'Installation', href: '/docs/self-hosting/installation' },
-              { title: 'Environment variables', href: '/docs/self-hosting/environment' },
-              { title: 'Configuration', href: '/docs/self-hosting/configuration' },
-              { title: 'Docker Compose', href: '/docs/self-hosting/docker-compose' },
-              { title: 'Production', href: '/docs/self-hosting/production' },
-              { title: 'User management', href: '/docs/self-hosting/user-management' },
-              { title: 'Troubleshooting and FAQs', href: '/docs/self-hosting/troubleshooting' },
+              {
+                title: 'Configuration',
+                items: [
+                  { title: 'Environment variables', href: '/docs/self-hosting/environment' },
+                  { title: 'System configuration', href: '/docs/self-hosting/configuration' },
+                ]
+              },
+              {
+                title: 'Production',
+                items: [
+                  { title: 'Checklist', href: '/docs/self-hosting/production/checklist' },
+                  { title: 'Security & TLS', href: '/docs/self-hosting/production/security-tls' },
+                  { title: 'Backups & restore', href: '/docs/self-hosting/production/backups-restore' },
+                  { title: 'Monitoring', href: '/docs/self-hosting/production/monitoring' },
+                  { title: 'Upgrades & rollback', href: '/docs/self-hosting/production/upgrades-rollback' },
+                ]
+              },
+              { title: 'Troubleshooting & FAQs', href: '/docs/self-hosting/troubleshooting' },
+              { title: 'Support', href: '/docs/self-hosting/support' },
             ]
           },
         ]

--- a/src/pages/docs/self-hosting/production.mdx
+++ b/src/pages/docs/self-hosting/production.mdx
@@ -1,137 +1,28 @@
 ---
-title: "Production Hardening & Operations"
-description: "Production readiness checklist — replace secrets, configure TLS, set up managed data stores, run Postgres/ClickHouse/MinIO backups, and follow the upgrade runbook."
+title: "Production"
+description: "What to harden before a self-hosted Future AGI instance goes live"
 ---
 
-## About
+Everything past a local trial happens here. The default Docker Compose stack boots with placeholder secrets, no TLS, and compose-managed data stores. That's fine on a laptop. Before real traffic reaches the instance, work through the flow below in order, then keep each page as a runbook.
 
-Run through this before exposing the stack to real users. Covers secrets, TLS, swapping in managed data stores, backup commands for Postgres/ClickHouse/MinIO, Prometheus monitoring, and the upgrade and rollback runbook.
+## In this page
 
-## Hardening checklist
-
-**Secrets** — replace all `CHANGEME` values before going live:
-
-```bash
-openssl rand -hex 32    # SECRET_KEY, AGENTCC_INTERNAL_API_KEY
-openssl rand -base64 24 # PG_PASSWORD, MINIO_ROOT_PASSWORD
-```
-
-**Runtime flags** in `.env`:
-- `ENV_TYPE=prod`
-- `FAST_STARTUP=false`
-- `GRANIAN_WORKERS=<your CPU count>`
-
-**TLS** — the frontend and backend don't terminate TLS. Put Caddy, nginx, or Traefik in front:
-
-```
-# Caddyfile (simplest — auto-issues Let's Encrypt certs)
-app.yourcompany.com    { reverse_proxy localhost:3000 }
-api.yourcompany.com    { reverse_proxy localhost:8000 }
-```
-
-After setting up TLS, set `VITE_HOST_API=https://api.yourcompany.com` in `.env` and rebuild:
-
-```bash
-docker compose build frontend && docker compose up -d frontend
-```
-
-**Managed data stores** — for production, replace compose-managed services:
-
-| Replace | With | Change |
-|---|---|---|
-| `postgres` | RDS / Aurora / Cloud SQL | Set `PG_*` vars to managed endpoint |
-| `clickhouse` | ClickHouse Cloud | Set `CH_HOST`, `CH_PORT`, etc. |
-| `redis` | ElastiCache / Upstash | Set `REDIS_URL` |
-| `minio` | AWS S3 | Set `S3_ENDPOINT_URL=https://s3.amazonaws.com` + AWS creds |
-
-<Note>
-`code-executor` requires `privileged: true`. Run on EC2 / GCE instances — not Fargate or Cloud Run.
-</Note>
-
-**Secrets manager** — use AWS Secrets Manager, HashiCorp Vault, or GCP Secret Manager instead of a plain `.env` file.
-
----
-
-## Backups
-
-### PostgreSQL
-
-```bash
-# Backup
-docker compose exec postgres \
-  pg_dump -U futureagi -d futureagi --format=custom \
-  > backup-$(date +%F).dump
-
-# Restore
-docker compose exec -T postgres \
-  pg_restore -U futureagi -d futureagi --clean --if-exists \
-  < backup-2026-04-22.dump
-```
-
-Volumes: `future-agi_postgres-data` · `future-agi_clickhouse-data` · `future-agi_redis-data` · `future-agi_minio-data` · `future-agi_peerdb-catalog-data` · `future-agi_peerdb-minio-data`
-
-### ClickHouse
-
-```sql
-BACKUP TABLE default.traces TO S3('s3://your-bucket/ch-backup/', 'KEY', 'SECRET');
-```
-
-ClickHouse data can also be rebuilt from scratch by re-running PeerDB init since it replicates from Postgres.
-
-### MinIO
-
-```bash
-mc alias set local http://localhost:9005 futureagi <MINIO_ROOT_PASSWORD>
-mc alias set s3 https://s3.amazonaws.com <AWS_KEY> <AWS_SECRET>
-mc mirror local/ s3/your-bucket/
-```
-
----
-
-## Monitoring
-
-Backend exposes Prometheus metrics at `http://localhost:8000/metrics`. Add a scraper:
-
-```yaml
-# prometheus.yml
-scrape_configs:
-  - job_name: futureagi
-    static_configs:
-      - targets: ['localhost:8000']
-    metrics_path: /metrics
-```
-
-Key signals: backend error rate, Temporal workflow success/failure, Postgres WAL lag (PeerDB health), ClickHouse query latency, PeerDB mirror status at [localhost:3001](http://localhost:3001).
-
----
-
-## Upgrades
-
-```bash
-git pull
-docker compose build
-docker compose up -d
-```
-
-Migrations run automatically. If a migration fails: `docker compose exec backend python manage.py migrate`
-
-If release notes mention PeerDB changes: `docker compose run --rm peerdb-init bash /setup.sh`
-
-**Rollback:**
-
-```bash
-git log --oneline -5
-git checkout <previous-hash>
-docker compose build && docker compose up -d
-```
-
-## Next Steps
+Production readiness for a self-hosted instance breaks into five steps. Do them in order the first time.
 
 <CardGroup cols={2}>
-  <Card title="Troubleshooting" icon="wrench" href="/docs/self-hosting/troubleshooting">
-    Symptoms, causes, and fixes for common errors.
+  <Card title="Checklist" icon="list-check" href="/docs/self-hosting/production/checklist">
+    The go-live pass: secrets, prod runtime flags, and managed data stores
   </Card>
-  <Card title="System Configuration" icon="sliders" href="/docs/self-hosting/configuration">
-    Tune the LLM gateway, PeerDB mirrors, and Temporal workers.
+  <Card title="Security & TLS" icon="shield" href="/docs/self-hosting/production/security-tls">
+    Terminate TLS in front of the stack and lock down secrets
+  </Card>
+  <Card title="Backups & restore" icon="database" href="/docs/self-hosting/production/backups-restore">
+    Back up and restore Postgres, ClickHouse, and MinIO
+  </Card>
+  <Card title="Monitoring" icon="gauge" href="/docs/self-hosting/production/monitoring">
+    Scrape Prometheus metrics and watch the signals that matter
+  </Card>
+  <Card title="Upgrades & rollback" icon="arrows-rotate" href="/docs/self-hosting/production/upgrades-rollback">
+    Pull a release, run migrations, and roll back safely
   </Card>
 </CardGroup>

--- a/src/pages/docs/self-hosting/production.mdx
+++ b/src/pages/docs/self-hosting/production.mdx
@@ -7,7 +7,7 @@ Everything past a local trial happens here. The default Docker Compose stack boo
 
 ## In this page
 
-Production readiness for a self-hosted instance breaks into five steps. Do them in order the first time, then keep each page as a runbook.
+Production readiness for a self-hosted instance breaks into five steps. Do them in order the first time.
 
 **Before you go live**
 

--- a/src/pages/docs/self-hosting/production.mdx
+++ b/src/pages/docs/self-hosting/production.mdx
@@ -7,7 +7,9 @@ Everything past a local trial happens here. The default Docker Compose stack boo
 
 ## In this page
 
-Production readiness for a self-hosted instance breaks into five steps. Do them in order the first time.
+Production readiness for a self-hosted instance breaks into five steps. Do them in order the first time, then keep each page as a runbook.
+
+**Before you go live**
 
 <CardGroup cols={2}>
   <Card title="Checklist" icon="list-check" href="/docs/self-hosting/production/checklist">
@@ -16,11 +18,16 @@ Production readiness for a self-hosted instance breaks into five steps. Do them 
   <Card title="Security & TLS" icon="shield" href="/docs/self-hosting/production/security-tls">
     Terminate TLS in front of the stack and lock down secrets
   </Card>
+</CardGroup>
+
+**Operating it**
+
+<CardGroup cols={3}>
   <Card title="Backups & restore" icon="database" href="/docs/self-hosting/production/backups-restore">
     Back up and restore Postgres, ClickHouse, and MinIO
   </Card>
   <Card title="Monitoring" icon="gauge" href="/docs/self-hosting/production/monitoring">
-    Scrape Prometheus metrics and watch the signals that matter
+    Watch the health signals the stack actually exposes
   </Card>
   <Card title="Upgrades & rollback" icon="arrows-rotate" href="/docs/self-hosting/production/upgrades-rollback">
     Pull a release, run migrations, and roll back safely

--- a/src/pages/docs/self-hosting/production/backups-restore.mdx
+++ b/src/pages/docs/self-hosting/production/backups-restore.mdx
@@ -3,15 +3,15 @@ title: "Backups & restore"
 description: "Back up and restore the data stores behind a self-hosted instance"
 ---
 
-A self-hosted instance keeps state in four stores: Postgres for application data, ClickHouse for observability records, MinIO for object storage, and Redis for cache and queues. This page covers backing up and restoring the three that hold durable data. Redis is a cache and doesn't need a backup.
+A self-hosted instance keeps state in a few stores: Postgres for application data, ClickHouse for the observability records (spans and traces), and MinIO for object storage. Redis is a cache (sessions, locks, rate limits, pub/sub), so it rebuilds on its own and doesn't need a backup. RabbitMQ holds the task queue: losing it drops in-flight background jobs, so drain it before planned downtime rather than backing it up.
 
 ## Postgres
 
-Postgres holds the application data, so back it up on a schedule. Use the custom format so restores can run selectively:
+Postgres holds the application data, so back it up on a schedule. Use the custom format, and pass `-T` so `docker compose exec` doesn't allocate a TTY and mangle the binary dump:
 
 ```bash
 # Backup
-docker compose exec postgres \
+docker compose exec -T postgres \
   pg_dump -U futureagi -d futureagi --format=custom \
   > backup-$(date +%F).dump
 
@@ -21,28 +21,30 @@ docker compose exec -T postgres \
   < backup-2026-04-22.dump
 ```
 
-The Docker volumes that hold state:
+The named volumes that hold state. The compose project name is `futureagi`, so every volume is prefixed `futureagi_`:
 
 | Volume | Holds |
 |---|---|
-| `future-agi_postgres-data` | Postgres application data |
-| `future-agi_clickhouse-data` | ClickHouse records |
-| `future-agi_redis-data` | Redis cache |
-| `future-agi_minio-data` | MinIO objects |
-| `future-agi_peerdb-catalog-data` | PeerDB replication catalog |
-| `future-agi_peerdb-minio-data` | PeerDB staging objects |
+| `futureagi_postgres-data` | Postgres application data |
+| `futureagi_clickhouse-data` | ClickHouse spans and traces |
+| `futureagi_minio-data` | MinIO objects |
+| `futureagi_rabbitmq-data` | RabbitMQ task queue |
+| `futureagi_redis-data` | Redis cache (rebuildable) |
+| `futureagi_peerdb-catalog-data` | PeerDB replication catalog |
+| `futureagi_peerdb-minio-data` | PeerDB staging objects |
+| `futureagi_fi-collector-data` | fi-collector buffer |
 
 ## ClickHouse
 
-ClickHouse can back up straight to S3:
+ClickHouse is not just a replica anymore. Since the CH25 cutover (`CH25_DROP_LEGACY_CDC_CHAIN` defaults to `true`), the fi-collector writes `spans` straight to ClickHouse and Django dual-writes `traces`. PeerDB only rebuilds the tables it mirrors from Postgres, so if you lose ClickHouse the observability data does **not** come back from a PeerDB re-init. Back it up on its own:
 
 ```sql
-BACKUP TABLE default.traces TO S3('s3://your-bucket/ch-backup/', 'KEY', 'SECRET');
+BACKUP DATABASE default TO S3('s3://your-bucket/ch-backup/', 'KEY', 'SECRET');
 ```
 
-<Note>
-ClickHouse is a replica of Postgres data, streamed through PeerDB. If you lose it, rebuild it from scratch by re-running PeerDB init rather than restoring a backup. The steps are in [Upgrades & rollback](/docs/self-hosting/production/upgrades-rollback).
-</Note>
+<Warning>
+Don't rely on PeerDB init to rebuild ClickHouse. It restores the mirrored Postgres tables, not the `spans` the collector writes directly. ClickHouse needs a real backup on its own schedule.
+</Warning>
 
 ## MinIO
 
@@ -63,6 +65,6 @@ If you've already moved to [managed data stores](/docs/self-hosting/production/c
     Watch store health and replication lag
   </Card>
   <Card title="Upgrades & rollback" icon="arrows-rotate" href="/docs/self-hosting/production/upgrades-rollback">
-    Rebuild ClickHouse and roll back releases
+    Roll back releases without losing data
   </Card>
 </CardGroup>

--- a/src/pages/docs/self-hosting/production/backups-restore.mdx
+++ b/src/pages/docs/self-hosting/production/backups-restore.mdx
@@ -1,0 +1,68 @@
+---
+title: "Backups & restore"
+description: "Back up and restore the data stores behind a self-hosted instance"
+---
+
+A self-hosted instance keeps state in four stores: Postgres for application data, ClickHouse for observability records, MinIO for object storage, and Redis for cache and queues. This page covers backing up and restoring the three that hold durable data. Redis is a cache and doesn't need a backup.
+
+## Postgres
+
+Postgres holds the application data, so back it up on a schedule. Use the custom format so restores can run selectively:
+
+```bash
+# Backup
+docker compose exec postgres \
+  pg_dump -U futureagi -d futureagi --format=custom \
+  > backup-$(date +%F).dump
+
+# Restore
+docker compose exec -T postgres \
+  pg_restore -U futureagi -d futureagi --clean --if-exists \
+  < backup-2026-04-22.dump
+```
+
+The Docker volumes that hold state:
+
+| Volume | Holds |
+|---|---|
+| `future-agi_postgres-data` | Postgres application data |
+| `future-agi_clickhouse-data` | ClickHouse records |
+| `future-agi_redis-data` | Redis cache |
+| `future-agi_minio-data` | MinIO objects |
+| `future-agi_peerdb-catalog-data` | PeerDB replication catalog |
+| `future-agi_peerdb-minio-data` | PeerDB staging objects |
+
+## ClickHouse
+
+ClickHouse can back up straight to S3:
+
+```sql
+BACKUP TABLE default.traces TO S3('s3://your-bucket/ch-backup/', 'KEY', 'SECRET');
+```
+
+<Note>
+ClickHouse is a replica of Postgres data, streamed through PeerDB. If you lose it, rebuild it from scratch by re-running PeerDB init rather than restoring a backup. The steps are in [Upgrades & rollback](/docs/self-hosting/production/upgrades-rollback).
+</Note>
+
+## MinIO
+
+Mirror the MinIO bucket to S3 with the MinIO client:
+
+```bash
+mc alias set local http://localhost:9005 futureagi <MINIO_ROOT_PASSWORD>
+mc alias set s3 https://s3.amazonaws.com <AWS_KEY> <AWS_SECRET>
+mc mirror local/ s3/your-bucket/
+```
+
+If you've already moved to [managed data stores](/docs/self-hosting/production/checklist), your provider's own backup tooling replaces these commands.
+
+## Dive deeper
+
+<CardGroup cols={2}>
+  <Card title="Monitoring" icon="gauge" href="/docs/self-hosting/production/monitoring">
+    Watch store health and replication lag
+  </Card>
+  <Card title="Upgrades & rollback" icon="arrows-rotate" href="/docs/self-hosting/production/upgrades-rollback">
+    Rebuild ClickHouse and roll back releases
+  </Card>
+</CardGroup>

--- a/src/pages/docs/self-hosting/production/checklist.mdx
+++ b/src/pages/docs/self-hosting/production/checklist.mdx
@@ -1,0 +1,57 @@
+---
+title: "Checklist"
+description: "The go-live pass before a self-hosted instance takes real traffic"
+---
+
+Run through this once before the stack is reachable by anyone else. It covers the three things that separate a laptop trial from a real deployment: replacing the shipped secrets, switching the backend into production mode, and swapping compose-managed data stores for managed ones.
+
+## Replace the shipped secrets
+
+The stack boots with `CHANGEME` placeholders. Replace every one before the instance is reachable, and generate each value rather than making one up:
+
+```bash
+openssl rand -hex 32     # SECRET_KEY, AGENTCC_INTERNAL_API_KEY
+openssl rand -base64 24  # PG_PASSWORD, MINIO_ROOT_PASSWORD
+```
+
+<Warning>
+`PG_PASSWORD` and `MINIO_ROOT_PASSWORD` are written to their volumes on first boot only. Set them before your first `docker compose up`. Changing them after the volume exists locks you out. The full field list is in [Environment variables](/docs/self-hosting/environment).
+</Warning>
+
+## Switch the backend to production mode
+
+Set these runtime flags before going live:
+
+| Variable | Go-live value | Why |
+|---|---|---|
+| `ENV_TYPE` | `prod` | Disables debug output and runs Django `check --deploy` |
+| `FAST_STARTUP` | `false` | Always applies migrations on restart |
+| `GRANIAN_WORKERS` | your CPU count | One worker per core, up from the default `1` |
+
+To tune the gateway, PeerDB, and Temporal workers, see [System configuration](/docs/self-hosting/configuration).
+
+## Move to managed data stores
+
+Compose-managed Postgres, ClickHouse, Redis, and MinIO are fine for a trial. For production, point the stack at managed services so data outlives the containers:
+
+| Replace | With | Set |
+|---|---|---|
+| `postgres` | RDS, Aurora, or Cloud SQL | `PG_*` to the managed endpoint |
+| `clickhouse` | ClickHouse Cloud | `CH_HOST`, `CH_PORT`, and credentials |
+| `redis` | ElastiCache or Upstash | `REDIS_URL` |
+| `minio` | AWS S3 | `S3_ENDPOINT_URL` plus AWS credentials |
+
+<Note>
+`code-executor` needs `privileged: true`, so it can't run on ECS Fargate or Cloud Run. Put it on an EC2 or GCE instance. The platform matrix is in [Requirements](/docs/self-hosting/requirements).
+</Note>
+
+## Dive deeper
+
+<CardGroup cols={2}>
+  <Card title="Security & TLS" icon="shield" href="/docs/self-hosting/production/security-tls">
+    Put TLS in front of the stack and move secrets into a manager
+  </Card>
+  <Card title="Backups & restore" icon="database" href="/docs/self-hosting/production/backups-restore">
+    Set up backups before the instance holds real data
+  </Card>
+</CardGroup>

--- a/src/pages/docs/self-hosting/production/checklist.mdx
+++ b/src/pages/docs/self-hosting/production/checklist.mdx
@@ -3,19 +3,33 @@ title: "Checklist"
 description: "The go-live pass before a self-hosted instance takes real traffic"
 ---
 
-Run through this once before the stack is reachable by anyone else. It covers the three things that separate a laptop trial from a real deployment: replacing the shipped secrets, switching the backend into production mode, and swapping compose-managed data stores for managed ones.
+Run through this once before the stack is reachable by anyone else. Three things separate a laptop trial from a real deployment:
 
-## Replace the shipped secrets
+- Replace the dev-only secret defaults
+- Bring the stack up with the production overlay, so it refuses to boot until those secrets are set
+- Move the compose-managed data stores to managed services
 
-The stack boots with `CHANGEME` placeholders. Replace every one before the instance is reachable, and generate each value rather than making one up:
+## Replace the dev-only secrets
+
+The stack boots with dev-only placeholders baked into `docker-compose.yml`, values like `local-dev-only-not-for-production-replace-me`, and `futureagi` for the database passwords. It runs fine with them, which is the point on a laptop and the danger in production.
+
+What forces real secrets is the production overlay, `deploy/docker-compose.production.yml`. It re-binds each one with `${VAR:?}`, so the stack won't start until you've set them. Bring the stack up with that overlay and set, at minimum:
+
+- `SECRET_KEY`
+- `AGENTCC_INTERNAL_API_KEY`
+- `AGENTCC_ADMIN_TOKEN`
+- `PG_PASSWORD`
+- `MINIO_ROOT_PASSWORD`
+- `RABBITMQ_USER` and `RABBITMQ_PASSWORD`
+- `FRONTEND_URL` and `VITE_HOST_API`
 
 ```bash
-openssl rand -hex 32     # SECRET_KEY, AGENTCC_INTERNAL_API_KEY
-openssl rand -base64 24  # PG_PASSWORD, MINIO_ROOT_PASSWORD
+openssl rand -hex 32     # SECRET_KEY, AGENTCC_INTERNAL_API_KEY, AGENTCC_ADMIN_TOKEN
+openssl rand -base64 24  # PG_PASSWORD, MINIO_ROOT_PASSWORD, RABBITMQ_PASSWORD
 ```
 
 <Warning>
-`PG_PASSWORD` and `MINIO_ROOT_PASSWORD` are written to their volumes on first boot only. Set them before your first `docker compose up`. Changing them after the volume exists locks you out. The full field list is in [Environment variables](/docs/self-hosting/environment).
+`PG_PASSWORD` is baked into the Postgres volume on the **first** boot, so set it before your first `docker compose up`. `MINIO_ROOT_PASSWORD` is read from the environment on every boot, so that one you can change and restart. The full field list is in [Environment variables](/docs/self-hosting/environment).
 </Warning>
 
 ## Switch the backend to production mode
@@ -28,21 +42,19 @@ Set these runtime flags before going live:
 | `FAST_STARTUP` | `false` | Always applies migrations on restart |
 | `GRANIAN_WORKERS` | your CPU count | One worker per core, up from the default `1` |
 
-To tune the gateway, PeerDB, and Temporal workers, see [System configuration](/docs/self-hosting/configuration).
-
 ## Move to managed data stores
 
-Compose-managed Postgres, ClickHouse, Redis, and MinIO are fine for a trial. For production, point the stack at managed services so data outlives the containers:
+Compose-managed Postgres, ClickHouse, Redis, and MinIO are fine for a trial. For production, point the stack at managed services. The catch: the backend reads these hosts from **hardcoded values in the `backend` env block of `docker-compose.yml`** (`PG_HOST: postgres`, `CH_HOST: clickhouse`, `REDIS_URL: redis://redis:6379/0`, `S3_ENDPOINT_URL: http://minio:9000`), not from `.env`. Setting them in `.env` does nothing. You edit the compose file.
 
-| Replace | With | Set |
+| Replace | With | Edit in `docker-compose.yml` |
 |---|---|---|
-| `postgres` | RDS, Aurora, or Cloud SQL | `PG_*` to the managed endpoint |
-| `clickhouse` | ClickHouse Cloud | `CH_HOST`, `CH_PORT`, and credentials |
+| `postgres` | RDS, Aurora, or Cloud SQL | `PG_HOST` / `PG_PORT` to the managed endpoint |
+| `clickhouse` | ClickHouse Cloud | `CH_HOST` / `CH_PORT` and the credentials |
 | `redis` | ElastiCache or Upstash | `REDIS_URL` |
-| `minio` | AWS S3 | `S3_ENDPOINT_URL` plus AWS credentials |
+| `minio` | AWS S3 | `STORAGE_BACKEND: s3` and the S3 credentials |
 
 <Note>
-`code-executor` needs `privileged: true`, so it can't run on ECS Fargate or Cloud Run. Put it on an EC2 or GCE instance. The platform matrix is in [Requirements](/docs/self-hosting/requirements).
+`code-executor` runs with `privileged: true`, so it can't run on ECS Fargate or Cloud Run. Put it on an EC2 or GCE instance. The platform matrix is in [Requirements](/docs/self-hosting/requirements).
 </Note>
 
 ## Dive deeper

--- a/src/pages/docs/self-hosting/production/monitoring.mdx
+++ b/src/pages/docs/self-hosting/production/monitoring.mdx
@@ -1,0 +1,46 @@
+---
+title: "Monitoring"
+description: "Scrape a self-hosted instance and watch the signals that predict trouble"
+---
+
+The backend exposes Prometheus metrics, so any Prometheus-compatible stack can scrape it. This page covers wiring up the scrape and the handful of signals worth alerting on.
+
+## Scrape the backend
+
+The backend serves Prometheus metrics at `http://localhost:8000/metrics`. Add it as a scrape target:
+
+```yaml
+# prometheus.yml
+scrape_configs:
+  - job_name: futureagi
+    static_configs:
+      - targets: ['localhost:8000']
+    metrics_path: /metrics
+```
+
+## Watch these signals
+
+| Signal | Why it matters |
+|---|---|
+| Backend error rate | The first sign a release or dependency broke |
+| Temporal workflow success and failure | Failing workflows mean evals and background jobs are stuck |
+| Postgres WAL lag | Rising lag means PeerDB replication is falling behind |
+| ClickHouse query latency | Slow queries surface as a slow dashboard |
+| PeerDB mirror status | The health of the Postgres to ClickHouse pipeline |
+
+PeerDB has its own console at [localhost:3001](http://localhost:3001) for mirror status and throughput.
+
+<Note>
+Postgres WAL lag and PeerDB mirror status are the two to page on first. When ClickHouse drifts from Postgres, dashboards read stale before anything visibly breaks.
+</Note>
+
+## Dive deeper
+
+<CardGroup cols={2}>
+  <Card title="Upgrades & rollback" icon="arrows-rotate" href="/docs/self-hosting/production/upgrades-rollback">
+    Keep the stack current without downtime
+  </Card>
+  <Card title="Troubleshooting & FAQs" icon="wrench" href="/docs/self-hosting/troubleshooting">
+    Symptoms, causes, and fixes for common errors
+  </Card>
+</CardGroup>

--- a/src/pages/docs/self-hosting/production/monitoring.mdx
+++ b/src/pages/docs/self-hosting/production/monitoring.mdx
@@ -1,37 +1,35 @@
 ---
 title: "Monitoring"
-description: "Scrape a self-hosted instance and watch the signals that predict trouble"
+description: "Watch a self-hosted instance with the health signals it actually exposes"
 ---
 
-The backend exposes Prometheus metrics, so any Prometheus-compatible stack can scrape it. This page covers wiring up the scrape and the handful of signals worth alerting on.
+The stack has no Prometheus `/metrics` endpoint yet (the fi-collector lists a metrics exporter as a TODO), so monitoring today is built from what the containers already expose: their Docker health checks, the fi-collector's admin health endpoint, and the PeerDB console. This page covers those and the signals worth watching.
 
-## Scrape the backend
+## Container health
 
-The backend serves Prometheus metrics at `http://localhost:8000/metrics`. Add it as a scrape target:
+Every service ships a Docker health check, so `docker compose ps` is the fastest read on what's up:
 
-```yaml
-# prometheus.yml
-scrape_configs:
-  - job_name: futureagi
-    static_configs:
-      - targets: ['localhost:8000']
-    metrics_path: /metrics
+```bash
+docker compose ps        # STATUS shows healthy / unhealthy per service
+docker stats             # live CPU and memory per container
 ```
 
-## Watch these signals
+Watch memory on `clickhouse` and the Temporal `worker` first. They're the resource drivers, and an OOM there is the most common cause of a stall.
 
-| Signal | Why it matters |
-|---|---|
-| Backend error rate | The first sign a release or dependency broke |
-| Temporal workflow success and failure | Failing workflows mean evals and background jobs are stuck |
-| Postgres WAL lag | Rising lag means PeerDB replication is falling behind |
-| ClickHouse query latency | Slow queries surface as a slow dashboard |
-| PeerDB mirror status | The health of the Postgres to ClickHouse pipeline |
+## fi-collector health
 
-PeerDB has its own console at [localhost:3001](http://localhost:3001) for mirror status and throughput.
+The fi-collector exposes an admin endpoint on `127.0.0.1:9464` (`FI_COLLECTOR_ADMIN_PORT`), which serves a health check. Hit it to confirm the collector is up and accepting spans:
+
+```bash
+curl -s http://localhost:9464/healthz
+```
+
+## PeerDB replication
+
+The Postgres-to-ClickHouse pipeline has its own console at [localhost:3001](http://localhost:3001). Mirror status there tells you whether trace analytics are keeping up with Postgres. A mirror in anything other than `running` means the dashboard is reading stale.
 
 <Note>
-Postgres WAL lag and PeerDB mirror status are the two to page on first. When ClickHouse drifts from Postgres, dashboards read stale before anything visibly breaks.
+A Prometheus metrics exporter is on the fi-collector roadmap. When it lands, scrape it here. Until then, the checks above are what the stack actually exposes.
 </Note>
 
 ## Dive deeper

--- a/src/pages/docs/self-hosting/production/monitoring.mdx
+++ b/src/pages/docs/self-hosting/production/monitoring.mdx
@@ -18,7 +18,7 @@ Watch memory on `clickhouse` and the Temporal `worker` first. They're the resour
 
 ## fi-collector health
 
-The fi-collector exposes an admin endpoint on `127.0.0.1:9464` (`FI_COLLECTOR_ADMIN_PORT`), which serves a health check. Hit it to confirm the collector is up and accepting spans:
+The fi-collector exposes an admin endpoint on `127.0.0.1:9464` (`FI_COLLECTOR_ADMIN_PORT`), which serves a health check. Hit it to confirm the collector is up:
 
 ```bash
 curl -s http://localhost:9464/healthz

--- a/src/pages/docs/self-hosting/production/monitoring.mdx
+++ b/src/pages/docs/self-hosting/production/monitoring.mdx
@@ -7,7 +7,7 @@ The stack has no Prometheus `/metrics` endpoint yet (the fi-collector lists a me
 
 ## Container health
 
-Every service ships a Docker health check, so `docker compose ps` is the fastest read on what's up:
+The data stores (Postgres, ClickHouse, Redis, RabbitMQ, MinIO, Temporal) ship Docker health checks; the application services just show `running`. Either way, `docker compose ps` is the fastest read on what's up:
 
 ```bash
 docker compose ps        # STATUS shows healthy / unhealthy per service

--- a/src/pages/docs/self-hosting/production/security-tls.mdx
+++ b/src/pages/docs/self-hosting/production/security-tls.mdx
@@ -41,7 +41,7 @@ For anything past a single trial host, store secrets in a dedicated manager inst
 - HashiCorp Vault
 - GCP Secret Manager
 
-Rotate the `CHANGEME` values from the [Checklist](/docs/self-hosting/production/checklist) first, then move them into the manager and inject them at deploy time.
+Rotate the dev-only default secrets from the [Checklist](/docs/self-hosting/production/checklist) first, then move them into the manager and inject them at deploy time.
 
 ## Isolate the code executor
 

--- a/src/pages/docs/self-hosting/production/security-tls.mdx
+++ b/src/pages/docs/self-hosting/production/security-tls.mdx
@@ -20,17 +20,17 @@ api.yourcompany.com  { reverse_proxy localhost:8000 }
     Point the proxy at the frontend on `localhost:3000` and the backend on `localhost:8000`. The full port list is in [Requirements](/docs/self-hosting/requirements#ports-reference).
   </Step>
   <Step title="Point the frontend at HTTPS">
-    Set `VITE_HOST_API=https://api.yourcompany.com` in `.env`. This is a build-time value, so the frontend has to be rebuilt for it to take effect.
+    Set `VITE_HOST_API=https://api.yourcompany.com` in `.env`. The frontend container reads it on start and writes it into `config.js`, so no rebuild is needed.
   </Step>
-  <Step title="Rebuild the frontend">
+  <Step title="Restart the frontend">
     ```bash
-    docker compose build frontend && docker compose up -d frontend
+    docker compose up -d frontend
     ```
   </Step>
 </Steps>
 
 <Warning>
-`VITE_HOST_API` is baked in at build time, not read at runtime. If the browser still calls the old host after you change it, the frontend wasn't rebuilt.
+`VITE_HOST_API` is applied when the frontend container starts, not at build time. If the browser still calls the old host after you change it, the container wasn't recreated: rerun `docker compose up -d frontend`.
 </Warning>
 
 ## Keep secrets out of the compose file

--- a/src/pages/docs/self-hosting/production/security-tls.mdx
+++ b/src/pages/docs/self-hosting/production/security-tls.mdx
@@ -1,0 +1,59 @@
+---
+title: "Security & TLS"
+description: "Terminate TLS in front of a self-hosted instance and lock down its secrets"
+---
+
+Neither the frontend nor the backend terminates TLS. In production you put a reverse proxy in front of the stack to handle certificates, then point the frontend at the HTTPS endpoint. This page covers both, plus where production secrets should live.
+
+## Terminate TLS with a reverse proxy
+
+Run Caddy, nginx, or Traefik in front of the stack. Caddy is the shortest path because it issues and renews Let's Encrypt certificates on its own:
+
+```
+# Caddyfile
+app.yourcompany.com  { reverse_proxy localhost:3000 }
+api.yourcompany.com  { reverse_proxy localhost:8000 }
+```
+
+<Steps>
+  <Step title="Put the proxy in front">
+    Point the proxy at the frontend on `localhost:3000` and the backend on `localhost:8000`. The full port list is in [Requirements](/docs/self-hosting/requirements#ports-reference).
+  </Step>
+  <Step title="Point the frontend at HTTPS">
+    Set `VITE_HOST_API=https://api.yourcompany.com` in `.env`. This is a build-time value, so the frontend has to be rebuilt for it to take effect.
+  </Step>
+  <Step title="Rebuild the frontend">
+    ```bash
+    docker compose build frontend && docker compose up -d frontend
+    ```
+  </Step>
+</Steps>
+
+<Warning>
+`VITE_HOST_API` is baked in at build time, not read at runtime. If the browser still calls the old host after you change it, the frontend wasn't rebuilt.
+</Warning>
+
+## Keep secrets out of the compose file
+
+For anything past a single trial host, store secrets in a dedicated manager instead of a plain `.env`:
+
+- AWS Secrets Manager
+- HashiCorp Vault
+- GCP Secret Manager
+
+Rotate the `CHANGEME` values from the [Checklist](/docs/self-hosting/production/checklist) first, then move them into the manager and inject them at deploy time.
+
+## Isolate the code executor
+
+`code-executor` runs with `privileged: true` so it can sandbox evaluation code. Keep it on a host you control, an EC2 or GCE instance, never a managed-container platform that can't grant that flag.
+
+## Dive deeper
+
+<CardGroup cols={2}>
+  <Card title="Backups & restore" icon="database" href="/docs/self-hosting/production/backups-restore">
+    Protect the data behind the proxy
+  </Card>
+  <Card title="System configuration" icon="gear" href="/docs/self-hosting/configuration">
+    Tune the gateway, PeerDB, and Temporal workers
+  </Card>
+</CardGroup>

--- a/src/pages/docs/self-hosting/production/upgrades-rollback.mdx
+++ b/src/pages/docs/self-hosting/production/upgrades-rollback.mdx
@@ -22,15 +22,15 @@ Upgrades are a git pull and a rebuild, and migrations run automatically on boot.
     ```
   </Step>
   <Step title="Re-run PeerDB init if the release notes say so">
-    When a release changes the replication setup, re-run init so ClickHouse stays in sync:
+    When a release changes which Postgres tables are mirrored, re-run init. The container's entrypoint is already `bash /setup.sh`, so no arguments are needed:
     ```bash
-    docker compose run --rm peerdb-init bash /setup.sh
+    docker compose run --rm peerdb-init
     ```
   </Step>
 </Steps>
 
 <Note>
-Because ClickHouse replicates from Postgres through PeerDB, re-running PeerDB init also rebuilds ClickHouse from scratch. That's the recovery path when the [ClickHouse store](/docs/self-hosting/production/backups-restore) is lost.
+PeerDB init only rebuilds the tables it mirrors from Postgres. It does **not** restore the `spans` the fi-collector writes straight to ClickHouse, so it is not a recovery path for lost ClickHouse data. For that, restore from a [ClickHouse backup](/docs/self-hosting/production/backups-restore).
 </Note>
 
 ## Roll back a bad release

--- a/src/pages/docs/self-hosting/production/upgrades-rollback.mdx
+++ b/src/pages/docs/self-hosting/production/upgrades-rollback.mdx
@@ -1,0 +1,59 @@
+---
+title: "Upgrades & rollback"
+description: "Pull a new release, run migrations, and roll back when one goes wrong"
+---
+
+Upgrades are a git pull and a rebuild, and migrations run automatically on boot. This page covers the routine upgrade, the two cases that need a manual step, and how to roll back.
+
+## Upgrade to a new release
+
+<Steps>
+  <Step title="Pull and rebuild">
+    ```bash
+    git pull
+    docker compose build
+    docker compose up -d
+    ```
+  </Step>
+  <Step title="Let migrations run">
+    Database migrations run automatically on backend startup. If one fails, run it by hand:
+    ```bash
+    docker compose exec backend python manage.py migrate
+    ```
+  </Step>
+  <Step title="Re-run PeerDB init if the release notes say so">
+    When a release changes the replication setup, re-run init so ClickHouse stays in sync:
+    ```bash
+    docker compose run --rm peerdb-init bash /setup.sh
+    ```
+  </Step>
+</Steps>
+
+<Note>
+Because ClickHouse replicates from Postgres through PeerDB, re-running PeerDB init also rebuilds ClickHouse from scratch. That's the recovery path when the [ClickHouse store](/docs/self-hosting/production/backups-restore) is lost.
+</Note>
+
+## Roll back a bad release
+
+Roll back to the previous commit and rebuild:
+
+```bash
+git log --oneline -5
+git checkout <previous-hash>
+docker compose build && docker compose up -d
+```
+
+<Warning>
+Checking out older code does not undo a migration that already ran. If a release applied a migration you need to reverse, roll it back before you switch code, or restore Postgres from a backup.
+</Warning>
+
+## Dive deeper
+
+<CardGroup cols={2}>
+  <Card title="Troubleshooting & FAQs" icon="wrench" href="/docs/self-hosting/troubleshooting">
+    Symptoms, causes, and fixes for common errors
+  </Card>
+  <Card title="Support" icon="comments" href="/docs/self-hosting/support">
+    Where to get help when you're stuck
+  </Card>
+</CardGroup>

--- a/src/pages/docs/self-hosting/support.mdx
+++ b/src/pages/docs/self-hosting/support.mdx
@@ -8,7 +8,7 @@ Running the open-source stack and hit something these pages don't cover? Here's 
 ## Where to get help
 
 <CardGroup cols={2}>
-  <Card title="Discord" icon="comments" href="https://discord.gg/QDVvTgA8Xp">
+  <Card title="Discord" icon="comments" href="https://discord.com/invite/n2tCUKBkAw">
     Ask the community and the team in the Future AGI Discord
   </Card>
   <Card title="GitHub issues" icon="github" href="https://github.com/future-agi/future-agi/issues">
@@ -30,14 +30,3 @@ Most self-hosting questions are already answered in [Troubleshooting & FAQs](/do
 ## Commercial support
 
 For managed hosting, an SLA, or help with a production rollout, reach out at [sales@futureagi.com](mailto:sales@futureagi.com).
-
-## Dive deeper
-
-<CardGroup cols={2}>
-  <Card title="Troubleshooting & FAQs" icon="wrench" href="/docs/self-hosting/troubleshooting">
-    Symptoms, causes, and fixes for common errors
-  </Card>
-  <Card title="Production" icon="shield" href="/docs/self-hosting/production">
-    Harden the instance before it goes live
-  </Card>
-</CardGroup>

--- a/src/pages/docs/self-hosting/support.mdx
+++ b/src/pages/docs/self-hosting/support.mdx
@@ -1,0 +1,43 @@
+---
+title: "Support"
+description: "Where to get help running a self-hosted Future AGI instance"
+---
+
+Running the open-source stack and hit something these pages don't cover? Here's where to reach the team and the community, and what to include so you get a useful answer fast.
+
+## Where to get help
+
+<CardGroup cols={2}>
+  <Card title="Discord" icon="comments" href="https://discord.gg/QDVvTgA8Xp">
+    Ask the community and the team in the Future AGI Discord
+  </Card>
+  <Card title="GitHub issues" icon="github" href="https://github.com/future-agi/future-agi/issues">
+    Report a bug or request a feature on the open-source repo
+  </Card>
+</CardGroup>
+
+## Before you post
+
+A self-hosting question is easier to answer with the basics attached:
+
+- What you ran and what happened, with the exact error
+- Output of `docker compose ps` so the team can see which service is down
+- Logs from the failing service: `docker compose logs <service> --tail=100`
+- Your platform (Linux host, EC2, GCE) and whether you're on managed data stores
+
+Most self-hosting questions are already answered in [Troubleshooting & FAQs](/docs/self-hosting/troubleshooting). Check there first.
+
+## Commercial support
+
+For managed hosting, an SLA, or help with a production rollout, reach out at [sales@futureagi.com](mailto:sales@futureagi.com).
+
+## Dive deeper
+
+<CardGroup cols={2}>
+  <Card title="Troubleshooting & FAQs" icon="wrench" href="/docs/self-hosting/troubleshooting">
+    Symptoms, causes, and fixes for common errors
+  </Card>
+  <Card title="Production" icon="shield" href="/docs/self-hosting/production">
+    Harden the instance before it goes live
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## What

Restructures the self-hosting sidebar to the agreed tree, and fills in the pages that were missing behind it: the Production subsection (5 pages) and Support.

## Sidebar (navigation.ts)

Self-Hosting → Overview · Requirements · Install · Configuration{Environment variables, System configuration} · Production{Checklist, Security & TLS, Backups & restore, Monitoring, Upgrades & rollback} · Troubleshooting & FAQs · Support

Dropped the flat `User management` entry from the sidebar (page left in place).

## Pages added

- `production/checklist.mdx` — go-live pass: secrets, prod runtime flags, managed data stores
- `production/security-tls.mdx` — reverse-proxy TLS termination and secret handling
- `production/backups-restore.mdx` — Postgres, ClickHouse, MinIO backup and restore
- `production/monitoring.mdx` — Prometheus scrape and the signals to watch
- `production/upgrades-rollback.mdx` — upgrade flow, migrations, and rollback
- `support.mdx` — Discord, GitHub issues, commercial contact

`production.mdx` is slimmed from the flat page into a short overview that routes into the subsection.

## Scope / coordination

This PR owns only the sidebar + Production + Support. The rest of the tree is handled by in-flight PRs and is untouched here: env/system (#704, #695), Requirements (#696), Install (#697). When #704/#695 land the nested Configuration paths, the two Configuration child hrefs repoint from `/environment` and `/configuration` to the nested paths.

## Self-review (against review-docs-like-khushal.md)

- Diataxis: How-to · Depth: 3 · scannable operational runbooks
- No em-dashes; trailing periods dropped in table cells and card bodies; `<TLDR>` / `<Warning>` / `<Note>` used for their real purposes; `## Dive deeper` footers; forward-flowing cards; valid Card icons only
- Rendered locally on :4321 — every page returns 200, the sidebar matches the tree, zero 404s

## Preview

```
npm run dev
```

Then visit `/docs/self-hosting/production` and the five subpages.

TH-6391
