### PR TITLE
docs(observe): clean up redundant Troubleshooting sidebar labels

### DIFF
--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -388,8 +388,8 @@ export const tabNavigation: NavTab[] = [
             title: 'Troubleshooting',
             items: [
               { title: 'No traces appear', href: '/docs/observe/troubleshooting/no-traces-appearing' },
-              { title: 'Spans and attributes', href: '/docs/observe/troubleshooting/missing-attributes' },
-              { title: 'Dashboard numbers', href: '/docs/observe/troubleshooting/dashboard-numbers-look-wrong' },
+              { title: 'Missing spans or fields', href: '/docs/observe/troubleshooting/missing-attributes' },
+              { title: 'Dashboard numbers look wrong', href: '/docs/observe/troubleshooting/dashboard-numbers-look-wrong' },
               { title: 'Alerts not firing', href: '/docs/observe/troubleshooting/alerts-did-not-fire' },
             ]
           },

--- a/src/pages/docs/observe/troubleshooting/dashboard-numbers-look-wrong.mdx
+++ b/src/pages/docs/observe/troubleshooting/dashboard-numbers-look-wrong.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Dashboard numbers"
+title: "Dashboard numbers look wrong"
 description: "A dashboard widget shows a number you didn't expect. Almost always it's the time range, granularity, aggregation, filters, or sampling — not bad data."
 slug: "dashboard-numbers-look-wrong"
 page_type: "troubleshooting"

--- a/src/pages/docs/observe/troubleshooting/missing-attributes.mdx
+++ b/src/pages/docs/observe/troubleshooting/missing-attributes.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Spans and attributes"
+title: "Missing spans or fields"
 description: "The trace appears but spans are missing or fields like input/output are blank. Usual causes: masking is on, the instrumentor isn't attached, or a custom key isn't indexed."
 slug: "missing-attributes"
 page_type: "troubleshooting"


### PR DESCRIPTION
## What this is
Cleans up the redundant **Observe → Troubleshooting** sidebar labels. The entries read as overlapping ("No traces appear" vs "Spans and attributes" both sound like *"my data isn't showing"*), so this renames the two vague ones into distinct symptoms.

## Changes
- Sidebar label **"Spans and attributes" → "Missing spans or fields"** (the *trace shows but parts are blank* case)
- Sidebar label **"Dashboard numbers" → "Dashboard numbers look wrong"** (an actual symptom)
- Synced each page's frontmatter `title` to its sidebar item (guide §7)

Troubleshooting now reads as four distinct symptoms: **No traces appear · Missing spans or fields · Dashboard numbers look wrong · Alerts not firing.**

## Scope
Labels + title-sync only. Content, images, and other sections are untouched.

