### PR TITLE
docs(observe): Reference + Troubleshooting audit — dead-link fixes + findings

### DIFF
--- a/src/pages/docs/observe/reference/export-formats.mdx
+++ b/src/pages/docs/observe/reference/export-formats.mdx
@@ -22,7 +22,7 @@ geo:
 canonical: "/docs/observe/reference/export-formats"
 related:
   - "/docs/observe/features/llm-tracing"
-  - "/docs/traceai/manual-instrumentation/set-up-tracing"
+  - "/docs/observe/features/manual-tracing/set-up-tracing"
   - "https://opentelemetry.io/docs/"
 ---
 
@@ -60,7 +60,7 @@ When unset, both variables default to the FutureAGI cloud collector, so a cloud 
 - **Cloud:** leave the defaults; set `FI_API_KEY` and `FI_SECRET_KEY`.
 - **Self-hosted:** point `FI_BASE_URL` / `FI_GRPC_URL` at your own collector host so spans stay in your network.
 
-Choose the transport with `transport=Transport.HTTP` (default) or `Transport.GRPC` in `register()`. See [Set up tracing](/docs/traceai/manual-instrumentation/set-up-tracing).
+Choose the transport with `transport=Transport.HTTP` (default) or `Transport.GRPC` in `register()`. See [Set up tracing](/docs/observe/features/manual-tracing/set-up-tracing).
 
 ### Endpoint contract
 
@@ -73,11 +73,11 @@ The ingestion endpoint is an **OTLP/traces** receiver — you don't call it dire
 | Auth | `FI_API_KEY` + `FI_SECRET_KEY` from the [keys page](https://app.futureagi.com/dashboard/keys), sent by the SDK on every export. Keys are workspace-scoped. |
 | Success | The exporter batches spans and sends them in the background; a successful export returns no payload. Spans appear in Observe within seconds. |
 | Errors | A `401` means the keys are wrong for this workspace; a `4xx` means a malformed/oversized batch; transient `5xx`/network errors are retried by the batch exporter. |
-| Limits | Spans are sent by the **batch** span processor on an interval, so a short-lived process must call `trace_provider.force_flush()` before exit or the last batch is lost. Very large payloads (huge prompts/outputs) can be dropped — [mask or trim](/docs/traceai/manual-instrumentation/mask-span-attributes) them at the SDK. |
+| Limits | Spans are sent by the **batch** span processor on an interval, so a short-lived process must call `trace_provider.force_flush()` before exit or the last batch is lost. Very large payloads (huge prompts/outputs) can be dropped — [mask or trim](/docs/observe/features/manual-tracing/mask-span-attributes) them at the SDK. |
 | Versioning | Pin `fi-instrumentation-otel` and each instrumentor to a tested version so a release can't change span shape under you; the wire format follows the OTLP version the SDK ships. |
 
 <Warning>
-  Span input and output can carry customer data before they leave your process. Redact at the SDK with `TraceConfig` or the `FI_HIDE_*` variables — see [Mask span attributes](/docs/traceai/manual-instrumentation/mask-span-attributes).
+  Span input and output can carry customer data before they leave your process. Redact at the SDK with `TraceConfig` or the `FI_HIDE_*` variables — see [Mask span attributes](/docs/observe/features/manual-tracing/mask-span-attributes).
 </Warning>
 
 ## Related
@@ -86,7 +86,7 @@ The ingestion endpoint is an **OTLP/traces** receiver — you don't call it dire
   <Card title="Trace explorer" icon="magnifying-glass" href="/docs/observe/features/llm-tracing">
     Filter, then export the current view.
   </Card>
-  <Card title="Set up tracing" icon="gear" href="/docs/traceai/manual-instrumentation/set-up-tracing">
+  <Card title="Set up tracing" icon="gear" href="/docs/observe/features/manual-tracing/set-up-tracing">
     Configure the OTLP endpoint and transport.
   </Card>
 </CardGroup>

--- a/src/pages/docs/observe/troubleshooting/missing-attributes.mdx
+++ b/src/pages/docs/observe/troubleshooting/missing-attributes.mdx
@@ -26,8 +26,8 @@ geo:
 canonical: "/docs/observe/troubleshooting/missing-attributes"
 related:
   - "/docs/observe/features/llm-tracing"
-  - "/docs/traceai/manual-instrumentation/add-attributes-metadata-tags"
-  - "/docs/traceai/manual-instrumentation/mask-span-attributes"
+  - "/docs/observe/features/manual-tracing/add-attributes-metadata-tags"
+  - "/docs/observe/features/manual-tracing/mask-span-attributes"
   - "/docs/observe/concepts/spans"
 ---
 
@@ -50,16 +50,16 @@ The trace shows up, but it's incomplete — a nested span is missing, or fields 
 - Redaction is **off** for the fields you expect to see (`FI_HIDE_INPUTS` / `FI_HIDE_OUTPUTS` and `TraceConfig` masking).
 - The framework's instrumentor is installed and `instrument()` ran against the same tracer provider.
 - Custom attributes are set while the span is **still active**, before its `with` block closes.
-- Anything you filter on uses a [semantic-convention](/docs/traceai/manual-instrumentation/semantic-conventions) key with a supported value type.
+- Anything you filter on uses a [semantic-convention](/docs/observe/features/manual-tracing/semantic-conventions) key with a supported value type.
 
 ## Causes and fixes
 
 | Cause | What you see | Fix |
 |---|---|---|
-| Redaction is on (check first) | Input/output render as hidden or blank, but the span is otherwise complete | Confirm whether `FI_HIDE_INPUTS` / `FI_HIDE_OUTPUTS` or `TraceConfig` masking is set — if so, the blank is expected. See [Mask span attributes](/docs/traceai/manual-instrumentation/mask-span-attributes). |
+| Redaction is on (check first) | Input/output render as hidden or blank, but the span is otherwise complete | Confirm whether `FI_HIDE_INPUTS` / `FI_HIDE_OUTPUTS` or `TraceConfig` masking is set — if so, the blank is expected. See [Mask span attributes](/docs/observe/features/manual-tracing/mask-span-attributes). |
 | Instrumentor not attached for that framework | A framework's child spans (e.g. nested LangGraph nodes) never appear | Install and `instrument()` the instrumentor for the missing framework, attached to the provider. |
 | Attribute set on the wrong span / after close | A custom attribute you set isn't on the span | Set attributes while the span is active; a value set after the `with` block closes is dropped. |
-| Custom key isn't indexed for filtering | The attribute is on the span but you can't filter by it | Use a [semantic-convention](/docs/traceai/manual-instrumentation/semantic-conventions) key where one exists — the UI filters on standard keys. |
+| Custom key isn't indexed for filtering | The attribute is on the span but you can't filter by it | Use a [semantic-convention](/docs/observe/features/manual-tracing/semantic-conventions) key where one exists — the UI filters on standard keys. |
 | Unsupported value type | The attribute is silently dropped | Attribute values must be string, bool, int, float, or an array of those. |
 
 ## Diagnostic commands
@@ -95,10 +95,10 @@ If you're still stuck, contact support@futureagi.com with your `project_name`, t
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="Add attributes & metadata" icon="tags" href="/docs/traceai/manual-instrumentation/add-attributes-metadata-tags">
+  <Card title="Add attributes & metadata" icon="tags" href="/docs/observe/features/manual-tracing/add-attributes-metadata-tags">
     How attributes get onto spans.
   </Card>
-  <Card title="Mask span attributes" icon="eye-slash" href="/docs/traceai/manual-instrumentation/mask-span-attributes">
+  <Card title="Mask span attributes" icon="eye-slash" href="/docs/observe/features/manual-tracing/mask-span-attributes">
     Why a field might be intentionally hidden.
   </Card>
 </CardGroup>

--- a/src/pages/docs/observe/troubleshooting/no-traces-appearing.mdx
+++ b/src/pages/docs/observe/troubleshooting/no-traces-appearing.mdx
@@ -27,7 +27,7 @@ related:
   - "/docs/observe/quickstart"
   - "/docs/observe/features/llm-tracing"
   - "/docs/traceai/troubleshooting/spans-not-exported"
-  - "/docs/traceai/manual-instrumentation/set-up-tracing"
+  - "/docs/observe/features/manual-tracing/set-up-tracing"
 ---
 
 ## Symptom
@@ -92,7 +92,7 @@ Send one request, then open **Observe → your project → Tracing** with **Auto
 ## Prevent recurrence
 
 - Add `trace_provider.force_flush()` to short scripts and job runners.
-- Call `register()` + `instrument()` once at startup, before any client is built — see [Set up tracing](/docs/traceai/manual-instrumentation/set-up-tracing).
+- Call `register()` + `instrument()` once at startup, before any client is built — see [Set up tracing](/docs/observe/features/manual-tracing/set-up-tracing).
 - Keep `FI_API_KEY`, `FI_SECRET_KEY`, and `project_type` in your startup config so they can't drift per environment.
 
 If you're still stuck, collect your `project_name`, a request timestamp, your installed `fi-instrumentation-otel` and instrumentor versions, and any stderr, and contact support@futureagi.com.
@@ -103,7 +103,7 @@ If you're still stuck, collect your `project_name`, a request timestamp, your in
   <Card title="Observe quickstart" icon="rocket" href="/docs/observe/quickstart">
     Get a first trace flowing end to end.
   </Card>
-  <Card title="Set up tracing" icon="gear" href="/docs/traceai/manual-instrumentation/set-up-tracing">
+  <Card title="Set up tracing" icon="gear" href="/docs/observe/features/manual-tracing/set-up-tracing">
     The setup this page diagnoses.
   </Card>
   <Card title="Spans not exported" icon="bug" href="/docs/traceai/troubleshooting/spans-not-exported">


### PR DESCRIPTION
> **Draft — audit + safe fixes.** This documents a full broken-link / missing-image audit of the Observe **Reference** and **Troubleshooting** sections, and applies the fixes that are safe to make now. Screenshots and missing pages are Khushal's content gaps, documented below (not touched, per request).

## ✅ Fixed in this PR
Repointed 4 dead links from the old `/docs/traceai/manual-instrumentation/*` path (doesn't exist) to the live `/docs/observe/features/manual-tracing/*`:
- `set-up-tracing`, `mask-span-attributes`, `add-attributes-metadata-tags`, `semantic-conventions`
- Across: `reference/export-formats`, `troubleshooting/no-traces-appearing`, `troubleshooting/missing-attributes` (prose links, cards, and `related:` frontmatter)

## 🔴 Missing pages — need to be created (not repointable, no target exists)
| Missing page | Refs | Where |
|---|---|---|
| `observe/features/llm-tracing` (**Trace explorer**) | **11 refs / 5 pages** | filters, export-formats, no-traces-appearing, missing-attributes, dashboard-numbers-look-wrong |
| `traceai/troubleshooting/spans-not-exported` | 1 | no-traces-appearing |

## 🖼️ Missing images — screenshots needed (`public/images/docs/observe/`)
Only `llm-tracing-overview.webp` exists today. All 4 troubleshooting screenshots are absent:
| Filename | Page | Should show |
|---|---|---|
| `llm-tracing-date-range.webp` | No traces appear | trace-explorer date-range picker widened to Today, recent trace visible |
| `troubleshooting-missing-attributes.webp` | Missing spans or fields | ⚠️ current alt/caption describe the **wrong** scenario ("No traces found" empty list) — should show a trace that appears with a span's input/output **blank/hidden** |
| `troubleshooting-dashboard-numbers.webp` | Dashboard numbers look wrong | System Metrics dashboard (latency/tokens/traffic/cost) |
| `troubleshooting-alerts-not-firing.webp` | Alerts not firing | alerts list, an Active monitor with Last Triggered `-`, 0 triggers |

## 📝 Other findings (not changed here)
- `reference/export-formats`: uses a banned `## About` heading + heavy frontmatter (its sibling `filters.mdx` is minimal), and it's **orphaned** (not in the sidebar).
- `reference/filters`: **Node Type** and **Span Kind** are near-duplicate properties.
- `missing-attributes`: caption/alt need a rewrite once the correct screenshot lands (see above).
