### PR TITLE
docs(evaluation): SDK & API (reference)

### DIFF
--- a/src/pages/docs/evaluation/reference/sdk-api.mdx
+++ b/src/pages/docs/evaluation/reference/sdk-api.mdx
@@ -128,15 +128,15 @@ Inputs the metric needs (`output`, `context`, `expected_response`, and so on) ar
 
 <CardGroup cols={2}>
   <Card title="Evaluate via Platform & SDK" icon="play" href="/docs/evaluation/guides/running-evaluations">
-    Run your first eval from the UI or code.
+    Run your first eval from the UI or code
   </Card>
   <Card title="SDK evals reference" icon="code" href="/docs/sdk/evals">
-    The complete SDK eval documentation.
+    The complete SDK eval documentation
   </Card>
   <Card title="Output types & scoring" icon="shapes" href="/docs/evaluation/reference/output-types">
-    What the result fields mean and how scoring works.
+    What the result fields mean and how scoring works
   </Card>
   <Card title="Built-in evals" icon="list-check" href="/docs/evaluation/builtin">
-    Every template, its method, and required inputs.
+    Every template, its method, and required inputs
   </Card>
 </CardGroup>

--- a/src/pages/docs/evaluation/reference/sdk-api.mdx
+++ b/src/pages/docs/evaluation/reference/sdk-api.mdx
@@ -3,13 +3,11 @@ title: "SDK & API"
 description: "Run evaluations from code with the evaluate() function"
 ---
 
-## About
+## Evals from code
 
 Everything you can do with evals in the platform, you can also do from code. The `ai-evaluation` package gives you a single `evaluate()` function that runs a metric locally, in the cloud, or as an LLM judge, and returns a result you can assert on.
 
 This page is the reference for reaching evals programmatically. For the full SDK docs, see the [SDK evals section](/docs/sdk/evals).
-
----
 
 ## Install and authenticate
 
@@ -30,7 +28,7 @@ export FI_SECRET_KEY="your-secret-key"
 
 Find both under **Settings → API Keys** in the platform.
 
----
+The LLM-as-Judge engine doesn't use these keys: it goes through LiteLLM, which reads your model provider's standard environment variable (`OPENAI_API_KEY`, `GEMINI_API_KEY`, and so on).
 
 ## One function, three engines
 
@@ -38,21 +36,22 @@ Find both under **Settings → API Keys** in the platform.
 
 | You pass | Engine | Speed | Key needed |
 |---|---|---|---|
-| Metric name only | Local heuristic | `<`1ms | No |
+| Metric name only | Local heuristic | under 1ms | No |
 | Metric + `model="turing_flash"` | Cloud (Turing) | ~1–3s | `FI_API_KEY` + `FI_SECRET_KEY` |
 | `prompt=` + `engine="llm"` + `model=` | LLM-as-Judge | ~2–5s | Model provider key |
-| Metric + `model=` + `augment=True` | Local + LLM refinement | ~2–5s | Model provider key |
 
 Force an engine with `engine="local"`, `engine="turing"`, or `engine="llm"`.
 
+There's also a combined mode: a metric plus `model=` and `augment=True` runs the local heuristic first, then hands its score and reasoning to the LLM for refinement.
+
 ```python
-# Local metric — instant, no key
+# Local metric: instant, no key
 result = evaluate("contains", output="Hello world", keyword="Hello")
 
-# Cloud metric — needs credentials + model
+# Cloud metric: needs credentials + model
 result = evaluate("toxicity", output="You're doing great!", model="turing_flash")
 
-# LLM-as-Judge — custom criteria
+# LLM-as-Judge: custom criteria
 result = evaluate(
     prompt="Rate helpfulness from 0 to 1",
     output="Here are 3 steps to fix that...",
@@ -61,7 +60,7 @@ result = evaluate(
 )
 ```
 
----
+The Turing engine calls the same evaluation API the platform uses, so a template scored from code returns the same score you'd see in the platform.
 
 ## What a result contains
 
@@ -70,10 +69,15 @@ A single eval returns an `EvalResult`. A list of metrics returns one result per 
 | Field | Description |
 |---|---|
 | `eval_name` | The metric that produced this result |
-| `score` | The numeric result: `1.0` / `0.0`, or a `0`–`1` / `0`–`100` value depending on the metric |
+| `score` | The numeric result: `1.0` / `0.0` for pass/fail metrics, or a `0`–`1` value |
 | `passed` | The boolean verdict |
 | `reason` | Why the evaluator scored it that way |
 | `latency_ms` | How long the eval took |
+| `status` | "completed", or "error" when the run failed |
+| `error` | The error message when status is "error" |
+| `metadata` | Extra engine-specific detail about the run |
+
+When a metric returns only a score, `passed` derives from `score >= 0.5`.
 
 ```python
 print(result.score)    # 1.0
@@ -81,11 +85,16 @@ print(result.passed)   # True
 print(result.reason)   # "Keyword 'Hello' found"
 ```
 
+```python
+# Batch: several metrics in one call
+results = evaluate(["contains", "is_json"], output='{"greeting": "Hello"}', keyword="Hello")
+for r in results:
+    print(r.eval_name, r.passed)
+```
+
 <Warning>
   Don't mix local and cloud metrics in one batch call. If you pass `model="turing_flash"`, local metrics return `score=None`. Run them in separate calls.
 </Warning>
-
----
 
 ## Function signature
 
@@ -98,8 +107,8 @@ def evaluate(
     model: str | None = None,
     augment: bool | None = None,
     config: dict | None = None,
-    generate_prompt: bool = False,
     feedback_store: Any | None = None,
+    generate_prompt: bool = False,
     fi_api_key: str | None = None,
     fi_secret_key: str | None = None,
     fi_base_url: str | None = None,
@@ -109,32 +118,24 @@ def evaluate(
 
 Inputs the metric needs (`output`, `context`, `expected_response`, and so on) are passed as keyword arguments. The [Built-in evals reference](/docs/evaluation/builtin) lists the required inputs for each template.
 
----
+`generate_prompt=True` turns a short plain-English `prompt` into full grading criteria before the run; it needs a `model=`.
 
-## Where to go next in the SDK
+## Keep exploring
+
+The SDK reference in depth:
 
 | Page | What it covers |
 |---|---|
-| [Running Evaluations](/docs/sdk/evals/evaluate) | The full `evaluate()` reference: parameters, return types, batch runs |
+| [`evaluate()`](/docs/sdk/evals/evaluate) | The full `evaluate()` reference: parameters, return types, batch runs |
 | [Metrics Reference](/docs/sdk/evals/metrics) | Every local metric by category: string, JSON, similarity, hallucination, RAG, agents, guardrails |
 | [Cloud Evals](/docs/sdk/evals/cloud-evals) | 100+ pre-built Turing templates |
 | [LLM-as-Judge](/docs/sdk/evals/llm-judge) | Custom criteria with any LiteLLM model |
 | [Streaming](/docs/sdk/evals/streaming) | Score output token-by-token with early stopping |
 | [Distributed Evaluator](/docs/sdk/evals/distributed) | Run at scale with ThreadPool, Celery, Ray, or Temporal |
 
----
-
-## Next Steps
-
 <CardGroup cols={2}>
-  <Card title="Evaluate via Platform & SDK" icon="play" href="/docs/evaluation/guides/running-evaluations">
+  <Card title="Running Evaluations" icon="play" href="/docs/evaluation/guides/running-evaluations">
     Run your first eval from the UI or code
-  </Card>
-  <Card title="SDK evals reference" icon="code" href="/docs/sdk/evals">
-    The complete SDK eval documentation
-  </Card>
-  <Card title="Output types & scoring" icon="shapes" href="/docs/evaluation/reference/output-types">
-    What the result fields mean and how scoring works
   </Card>
   <Card title="Built-in evals" icon="list-check" href="/docs/evaluation/builtin">
     Every template, its method, and required inputs

--- a/src/pages/docs/evaluation/reference/sdk-api.mdx
+++ b/src/pages/docs/evaluation/reference/sdk-api.mdx
@@ -1,0 +1,142 @@
+---
+title: "SDK & API"
+description: "Run Future AGI evaluations from code: install, authenticate, the evaluate() entry point, engine routing, and the result fields you read back"
+---
+
+## About
+
+Everything you can do with evals in the platform, you can also do from code. The `ai-evaluation` package gives you a single `evaluate()` function that runs a metric locally, in the cloud, or as an LLM judge, and returns a result you can assert on.
+
+This page is the reference for reaching evals programmatically. For the full SDK docs, see the [SDK evals section](/docs/sdk/evals).
+
+---
+
+## Install and authenticate
+
+```bash
+pip install ai-evaluation
+```
+
+```python
+from fi.evals import evaluate
+```
+
+The 76+ local metrics run without an API key. Cloud evals and LLM-as-Judge need your Future AGI credentials:
+
+```bash
+export FI_API_KEY="your-api-key"
+export FI_SECRET_KEY="your-secret-key"
+```
+
+Find both under **Settings → API Keys** in the platform.
+
+---
+
+## One function, three engines
+
+`evaluate()` picks the engine from what you pass. You never call a different function to switch engines.
+
+| You pass | Engine | Speed | Key needed |
+|---|---|---|---|
+| Metric name only | Local heuristic | `<`1ms | No |
+| Metric + `model="turing_flash"` | Cloud (Turing) | ~1–3s | `FI_API_KEY` + `FI_SECRET_KEY` |
+| `prompt=` + `engine="llm"` + `model=` | LLM-as-Judge | ~2–5s | Model provider key |
+| Metric + `model=` + `augment=True` | Local + LLM refinement | ~2–5s | Model provider key |
+
+Force an engine with `engine="local"`, `engine="turing"`, or `engine="llm"`.
+
+```python
+# Local metric — instant, no key
+result = evaluate("contains", output="Hello world", keyword="Hello")
+
+# Cloud metric — needs credentials + model
+result = evaluate("toxicity", output="You're doing great!", model="turing_flash")
+
+# LLM-as-Judge — custom criteria
+result = evaluate(
+    prompt="Rate helpfulness from 0 to 1",
+    output="Here are 3 steps to fix that...",
+    engine="llm",
+    model="gemini/gemini-2.5-flash",
+)
+```
+
+---
+
+## What a result contains
+
+A single eval returns an `EvalResult`. A list of metrics returns one result per metric.
+
+| Field | Description |
+|---|---|
+| `eval_name` | The metric that produced this result |
+| `score` | The numeric result: `1.0` / `0.0`, or a `0`–`1` / `0`–`100` value depending on the metric |
+| `passed` | The boolean verdict |
+| `reason` | Why the evaluator scored it that way |
+| `latency_ms` | How long the eval took |
+
+```python
+print(result.score)    # 1.0
+print(result.passed)   # True
+print(result.reason)   # "Keyword 'Hello' found"
+```
+
+<Warning>
+  Don't mix local and cloud metrics in one batch call. If you pass `model="turing_flash"`, local metrics return `score=None`. Run them in separate calls.
+</Warning>
+
+---
+
+## Function signature
+
+```python
+def evaluate(
+    eval_name: str | list[str] | None = None,
+    *,
+    prompt: str | None = None,
+    engine: str | None = None,
+    model: str | None = None,
+    augment: bool | None = None,
+    config: dict | None = None,
+    generate_prompt: bool = False,
+    feedback_store: Any | None = None,
+    fi_api_key: str | None = None,
+    fi_secret_key: str | None = None,
+    fi_base_url: str | None = None,
+    **inputs,
+) -> EvalResult | BatchResult
+```
+
+Inputs the metric needs (`output`, `context`, `expected_response`, and so on) are passed as keyword arguments. The [Built-in evals reference](/docs/evaluation/builtin) lists the required inputs for each template.
+
+---
+
+## Where to go next in the SDK
+
+| Page | What it covers |
+|---|---|
+| [Running Evaluations](/docs/sdk/evals/evaluate) | The full `evaluate()` reference: parameters, return types, batch runs |
+| [Metrics Reference](/docs/sdk/evals/metrics) | Every local metric by category: string, JSON, similarity, hallucination, RAG, agents, guardrails |
+| [Cloud Evals](/docs/sdk/evals/cloud-evals) | 100+ pre-built Turing templates |
+| [LLM-as-Judge](/docs/sdk/evals/llm-judge) | Custom criteria with any LiteLLM model |
+| [Streaming](/docs/sdk/evals/streaming) | Score output token-by-token with early stopping |
+| [Distributed Evaluator](/docs/sdk/evals/distributed) | Run at scale with ThreadPool, Celery, Ray, or Temporal |
+
+---
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Evaluate via Platform & SDK" icon="play" href="/docs/evaluation/guides/running-evaluations">
+    Run your first eval from the UI or code.
+  </Card>
+  <Card title="SDK evals reference" icon="code" href="/docs/sdk/evals">
+    The complete SDK eval documentation.
+  </Card>
+  <Card title="Output types & scoring" icon="shapes" href="/docs/evaluation/reference/output-types">
+    What the result fields mean and how scoring works.
+  </Card>
+  <Card title="Built-in evals" icon="list-check" href="/docs/evaluation/builtin">
+    Every template, its method, and required inputs.
+  </Card>
+</CardGroup>

--- a/src/pages/docs/evaluation/reference/sdk-api.mdx
+++ b/src/pages/docs/evaluation/reference/sdk-api.mdx
@@ -1,6 +1,6 @@
 ---
 title: "SDK & API"
-description: "Run Future AGI evaluations from code: install, authenticate, the evaluate() entry point, engine routing, and the result fields you read back"
+description: "Run evaluations from code with the evaluate() function"
 ---
 
 ## About


### PR DESCRIPTION
Reference page for the Evaluation → References section.

How to run evals from code: install (`pip install ai-evaluation`), authenticate (`FI_API_KEY` + `FI_SECRET_KEY`), the single `evaluate()` entry point with its three-engine routing table, the `EvalResult` fields, the full function signature, and a map into the deeper SDK eval pages.

Grounded against the merged `sdk/evals/index.mdx` and `sdk/evals/evaluate.mdx` (signature, engine routing, result fields, and the local/cloud batch warning are quoted from there). No dead links.

Base: `docs/evaluation-revamp`.