### PR TITLE
docs(evaluation): Evaluation FAQ & fixes (troubleshooting)

### DIFF
--- a/src/pages/docs/evaluation/troubleshooting.mdx
+++ b/src/pages/docs/evaluation/troubleshooting.mdx
@@ -90,15 +90,15 @@ The SDK returns an `eval_id` immediately. Retrieve the result with `evaluator.ge
 
 <CardGroup cols={2}>
   <Card title="Evaluate via Platform & SDK" icon="play" href="/docs/evaluation/guides/running-evaluations">
-    The end-to-end flow for running an eval.
+    The end-to-end flow for running an eval
   </Card>
   <Card title="Output types & scoring" icon="shapes" href="/docs/evaluation/reference/output-types">
-    What each result value and field means.
+    What each result value and field means
   </Card>
   <Card title="Evaluator models" icon="robot" href="/docs/evaluation/concepts/evaluator-models">
-    The models that score your evals.
+    The models that score your evals
   </Card>
   <Card title="Built-in evals" icon="list-check" href="/docs/evaluation/builtin">
-    Every template, its method, and required inputs.
+    Every template, its method, and required inputs
   </Card>
 </CardGroup>

--- a/src/pages/docs/evaluation/troubleshooting.mdx
+++ b/src/pages/docs/evaluation/troubleshooting.mdx
@@ -1,0 +1,104 @@
+---
+title: "Evaluation FAQ & fixes"
+description: "Answers to common evaluation questions and fixes for the errors you hit most: model_name required, missing results, empty error localization, and batch scoring"
+---
+
+## About
+
+The questions people ask most about evaluation, and the errors they run into, with a direct fix for each. If your answer isn't here, reach out via [support](https://futureagi.com/contact-us).
+
+---
+
+## Getting started
+
+**What can I evaluate?**
+
+Future AGI has 70+ built-in evaluation templates covering quality, safety, factuality, RAG retrieval, format, bias, audio, and image, plus custom evals you define yourself. See the [Built-in evals reference](/docs/evaluation/builtin) for the full list.
+
+**How do I run my first eval?**
+
+Run it from the platform UI or the Python SDK. See [Evaluate via Platform & SDK](/docs/evaluation/guides/running-evaluations) for the step-by-step flow.
+
+**Do I need to write code?**
+
+No. You can add evals to a dataset or run and score them entirely from the UI. The [SDK](/docs/evaluation/reference/sdk-api) is there when you want to run the same evals from your own pipeline.
+
+---
+
+## Choosing an eval
+
+**Which evals should I use for RAG?**
+
+Use retrieval-specific evals like context adherence, chunk attribution, and recall@k. See the [RAG Evaluation cookbook](/docs/cookbook/evaluate-rag) for a walkthrough.
+
+**Which evals need an expected answer?**
+
+Match and statistical evals compare your output against a reference value, so they need one: [Ground Truth Match](/docs/evaluation/builtin/ground-truth-match), Fuzzy Match, BLEU, ROUGE, and the similarity metrics all take an `expected_response` (or `expected_value`).
+
+**Do all evals call an LLM?**
+
+No. Each template uses one of four methods: LLM as Judge, deterministic / rule-based, statistical, or ranker. Rule-based and statistical evals run without a model call. The [Built-in evals reference](/docs/evaluation/builtin) lists the method for each.
+
+---
+
+## Results and scoring
+
+**What does a result of `1.0` or `0.0` mean?**
+
+Pass/Fail templates return `1.0` for pass and `0.0` for fail. Score templates return a `0`–`100` value, and choice templates return a category label. See [Output types & scoring](/docs/evaluation/reference/output-types).
+
+**How do I see why an eval failed?**
+
+Every result carries a `reason` field explaining the verdict; see [Output types & scoring](/docs/evaluation/reference/output-types). For a failed result, error localization also pinpoints which input field, the prompt, context, or query, drove the failure.
+
+**Why is the error localization section empty?**
+
+Error localization only runs on a failed, scorable result. It is skipped when the eval passed, when the eval is a code-type or composite eval, or when the result is missing or non-numeric.
+
+---
+
+## SDK
+
+**Which API keys do I need?**
+
+Local metrics need none. Cloud evals and LLM-as-Judge need `FI_API_KEY` and `FI_SECRET_KEY`, found under **Settings → API Keys**.
+
+**Can I run several evals in one call?**
+
+Yes, pass a list of metric names to batch them. Do not mix local and cloud metrics in the same batch, run those separately.
+
+**How do I get results from an async run?**
+
+The SDK returns an `eval_id` immediately. Retrieve the result with `evaluator.get_eval_result(eval_id)` once the run finishes.
+
+---
+
+## Common errors and fixes
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `model_name required` | A cloud eval was run without an evaluator model | Pass `model_name="turing_flash"` (or another [evaluator model](/docs/evaluation/concepts/evaluator-models)) |
+| A local metric returns `score=None` in a batch | Local and cloud metrics were mixed in one call | Run the local and cloud metrics in separate calls |
+| Eval errors on a missing field | A required input for the template wasn't provided | Check the template's required inputs in the [Built-in evals reference](/docs/evaluation/builtin) |
+| Results don't appear after a run | Credentials not set, or evaluator model unavailable | Verify `FI_API_KEY` and `FI_SECRET_KEY` are configured |
+| Error localization block is empty | Result passed, or the eval is code-type / composite, or the result is non-numeric | Localization only runs on a scorable failed result |
+| Can't find your API keys | You need the Owner role | Go to **Settings → API Keys**; see [API Keys](/docs/admin-settings/api-keys) |
+
+---
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Evaluate via Platform & SDK" icon="play" href="/docs/evaluation/guides/running-evaluations">
+    The end-to-end flow for running an eval.
+  </Card>
+  <Card title="Output types & scoring" icon="shapes" href="/docs/evaluation/reference/output-types">
+    What each result value and field means.
+  </Card>
+  <Card title="Evaluator models" icon="robot" href="/docs/evaluation/concepts/evaluator-models">
+    The models that score your evals.
+  </Card>
+  <Card title="Built-in evals" icon="list-check" href="/docs/evaluation/builtin">
+    Every template, its method, and required inputs.
+  </Card>
+</CardGroup>

--- a/src/pages/docs/evaluation/troubleshooting.mdx
+++ b/src/pages/docs/evaluation/troubleshooting.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Evaluation FAQ & fixes"
-description: "Answers to common evaluation questions and fixes for the errors you hit most: model_name required, missing results, empty error localization, and batch scoring"
+description: "Common evaluation questions, and fixes for the errors you hit most"
 ---
 
 ## About


### PR DESCRIPTION
The Evaluation → Troubleshooting page.

Grouped FAQ (getting started, choosing an eval, results & scoring, SDK) plus a Common Errors & Fixes table: `model_name required`, local `score=None` in a mixed batch, missing required inputs, results not appearing, empty error localization, and finding API keys.

Every answer and error row is grounded: the eval + troubleshooting sections of the merged `faq.mdx`, the error-localization skip conditions, the built-in required-inputs, and the SDK batch warning. All links point to pages live on the branch (no links into unmerged PRs).

Base: `docs/evaluation-revamp`.