### PR TITLE
docs(integrations): add Pydantic AI traceAI integration page

### DIFF
--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -606,6 +606,7 @@ export const tabNavigation: NavTab[] = [
               { title: 'Haystack', href: '/docs/integrations/traceai/haystack' },
               { title: 'DSPy', href: '/docs/integrations/traceai/dspy' },
               { title: 'OpenAI Agents', href: '/docs/integrations/traceai/openai_agents' },
+              { title: 'Pydantic AI', href: '/docs/integrations/traceai/pydantic-ai' },
               { title: 'Smol Agents', href: '/docs/integrations/traceai/smol_agents' },
               { title: 'Instructor', href: '/docs/integrations/traceai/instructor' },
               { title: 'PromptFlow', href: '/docs/integrations/traceai/promptflow' },

--- a/src/pages/docs/integrations/index.mdx
+++ b/src/pages/docs/integrations/index.mdx
@@ -35,6 +35,7 @@ TraceAI provides pre-built auto-instrumentation for the following frameworks and
   <Card title="CrewAI" href="/docs/integrations/traceai/crewai" />
   <Card title="Haystack" href="/docs/integrations/traceai/haystack" />
   <Card title="AutoGen" href="/docs/integrations/traceai/autogen" />
+  <Card title="Pydantic AI" href="/docs/integrations/traceai/pydantic-ai" />
   <Card title="PromptFlow" href="/docs/integrations/traceai/promptflow" />
   <Card title="Vercel" href="/docs/integrations/traceai/vercel" />
   <Card title="Mastra" href="/docs/integrations/traceai/mastra" />

--- a/src/pages/docs/integrations/traceai/pydantic-ai.mdx
+++ b/src/pages/docs/integrations/traceai/pydantic-ai.mdx
@@ -1,0 +1,106 @@
+---
+title: "Pydantic AI Integration with Future AGI Tracing"
+description: "Integrate Pydantic AI with Future AGI. Trace agent runs, tool calls, structured outputs, and token usage automatically with traceAI-pydantic-ai."
+---
+
+## 1. Installation
+First install the traceAI package to access the observability framework.
+
+```bash
+pip install traceAI-pydantic-ai
+```
+
+---
+
+## 2. Set Environment Variables
+
+Set up your environment variables to authenticate with both FutureAGI and your model provider (e.g. OpenAI).
+
+```python
+import os
+
+os.environ["OPENAI_API_KEY"] = "your-openai-api-key"
+os.environ["FI_API_KEY"] = "your-futureagi-api-key"
+os.environ["FI_SECRET_KEY"] = "your-futureagi-secret-key"
+```
+
+---
+
+## 3. Initialize Trace Provider
+
+Set up the trace provider to create a new project in FutureAGI and establish telemetry data pipelines.
+
+```python
+from fi_instrumentation import register
+from fi_instrumentation.fi_types import ProjectType
+
+trace_provider = register(
+    project_type=ProjectType.OBSERVE,
+    project_name="pydantic_ai_project",
+)
+```
+
+---
+
+## 4. Instrument your Project
+
+Instrument your project with the Pydantic AI Instrumentor. This step ensures that all agent runs, tool calls, and model interactions are tracked and monitored.
+
+```python
+from traceai_pydantic_ai import PydanticAIInstrumentor
+
+PydanticAIInstrumentor().instrument(tracer_provider=trace_provider)
+```
+
+---
+
+## 5. Interact with Pydantic AI
+
+Use Pydantic AI as you normally would. Our Instrumentor will automatically trace and send the telemetry data to our platform.
+
+```python
+from pydantic_ai import Agent
+
+agent = Agent(
+    "openai:gpt-4o",
+    instructions="Be concise and helpful.",
+)
+
+result = agent.run_sync("What is the capital of France?")
+print(result.output)
+```
+
+---
+
+## 6. Trace Tool Calls and Structured Outputs
+
+Tool functions and Pydantic model result types are traced automatically, including their inputs, outputs, and token usage.
+
+```python
+from pydantic import BaseModel, Field
+from pydantic_ai import Agent, RunContext
+
+
+class TaskResult(BaseModel):
+    status: str = Field(description="Task status: success, failed, pending")
+    result: str = Field(description="Task result or error message")
+
+
+agent = Agent(
+    "openai:gpt-4o-mini",
+    result_type=TaskResult,
+    instructions="Process tasks and return structured results.",
+)
+
+
+@agent.tool
+def process_data(ctx: RunContext, data: str) -> str:
+    """Process incoming data and return the result."""
+    return f"Processed '{data}'"
+
+
+result = agent.run_sync("Process the following data: 'user_event_12345'")
+print(result.output)
+```
+
+


### PR DESCRIPTION
## Summary

Adds a Pydantic AI integration guide under **Integrations → Frameworks & Agents**, documenting the [`traceAI-pydantic-ai`](https://pypi.org/project/traceai-pydantic-ai/) instrumentor.

The page follows the standard traceAI integration structure:
1. Install `traceAI-pydantic-ai`
2. Set environment variables (FI + model provider keys)
3. Initialize the trace provider via `register()`
4. Instrument with `PydanticAIInstrumentor().instrument(...)`
5. Interact with a Pydantic AI agent
6. Trace tool calls and structured (Pydantic model) outputs

## Changes
- `src/pages/docs/integrations/traceai/pydantic-ai.mdx` — new integration page
- `src/lib/navigation.ts` — add "Pydantic AI" to the Frameworks & Agents sidebar
- `src/pages/docs/integrations/index.mdx` — add a "Pydantic AI" card

## Verification
- Ran the documented `register()` + instrument + `run_sync()` flow end-to-end against the FutureAGI platform; traces land in the target project (model, token usage, and cost populate on the spans).