### PR TITLE
docs(simulation): Understanding Simulation (concept)

### DIFF
--- a/src/pages/docs/simulation/concepts/understanding-simulation.mdx
+++ b/src/pages/docs/simulation/concepts/understanding-simulation.mdx
@@ -15,9 +15,9 @@ Every simulation is assembled from three pieces. The [agent](/docs/simulation/co
 <Mermaid chart={`
 %%{init: {"flowchart": {"curve": "linear"}}}%%
 flowchart LR
-    A["Agent<br/>who is tested"] --> RUN["Simulation run"]
-    S["Scenario<br/>what happens"] --> RUN
-    P["Persona<br/>who is talking"] --> RUN
+    A["Agent<br/>The AI being tested"] --> RUN["Simulation"]
+    S["Scenario<br/>The situation to test"] --> RUN
+    P["Persona<br/>The user interacting with the AI"] --> RUN
     style RUN fill:#2f2f2f,stroke:#ffffff,stroke-width:2px
 `} />
 

--- a/src/pages/docs/simulation/concepts/understanding-simulation.mdx
+++ b/src/pages/docs/simulation/concepts/understanding-simulation.mdx
@@ -12,14 +12,19 @@ A **simulation** runs your agent against simulated users so you catch its failur
 
 Every simulation is assembled from three pieces. The [agent](/docs/simulation/concepts/agent-definitions) is who is tested, the [scenario](/docs/simulation/concepts/scenarios) is what happens, and the [persona](/docs/simulation/concepts/personas) is who is talking. A run brings the three together and executes them.
 
-<Mermaid chart={`
-%%{init: {"flowchart": {"curve": "linear"}}}%%
-flowchart LR
-    A["Agent<br/>The AI being tested"] --> RUN["Simulation"]
-    S["Scenario<br/>The situation to test"] --> RUN
-    P["Persona<br/>The user interacting with the AI"] --> RUN
-    style RUN fill:#2f2f2f,stroke:#ffffff,stroke-width:2px
-`} />
+<div style={{ display: 'flex', justifyContent: 'center', margin: '1.5rem 0' }}>
+  <svg width="240" height="240" viewBox="0 0 200 200" role="img" aria-label="A simulation is assembled from three equal pieces: Agent, Scenario, and Persona.">
+    <path d="M100,100 L100,10 A90,90 0 0,1 177.94,145 Z" fill="#2f2f2f" stroke="#ffffff" strokeWidth="1.5" />
+    <path d="M100,100 L177.94,145 A90,90 0 0,1 22.06,145 Z" fill="#2f2f2f" stroke="#ffffff" strokeWidth="1.5" />
+    <path d="M100,100 L22.06,145 A90,90 0 0,1 100,10 Z" fill="#2f2f2f" stroke="#ffffff" strokeWidth="1.5" />
+    <text x="151.96" y="66" textAnchor="middle" fill="#ffffff" fontSize="13" fontWeight="700">Agent</text>
+    <text x="151.96" y="80" textAnchor="middle" fill="#cccccc" fontSize="10">who's tested</text>
+    <text x="100" y="156" textAnchor="middle" fill="#ffffff" fontSize="13" fontWeight="700">Scenario</text>
+    <text x="100" y="170" textAnchor="middle" fill="#cccccc" fontSize="10">what happens</text>
+    <text x="48.04" y="66" textAnchor="middle" fill="#ffffff" fontSize="13" fontWeight="700">Persona</text>
+    <text x="48.04" y="80" textAnchor="middle" fill="#cccccc" fontSize="10">who's talking</text>
+  </svg>
+</div>
 
 Hold this shape and the rest of Simulation is detail: each of the three pieces has its own page, and everything else is how you run them and read what comes back.
 

--- a/src/pages/docs/simulation/concepts/understanding-simulation.mdx
+++ b/src/pages/docs/simulation/concepts/understanding-simulation.mdx
@@ -6,35 +6,53 @@ description: "How a simulation is assembled from three pieces, and where it fits
 
 ## What a simulation is
 
-A **simulation** runs your agent against simulated users so you catch its failures in a test instead of in production. The simulated user plays out a situation, your agent responds, and the whole conversation is scored, in voice or in chat. Run it before you ship, and again after every change, and you have a repeatable read on whether the agent is getting better or worse.
+A **simulation** runs your agent against simulated users so you catch its failures in a test instead of in production. The simulated user plays out a situation, your agent responds, and the whole conversation is scored by [evals](/docs/evaluation), in voice or in chat. Run it before you ship, and again after every change, and you have a repeatable read on whether the agent is getting better or worse.
 
 ## The three components
 
-Every simulation is assembled from three pieces. The [agent](/docs/simulation/concepts/agent-definitions) is who is tested, the [scenario](/docs/simulation/concepts/scenarios) is what happens, and the [persona](/docs/simulation/concepts/personas) is who is talking. A run brings the three together and executes them.
+Every simulation is assembled from three pieces. The [agent](/docs/simulation/concepts/agent-definitions) is who is tested, the [scenario](/docs/simulation/concepts/scenarios) is what happens, and the [persona](/docs/simulation/concepts/personas) is who is talking to the agent. A run brings the three together and executes them.
 
 <div style={{ display: 'flex', justifyContent: 'center', margin: '1.5rem 0' }}>
-  <svg width="240" height="240" viewBox="0 0 200 200" role="img" aria-label="A simulation is assembled from three equal pieces: Agent, Scenario, and Persona.">
-    <path d="M100,100 L100,10 A90,90 0 0,1 177.94,145 Z" fill="#2f2f2f" stroke="#ffffff" strokeWidth="1.5" />
-    <path d="M100,100 L177.94,145 A90,90 0 0,1 22.06,145 Z" fill="#2f2f2f" stroke="#ffffff" strokeWidth="1.5" />
-    <path d="M100,100 L22.06,145 A90,90 0 0,1 100,10 Z" fill="#2f2f2f" stroke="#ffffff" strokeWidth="1.5" />
-    <text x="151.96" y="66" textAnchor="middle" fill="#ffffff" fontSize="13" fontWeight="700">Agent</text>
-    <text x="151.96" y="80" textAnchor="middle" fill="#cccccc" fontSize="10">who's tested</text>
-    <text x="100" y="156" textAnchor="middle" fill="#ffffff" fontSize="13" fontWeight="700">Scenario</text>
-    <text x="100" y="170" textAnchor="middle" fill="#cccccc" fontSize="10">what happens</text>
-    <text x="48.04" y="66" textAnchor="middle" fill="#ffffff" fontSize="13" fontWeight="700">Persona</text>
-    <text x="48.04" y="80" textAnchor="middle" fill="#cccccc" fontSize="10">who's talking</text>
+  <svg width="300" height="234" viewBox="0 0 320 250" role="img" aria-label="A simulation is assembled from three equal pieces: Agent, Scenario, and Persona.">
+    <g transform="translate(6.1,-3.5)">
+      <path d="M160,128 L160,40 A88,88 0 0 1 236.21,172 Z" fill="#2f2f2f" stroke="#ffffff" stroke-width="1.5" />
+      <text x="207" y="98" text-anchor="middle" fill="#ffffff" font-size="13" font-weight="700">Agent</text>
+      <text x="207" y="113" text-anchor="middle" fill="#cccccc" font-size="10">who's tested</text>
+    </g>
+    <g transform="translate(0,7)">
+      <path d="M160,128 L236.21,172 A88,88 0 0 1 83.79,172 Z" fill="#2f2f2f" stroke="#ffffff" stroke-width="1.5" />
+      <text x="160" y="183" text-anchor="middle" fill="#ffffff" font-size="13" font-weight="700">Scenario</text>
+      <text x="160" y="198" text-anchor="middle" fill="#cccccc" font-size="10">what happens</text>
+    </g>
+    <g transform="translate(-6.1,-3.5)">
+      <path d="M160,128 L83.79,172 A88,88 0 0 1 160,40 Z" fill="#2f2f2f" stroke="#ffffff" stroke-width="1.5" />
+      <text x="113" y="98" text-anchor="middle" fill="#ffffff" font-size="13" font-weight="700">Persona</text>
+      <text x="113" y="113" text-anchor="middle" fill="#cccccc" font-size="10">who's talking</text>
+    </g>
   </svg>
 </div>
 
 Hold this shape and the rest of Simulation is detail: each of the three pieces has its own page, and everything else is how you run them and read what comes back.
 
-## One loop, walked once
+## The test-and-fix loop
 
-Take a support agent. You point Simulation at it, write a **refund request** scenario, and pick a **frustrated caller** persona. You run it, and a resolution eval fails: the agent quotes the wrong refund window. You shorten the prompt and add the policy, then run the same scenario and persona again. This time it passes, and you have proof the fix worked, not a hunch.
+Take a support agent:
+
+1. Write a refund request scenario and pick a frustrated caller persona
+2. Run it. A resolution eval fails: the agent quotes the wrong refund window
+3. Shorten the prompt and add the missing policy
+4. Run the same scenario and persona again. It passes
+
+Same scenario, same persona, a score that flipped: that's the loop, and it's proof the fix worked, not a hunch.
 
 ## Where Simulation fits
 
-Simulation is the pre-production counterpart to [Observe](/docs/observe): Observe watches real traffic, Simulation rehearses it. It scores calls with the same templates as [Evaluation](/docs/evaluation), so a bar means the same thing in a test and in production. [Replay](/docs/simulation/concepts/replay) bridges the two by turning a real conversation into a scenario, and when a run exposes a weakness, [optimization](/docs/simulation/concepts/optimization) improves the agent automatically.
+Simulation plugs into the rest of the platform:
+
+- **[Observe](/docs/observe)** watches real traffic; Simulation rehearses it before you ship
+- **[Evaluation](/docs/evaluation)** supplies the scoring: the same templates run in both, so a passing score means the same thing in a test and in production
+- **[Replay](/docs/simulation/concepts/replay)** bridges the two, turning a real conversation from Observe into a scenario you can rerun
+- **[Optimization](/docs/simulation/concepts/optimization)** picks up when a run exposes a weakness and improves the agent automatically
 
 ## Keep exploring
 

--- a/src/pages/docs/simulation/concepts/understanding-simulation.mdx
+++ b/src/pages/docs/simulation/concepts/understanding-simulation.mdx
@@ -1,0 +1,46 @@
+---
+title: "Understanding Simulation"
+description: "How a simulation is assembled from three pieces, and where it fits"
+---
+
+
+## What a simulation is
+
+A **simulation** runs your agent against simulated users so you catch its failures in a test instead of in production. The simulated user plays out a situation, your agent responds, and the whole conversation is scored, in voice or in chat. Run it before you ship, and again after every change, and you have a repeatable read on whether the agent is getting better or worse.
+
+## The three components
+
+Every simulation is assembled from three pieces. The [agent](/docs/simulation/concepts/agent-definitions) is who is tested, the [scenario](/docs/simulation/concepts/scenarios) is what happens, and the [persona](/docs/simulation/concepts/personas) is who is talking. A run brings the three together and executes them.
+
+<Mermaid chart={`
+%%{init: {"flowchart": {"curve": "linear"}}}%%
+flowchart LR
+    A["Agent<br/>who is tested"] --> RUN["Simulation run"]
+    S["Scenario<br/>what happens"] --> RUN
+    P["Persona<br/>who is talking"] --> RUN
+    style RUN fill:#2f2f2f,stroke:#ffffff,stroke-width:2px
+`} />
+
+Hold this shape and the rest of Simulation is detail: each of the three pieces has its own page, and everything else is how you run them and read what comes back.
+
+## One loop, walked once
+
+Take a support agent. You point Simulation at it, write a **refund request** scenario, and pick a **frustrated caller** persona. You run it, and a resolution eval fails: the agent quotes the wrong refund window. You shorten the prompt and add the policy, then run the same scenario and persona again. This time it passes, and you have proof the fix worked, not a hunch.
+
+## Where Simulation fits
+
+Simulation is the pre-production counterpart to [Observe](/docs/observe): Observe watches real traffic, Simulation rehearses it. It scores calls with the same templates as [Evaluation](/docs/evaluation), so a bar means the same thing in a test and in production. [Replay](/docs/simulation/concepts/replay) bridges the two by turning a real conversation into a scenario, and when a run exposes a weakness, [optimization](/docs/simulation/concepts/optimization) improves the agent automatically.
+
+## Keep exploring
+
+<CardGroup cols={3}>
+  <Card title="Agent definitions & versions" icon="robot" href="/docs/simulation/concepts/agent-definitions">
+    The agent under test, and how versions track changes
+  </Card>
+  <Card title="Scenarios" icon="list-check" href="/docs/simulation/concepts/scenarios">
+    The test cases that decide what happens
+  </Card>
+  <Card title="Personas" icon="users" href="/docs/simulation/concepts/personas">
+    The simulated customer your agent faces
+  </Card>
+</CardGroup>


### PR DESCRIPTION
New concept page: **Understanding Simulation**.

- Opens at first H2 (no hero)
- One Mermaid showing the three components (agent → run ← scenario + persona)
- One worked example (support agent + refund request + frustrated caller → eval fails → fix → re-run)
- Where Simulation fits: Observe, Evaluation, Replay, Optimization
- Keep exploring footer with cards

Aligned to Khushal review bar: no em-dashes, no marketing adjectives, declarative value H2s (no why it matters), ZERO dead links (all links resolve on branch). Providers scoped to Vapi + Retell only.

Base: `docs/simulation-revamp`.