### PR TITLE
docs(simulation): Personas, Runs & results, Replay, Optimization concepts

### DIFF
--- a/src/pages/docs/simulation/concepts/optimization.mdx
+++ b/src/pages/docs/simulation/concepts/optimization.mdx
@@ -1,0 +1,51 @@
+---
+title: "Optimization"
+description: "Let an algorithm search for a better prompt when hand-fixing isn't enough"
+---
+
+## What optimization is
+
+**Optimization** improves your agent's prompt and configuration automatically, scored by the same evals your simulation runs. Rather than hand-editing the prompt and rerunning, you let an algorithm propose and test many variations and hand you the best one. It's what Fix My Agent is built on: the diagnosis names what is wrong, and an optimization run does the rewriting.
+
+## How a run works
+
+An optimization run is a search for a better prompt, judged by your evals.
+
+<Mermaid chart={`
+%%{init: {"flowchart": {"curve": "linear"}}}%%
+flowchart LR
+    IN["Simulation results<br/>+ eval scores"] --> ALG["Algorithm<br/>proposes candidates"]
+    ALG --> TR["Trials<br/>each candidate run"]
+    TR --> SC["Scores"]
+    SC --> BEST["Best configuration"]
+`} />
+
+Say your refund agent keeps failing a resolution eval. You feed those failing calls in, the algorithm generates candidate prompts, each one is trialed against your scenarios and scored on that same eval, and the best-performing prompt surfaces for you to review and apply. Because the score is your own eval, the winner is the prompt that best satisfies the bar you set.
+
+## The algorithms
+
+You pick the search strategy to match the task and budget:
+
+- **Random Search**, quick variations for a fast baseline
+- **Bayesian**, intelligent selection of few-shot examples and configurations
+- **Meta-Prompt**, analyses failures and rewrites the whole prompt through deeper reasoning
+- **ProTeGi**, critiques failures and applies targeted fixes with beam search
+- **PromptWizard**, mutates across thinking styles, then critiques and refines the top ones
+- **GEPA**, an evolutionary search for production-grade results at the highest cost
+
+The [Optimization](/docs/optimization) product docs cover each algorithm in depth.
+
+## Optimization and Fix My Agent
+
+The two work together. Fix My Agent reads a run and hands you a prioritised list of issues with recommended fixes you apply by hand. An optimization run goes further and executes the improvement automatically, generating and scoring prompts until it finds a better one. Start with Fix My Agent's suggestions, and reach for optimization when manual fixes aren't enough.
+
+## Keep exploring
+
+<CardGroup cols={2}>
+  <Card title="Runs & results" icon="chart-mixed" href="/docs/simulation/concepts/runs-and-results">
+    The results an optimization run learns from
+  </Card>
+  <Card title="Agent definitions & versions" icon="robot" href="/docs/simulation/concepts/agent-definitions">
+    Save the improved prompt as a new version
+  </Card>
+</CardGroup>

--- a/src/pages/docs/simulation/concepts/personas.mdx
+++ b/src/pages/docs/simulation/concepts/personas.mdx
@@ -1,120 +1,51 @@
 ---
-title: "Personas: Simulated Customer Profiles in Future AGI"
-description: "Personas in Future AGI represent the customers or users your AI agent interacts with in simulation. Define them to create realistic test conversations."
+title: "Personas"
+description: "Give your test customer a personality, a voice, and a way of talking"
 ---
 
-## About
 
-A **persona** defines who the simulated customer is during a test — their demographics, personality, and communication style. The simulator uses these traits to play the "customer" side of the conversation, making interactions feel realistic rather than scripted. You can use one of **18 pre-built personas** or create your own. Personas are typed as **voice** or **chat**, each with settings specific to that channel.
+## What a persona is
 
-![Persona 1](/screenshot/product/simulation/personas/1.png)
+A **persona** is the simulated user in a simulation: its demographics, personality, and communication style. The simulator plays the persona as the customer side of the conversation, so a run feels like a real interaction instead of a fixed script. You reach for one of the built-in personas or define your own. A "Price-sensitive caller", for example, is a voice persona with an Indian accent, fast speech, and a high tendency to interrupt, plus a custom `objection_pattern` your [scenario](/docs/simulation/concepts/scenarios) can read.
 
-## Voice vs Chat
+<Mermaid chart={`
+%%{init: {"flowchart": {"curve": "linear"}}}%%
+flowchart LR
+    BI["Basic info<br/>name, age, location"] --> P["Persona"]
+    BH["Behaviour<br/>personality, style"] --> P
+    CH["Channel traits<br/>voice or chat"] --> P
+    P --> SA["Simulator agent<br/>plays the persona"]
+    style P fill:#2f2f2f,stroke:#ffffff,stroke-width:2px
+`} />
 
-When creating a custom persona, you select whether it is for **voice** or **chat** simulations.
-- **Voice**: Used in phone or voice-channel tests. You can set speech-related options: **accent**, **conversation speed**, **background noise**, and **interrupt sensitivity** (how easily the persona can be interrupted or can interrupt). Behavioural and basic-information settings apply to both.
-- **Chat**: Used in text-based tests. You can set text-related options: **tone**, **verbosity**, **punctuation style**, **emoji usage**, **slang**, **typos frequency**, and **regional mix**. Basic information and behavioural settings apply to both.
+## What you can customize
 
-The same persona is not shared across voice and chat; create separate personas if you need both for the same “type” of customer.
+A persona is typed as **voice** or **chat**, and it's customizable across a wide surface, from who the customer is to exactly how they sound. Set as much or as little as you need, and every field falls back to a sensible default:
 
-## Creating a custom persona
+- **Basic info**: name, description, and demographics, meaning gender, age range, and location
+- **Behaviour**: personality traits and communication style
+- **Voice traits**, on a voice persona: accent, conversation speed, background noise, and turn-taking, split into interrupt sensitivity and finished-speaking sensitivity
+- **Chat traits**, on a chat persona: tone, verbosity, punctuation style, emoji usage, slang, typo frequency, and regional mix
+- **Custom properties**: any attribute your scenario reads per row, like `objection_pattern` or `insurance_type`
+- **Instructions**: free-form guidance the simulator always follows, like "ask for a supervisor after the first objection"
 
-From the Personas page, click **Create your own persona**. Choose **Voice** or **Chat** depending on whether the persona will be used in voice or chat simulations; the form then shows the relevant settings for that type. Follow the steps in the tab that matches your choice.
-![Persona 2](/screenshot/product/simulation/personas/2.png)
+That is a deep surface, so most fields have sensible defaults and you only set the ones that matter for the test. Every field and its allowed values lives in the Persona settings reference.
 
-<Tabs sync={false}>
-  <Tab title="Voice type" icon="play">
-    Use this flow when creating a persona for **voice** (phone or voice-channel) simulations.
+## Built-in and custom personas
 
-    <Steps>
-      <Step title="Basic information">
-        Enter the core details the simulator uses to identify this persona. Same fields as chat; all optional except name and description if required by the UI.
+Future AGI ships 18 built-in personas you can drop into a run as-is. When none fit, you create a custom persona in your workspace, shape it across the layers above, and reuse it across every run.
 
-        ![Create Custom Personas](/screenshot/product/simulation/personas/3.png)
+## The simulator agent
 
-        | Property | Description |
-        | -------- | ----------- |
-        | Persona name | Name you give this persona (e.g. "Price-sensitive caller"). |
-        | Description | Short description, e.g. "An angry customer who is not happy with the service." |
-        | Gender (optional) | One or more: Male, Female. |
-        | Age (optional) | One or more ranges: 18–25, 25–32, 32–40, 40–50, 50–60, 60+. |
-        | Location (optional) | One or more: United States, Canada, United Kingdom, Australia, India. |
-      </Step>
-      <Step title="Behavioural settings">
-        Set **personality traits** and **communication style**. For voice, also set **accent** (e.g. American, Australian, Indian, Neutral). This controls how the persona responds and speaks during the call.
+The persona describes who the user is; the **simulator agent** is the actor that plays it. It is the model that generates the persona's side of the conversation, along with the voice it speaks in and the pacing it keeps, like how fast it talks and how long a call can run. Choosing a capable simulator agent is what makes the persona hold its character across a long conversation.
 
-        ![Create Custom Personas](/screenshot/product/simulation/personas/4.png)
-      </Step>
-      <Step title="Conversation settings (voice)">
-        Control how the voice conversation runs: **conversation speed** (e.g. very slow, slow, moderate, fast, very fast), how the simulator responds, and **background noise** (on/off) for realism. You can also set **interrupt sensitivity** and **finished-speaking sensitivity** so the persona behaves naturally with turn-taking and interruptions.
-
-        ![Create Custom Personas](/screenshot/product/simulation/personas/5.png)
-      </Step>
-      <Step title="Custom properties">
-        Add any extra attributes not covered by the predefined fields (e.g. "insurance_type", "objection_pattern") so scenarios can reference them.
-
-        ![Create Custom Personas](/screenshot/product/simulation/personas/6.png)
-        ![Create Custom Personas](/screenshot/product/simulation/personas/7.png)
-      </Step>
-      <Step title="Additional information">
-        Add free-form instructions (e.g. "Always ask for a supervisor after the first objection.").
-
-        ![Create Custom Personas](/screenshot/product/simulation/personas/8.png)
-      </Step>
-      <Step title="Add persona">
-        Click **Add** (or **Save**). The persona appears in your list and can be used in voice scenarios and run tests.
-      </Step>
-    </Steps>
-  </Tab>
-  <Tab title="Chat type" icon="eye">
-    Use this flow when creating a persona for **chat** simulations.
-
-    <Steps>
-      <Step title="Basic information">
-        Enter the core details the simulator uses to identify this persona. Same fields as voice; all optional except name and description if required by the UI.
-
-        ![Create Custom Personas](/screenshot/product/simulation/personas/3.png)
-
-        | Property | Description |
-        | -------- | ----------- |
-        | Persona name | Name you give this persona (e.g. "Price-sensitive buyer"). |
-        | Description | Short description, e.g. "An angry customer who is not happy with the service." |
-        | Gender (optional) | One or more: Male, Female. |
-        | Age (optional) | One or more ranges: 18–25, 25–32, 32–40, 40–50, 50–60, 60+. |
-        | Location (optional) | One or more: United States, Canada, United Kingdom, Australia, India. |
-      </Step>
-      <Step title="Behavioural settings">
-        Set **personality traits** and **communication style**. These define how the persona types and responds in chat.
-
-        ![Create Custom Personas](/screenshot/product/simulation/personas/10.png)
-      </Step>
-      <Step title="Conversation settings (chat)">
-        Control how the chat persona writes: **tone** (formal, casual, neutral), **verbosity** (brief, balanced, detailed), **punctuation style** (clean, minimal, expressive, erratic), **emoji usage** (never, light, regular, heavy), **slang usage**, **typos frequency**, and **regional mix**. These make the text feel realistic for the persona.
-
-        ![Create Custom Personas](/screenshot/product/simulation/personas/9.png)
-      </Step>
-      <Step title="Custom properties">
-        Add any extra attributes not covered by the predefined fields (e.g. "insurance_type", "objection_pattern") so scenarios can reference them.
-
-        ![Create Custom Personas](/screenshot/product/simulation/personas/6.png)
-        ![Create Custom Personas](/screenshot/product/simulation/personas/7.png)
-      </Step>
-      <Step title="Additional information">
-        Add free-form instructions (e.g. "Always ask for a supervisor after the first objection.").
-
-        ![Create Custom Personas](/screenshot/product/simulation/personas/8.png)
-      </Step>
-      <Step title="Add persona">
-        Click **Add** (or **Save**). The persona appears in your list and can be used in chat scenarios and run tests.
-      </Step>
-    </Steps>
-  </Tab>
-</Tabs>
-
-## Next Steps
+## Keep exploring
 
 <CardGroup cols={2}>
-  <Card title="Run Simulation" icon="play" href="/docs/simulation">
-    Tie your agent and scenario to a run test, attach evals, and run the simulation.
+  <Card title="Agent definitions & versions" icon="robot" href="/docs/simulation/concepts/agent-definitions">
+    The agent your persona talks to
+  </Card>
+  <Card title="Replay" icon="arrows-rotate" href="/docs/simulation/concepts/replay">
+    Turn a real call into a persona-driven test
   </Card>
 </CardGroup>

--- a/src/pages/docs/simulation/concepts/replay.mdx
+++ b/src/pages/docs/simulation/concepts/replay.mdx
@@ -1,0 +1,50 @@
+---
+title: "Replay"
+description: "Reproduce a real production bug as a test, instead of guessing at a synthetic one"
+---
+
+## What replay is
+
+**Replay** takes a real production conversation from [Observe](/docs/observe) and turns it into a scenario you can rerun against a dev agent. Say a caller got quoted the wrong refund window last week: you pick that exact conversation, generate a scenario from its transcript, and run it against your fixed agent to confirm it now gets it right. Instead of guessing at a synthetic case, you reproduce the real one.
+
+## Session replay and trace replay
+
+You choose how much of the production data becomes one conversation.
+
+### Session
+
+A whole session, every trace under one `session_id` in order, replays as a single multi-turn conversation. Reach for it when you want to rerun full production conversations end to end.
+
+### Trace
+
+Each selected trace replays as its own one-turn conversation, an input and an output. Reach for it when you want to replay individual calls or single-turn interactions.
+
+## Chat and voice
+
+Replay works in both channels. **Chat replay** rebuilds the conversation from the production transcripts. **Voice replay** goes further: it pulls the original voice setup (system prompt, assistant settings, and provider config) from the production call, so the replayed call runs on the same configuration as the original. Voice replay supports **Vapi** as the primary provider, with **Retell** supported for transcript comparison.
+
+<Mermaid chart={`
+%%{init: {"flowchart": {"curve": "linear"}}}%%
+flowchart LR
+    O["Production traces<br/>in Observe"] --> RS["Replay session"]
+    RS --> SC["Generated scenario"]
+    SC --> RUN["Simulation run"]
+    RUN --> CMP["Compare with the original"]
+`} />
+
+Once the run finishes, you compare the replayed conversation with the original side by side, transcripts, metrics, and for voice the audio, so you can see exactly what your change moved.
+
+## Replay closes the loop
+
+A production failure that only happened once can slip away. Save its replayed scenario into your regular runs and it becomes a permanent regression test: the exact conversation that broke is now something every future version has to pass.
+
+## Keep exploring
+
+<CardGroup cols={2}>
+  <Card title="Scenarios" icon="list-check" href="/docs/simulation/concepts/scenarios">
+    The scenario replay generates from a call
+  </Card>
+  <Card title="Agent definitions & versions" icon="robot" href="/docs/simulation/concepts/agent-definitions">
+    The agent definition replay recreates
+  </Card>
+</CardGroup>

--- a/src/pages/docs/simulation/concepts/runs-and-results.mdx
+++ b/src/pages/docs/simulation/concepts/runs-and-results.mdx
@@ -1,0 +1,52 @@
+---
+title: "Runs & results"
+description: "How a simulation executes, and what each run leaves behind to read and compare"
+---
+
+## What a run is
+
+A **run test** is one execution of a simulation. It bundles an [agent version](/docs/simulation/concepts/agent-definitions), the [scenarios](/docs/simulation/concepts/scenarios) to play, the [personas](/docs/simulation/concepts/personas) that play them, and the evals that score the result. Run one version of your support agent against a refund scenario with a frustrated persona, scored by a resolution eval, and you have one run test.
+
+## From run to calls
+
+Starting a run test creates an **execution**, and the execution fans out into calls: one call per scenario, or one per row when the scenario is dataset-backed. Each call runs the conversation end to end, then the execution moves through its statuses as work completes.
+
+<Mermaid chart={`
+%%{init: {"flowchart": {"curve": "linear"}}}%%
+flowchart LR
+    RT["Run test"] --> EX["Execution"]
+    EX --> C["Calls<br/>one per scenario or row"]
+    C --> OUT["Transcript + Recording<br/>Metrics + Eval results"]
+`} />
+
+An execution reports where it is. It moves through **pending**, **running**, and **evaluating**, then finishes as **completed**, or as **failed**, **cancelled**, or **cancelling** if it stops early.
+
+## What each call carries
+
+Every call is the record of one conversation. It holds:
+
+- The **transcript**, turn by turn, with the speaker role on each turn
+- The **recording**, for voice calls
+- **Conversation metrics**, like latency, talk ratio, and cost
+- **Eval results**, a score per metric for that call, and **tool-call results** when tool evaluation is on
+
+The exact metric fields and speaker roles live in the Call metrics reference.
+
+## Reruns and snapshots
+
+You can rerun a whole call or only its evals, for example after changing an eval config. A rerun doesn't overwrite the earlier result: the previous run is snapshotted, so you can compare a call before and after a change instead of losing the baseline.
+
+## Runs are comparable
+
+Because a run pins an agent version and replays the same scenarios and personas, two runs differ only by what you changed. That makes their scores directly comparable, so you can trend quality across versions and catch a regression before it ships.
+
+## Keep exploring
+
+<CardGroup cols={2}>
+  <Card title="Optimization" icon="wand-magic-sparkles" href="/docs/simulation/concepts/optimization">
+    Turn failing runs into an improved agent
+  </Card>
+  <Card title="Agent definitions & versions" icon="robot" href="/docs/simulation/concepts/agent-definitions">
+    Compare scores across agent versions
+  </Card>
+</CardGroup>


### PR DESCRIPTION
Four Simulation concept pages (Personas, Runs & results, Replay, Optimization).

## Why this is one batch PR
These four cross-link to each other. Raising them together keeps their mutual links resolving within the PR. If each were its own branch, every page would show dead links to the siblings that have not merged yet.

## The pages
- **Personas** (rewrite) — what a persona is, the full customization surface (basic info, behaviour, voice traits, chat traits, custom properties, instructions), built-in vs custom, the simulator agent
- **Runs & results** (new) — the run data model: run test to execution to calls, each call carrying transcript, recording, metrics, and eval results; statuses; reruns and snapshots; comparability
- **Replay** (new) — a real production conversation becomes a scenario you can rerun; session vs trace; chat and voice
- **Optimization** (new) — automatic prompt improvement scored by your evals; the six algorithms; how it relates to Fix My Agent

## Pending links (targets not built yet)
Some links were deliberately left out or point to pages landing in parallel, because those pages are not live yet:
- **Agent definitions & versions** (`concepts/agent-definitions`): cross-linked from these pages; it lands via the `agent-definition` to `agent-definitions` rename in a parallel PR. Those links resolve once it merges into this branch.
- **Guides and references** (Create personas, Persona settings, Explore results, Call metrics, Running optimizations, Fix My Agent, etc.): cards and inline links to these were omitted, since the pages are not built. They should be added when those pages land.

## Notes
- Concept shape: opens at first H2, one Mermaid mental model and one worked example each, forward Keep-exploring cards that avoid the sidebar Previous/Next neighbours, no em-dashes, minimal frontmatter
- Providers: Vapi and Retell only (no LiveKit)
- Grounding: drawn from the existing product pages on this branch plus the handoff skeletons; a final pass against `futureagi/simulate` is still pending (live product access was unavailable)