### PR TITLE
fix(sidebar): stop nested collapsible folders from clipping expanded children

### DIFF
--- a/src/components/Sidebar.astro
+++ b/src/components/Sidebar.astro
@@ -534,7 +534,7 @@ function inferApiMethod(title: string): { method: string; css: string } | null {
 
         // Set initial state
         if (isOpen) {
-          content.style.maxHeight = content.scrollHeight + 'px';
+          content.style.maxHeight = 'none';
           if (chevron) chevron.style.transform = 'rotate(90deg)';
         } else {
           content.style.maxHeight = '0';
@@ -547,7 +547,7 @@ function inferApiMethod(title: string): { method: string; css: string } | null {
           isOpen = !isOpen;
 
           if (isOpen) {
-            content.style.maxHeight = content.scrollHeight + 'px';
+            content.style.maxHeight = 'none';
             if (chevron) chevron.style.transform = 'rotate(90deg)';
           } else {
             content.style.maxHeight = '0';


### PR DESCRIPTION
## Problem

In the sidebar, open collapsible folders had their `max-height` pinned to the pixel `scrollHeight` measured at the moment they opened. That measurement is only correct if the folder's children were already at full height when it was measured.

On a built-in eval page this happened to work: "Built-in evals" was measured at load while its children were still expanded, so its height was large enough. **Anywhere else**, expanding "Built-in evals" measured it with children collapsed (folder headers only), so opening a nested folder like "RAG & retrieval" overflowed that frozen height and **clipped every sibling folder below it** (Safety & compliance, Conversation & agents, …). Net effect: the built-in evals catalog only rendered fully when the active page was already inside it.

## Fix

Open folders now use `max-height: none` instead of a fixed pixel height, so a parent always grows to fit an expanded child. There is no CSS transition on `max-height`, so no animation is lost.

## Verify

On any non-builtin page (e.g. *Output types & scoring*), expand **Built-in evals → RAG & retrieval** and confirm the other use-case folders still render below it instead of disappearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)