### PR TITLE
ci(changelog): open release-notes PR with App token (twin of #774)

### DIFF
--- a/.github/workflows/changelog-sync.yml
+++ b/.github/workflows/changelog-sync.yml
@@ -14,7 +14,16 @@ jobs:
   open-changelog-pr:
     runs-on: ubuntu-latest
     steps:
+      # App token (not GITHUB_TOKEN): the org forbids Actions from creating PRs
+      # with GITHUB_TOKEN, and App-minted tokens are exempt. Scoped to this repo.
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
       - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -28,7 +37,7 @@ jobs:
           node scripts/changelog-from-release.mjs "$VERSION" /tmp/release-body.md src/pages/docs/release-notes.mdx
       - name: Open PR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           VERSION: ${{ github.event.client_payload.version }}
           RELEASE_URL: ${{ github.event.client_payload.release_url }}
         run: |


### PR DESCRIPTION
Twin of #774 targeting `dev` (contributors branch from dev). Byte-identical workflow change. See #774 for rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)