### PR TITLE
docs(simulation): replace overview lifecycle chart with hand-authored loop diagram

### DIFF
--- a/public/images/docs/simulation/agent-development-loop.svg
+++ b/public/images/docs/simulation/agent-development-loop.svg
@@ -1,0 +1,58 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 790" width="800" height="790" font-family="system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" role="img" aria-label="The agent development loop: Build feeds Simulate; evals score every conversation; a failing score loops back through Fix into another simulation, a passing one deploys; Observe traces production, and replay turns real conversations into the next rehearsal.">
+  <defs>
+    <marker id="adl-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#aaaaaa" />
+    </marker>
+  </defs>
+
+  <!-- Outer ring: four arcs on one circle, centre 400,435, radius 250 throughout.
+       Endpoint angles are asymmetric so every arc clears its block by the same gap. -->
+  <path d="M497.7,204.9 A250,250 0 0 1 644.5,383.0" fill="none" stroke="#aaaaaa" stroke-width="1.2" marker-end="url(#adl-arrow)" />
+  <path d="M644.5,487.0 A250,250 0 0 1 497.7,665.1" fill="none" stroke="#aaaaaa" stroke-width="1.2" marker-end="url(#adl-arrow)" />
+  <path d="M302.3,665.1 A250,250 0 0 1 155.5,487.0" fill="none" stroke="#aaaaaa" stroke-width="1.2" marker-end="url(#adl-arrow)" />
+  <path d="M155.5,383.0 A250,250 0 0 1 302.3,204.9" fill="none" stroke="#aaaaaa" stroke-width="1.2" marker-end="url(#adl-arrow)" />
+  <text x="206" y="242" text-anchor="end" fill="#7a7a7a" font-size="11" font-style="italic">Replay</text>
+
+  <!-- Entry: Build feeds the loop from above -->
+  <path d="M400,106 L400,139" fill="none" stroke="#aaaaaa" stroke-width="1.2" marker-end="url(#adl-arrow)" />
+
+  <!-- Inner loop: Score cuts back to Simulate through Fix -->
+  <path d="M549,435 L501,435" fill="none" stroke="#aaaaaa" stroke-width="1.2" marker-end="url(#adl-arrow)" />
+  <path d="M400,389 L400,231" fill="none" stroke="#aaaaaa" stroke-width="1.2" marker-end="url(#adl-arrow)" />
+
+  <!-- Build, above the loop -->
+  <rect x="305" y="20" width="190" height="80" rx="14" fill="#2f2f2f" stroke="#ffffff" stroke-width="1.2" />
+  <text x="400" y="54" text-anchor="middle" fill="#ffffff" font-size="14" font-weight="700">Build</text>
+  <text x="400" y="76" text-anchor="middle" fill="#cccccc" font-size="11">develop your agent</text>
+
+  <!-- Simulate, top of the circle -->
+  <rect x="305" y="145" width="190" height="80" rx="14" fill="#2f2f2f" stroke="#ffffff" stroke-width="1.2" />
+  <text x="400" y="175" text-anchor="middle" fill="#ffffff" font-size="14" font-weight="700">Simulate</text>
+  <text x="400" y="195" text-anchor="middle" fill="#cccccc" font-size="11">rehearse voice or chat</text>
+  <text x="400" y="210" text-anchor="middle" fill="#cccccc" font-size="11">conversations</text>
+
+  <!-- Score, right -->
+  <rect x="555" y="395" width="190" height="80" rx="14" fill="#2f2f2f" stroke="#ffffff" stroke-width="1.2" />
+  <text x="650" y="425" text-anchor="middle" fill="#ffffff" font-size="14" font-weight="700">Score</text>
+  <text x="650" y="445" text-anchor="middle" fill="#cccccc" font-size="11">evals judge every</text>
+  <text x="650" y="460" text-anchor="middle" fill="#cccccc" font-size="11">conversation</text>
+
+  <!-- Fix, centre: the short way back around -->
+  <rect x="305" y="395" width="190" height="80" rx="14" fill="#2f2f2f" stroke="#ffffff" stroke-width="1.2" />
+  <text x="400" y="425" text-anchor="middle" fill="#ffffff" font-size="14" font-weight="700">Fix</text>
+  <text x="400" y="445" text-anchor="middle" fill="#cccccc" font-size="11">update the prompt</text>
+  <text x="400" y="460" text-anchor="middle" fill="#cccccc" font-size="11">or config</text>
+
+  <!-- Deploy, bottom -->
+  <rect x="305" y="645" width="190" height="80" rx="14" fill="#2f2f2f" stroke="#ffffff" stroke-width="1.2" />
+  <text x="400" y="679" text-anchor="middle" fill="#ffffff" font-size="14" font-weight="700">Deploy</text>
+  <text x="400" y="701" text-anchor="middle" fill="#cccccc" font-size="11">ship to production</text>
+
+  <!-- Observe, left -->
+  <rect x="55" y="395" width="190" height="80" rx="14" fill="#2f2f2f" stroke="#ffffff" stroke-width="1.2" />
+  <text x="150" y="425" text-anchor="middle" fill="#ffffff" font-size="14" font-weight="700">Observe</text>
+  <text x="150" y="445" text-anchor="middle" fill="#cccccc" font-size="11">trace live traffic</text>
+
+  <text x="400" y="545" text-anchor="middle" fill="#7a7a7a" font-size="12" font-weight="700">The agent development loop</text>
+  <text x="400" y="565" text-anchor="middle" fill="#6a6a6a" font-size="11">every change rehearses before it ships</text>
+</svg>

--- a/src/pages/docs/simulation/index.mdx
+++ b/src/pages/docs/simulation/index.mdx
@@ -21,17 +21,7 @@ Every run is inspectable. Each conversation comes back with:
 
 Simulation is the rehearsal stage of the agent development lifecycle: every change to your agent passes through it before production, and production feeds the next rehearsal.
 
-<Mermaid chart={`
-%%{init: {"flowchart": {"curve": "linear"}}}%%
-flowchart LR
-    B["<b>Build</b><br/>Develop your agent"] --> S["<b>Simulate</b><br/>Rehearse voice or chat conversations"]
-    S --> E["<b>Score</b><br/>Evals judge every conversation"]
-    E --> F["<b>Fix</b><br/>Update the prompt or config"]
-    F --> S
-    E --> D["<b>Deploy</b><br/>Ship to production"]
-    D --> O["<b>Observe</b><br/>Trace live traffic"]
-    O -->|"Replay"| S
-`} />
+<img src="/images/docs/simulation/agent-development-loop.svg" alt="The agent development loop: Build feeds Simulate; evals score every conversation; a failing score loops back through Fix into another simulation, a passing one deploys; Observe traces production, and replay turns real conversations into the next rehearsal." style={{ border: 'none', width: '100%', maxWidth: '620px', margin: '1.75rem auto', display: 'block' }} />
 
 The loop closes on itself twice: a failing score sends you back to fix and re-simulate, and a production trace you [replay](/docs/simulation/concepts/replay) becomes a new test case.
 


### PR DESCRIPTION
## What
Replaces the Mermaid lifecycle chart on the Simulation overview (`/docs/simulation`) with a hand-authored SVG, `agent-development-loop.svg`, in the same visual style as `replay-loop.svg`.

## Why
The lifecycle has two loops (Score → Fix → Simulate, and Observe → Replay → Simulate), and Mermaid's layered layout can only render those as long back edges hooking around the whole canvas, which made the diagram clumsy and confusing.

## How
- Simulate, Score, Deploy, Observe at the cardinal points of one circle, four equal-radius arcs clockwise (the ship loop)
- Fix at the centre with straight chords Score → Fix → Simulate, so the iterate loop cuts through the middle instead of routing around the outside
- Build feeds in from above as the entry point; the Observe → Simulate arc carries the Replay label
- Stroke width 1.2, standard block style, kebab-case SVG attributes

## Recording
View at `/docs/simulation` on a local dev server, or open `public/images/docs/simulation/agent-development-loop.svg` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)