### PR TITLE
docs(simulation): group guides into subfolders in the sidebar

### DIFF
--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -720,13 +720,29 @@ export const tabNavigation: NavTab[] = [
               { title: 'Create scenarios', href: '/docs/simulation/guides/create-scenarios' },
               { title: 'Explore scenarios', href: '/docs/simulation/guides/explore-scenarios' },
               { title: 'Create personas', href: '/docs/simulation/guides/create-personas' },
-              { title: 'Run a voice simulation', href: '/docs/simulation/guides/run-voice-simulation' },
-              { title: 'Run a chat simulation', href: '/docs/simulation/guides/run-chat-simulation' },
-              { title: 'Simulate a prompt', href: '/docs/simulation/guides/prompt-simulation' },
-              { title: 'Edit evals in a simulation', href: '/docs/simulation/guides/edit-evals' },
-              { title: 'Replay chat sessions', href: '/docs/simulation/guides/replay-chat' },
-              { title: 'Replay voice calls', href: '/docs/simulation/guides/replay-voice' },
-              { title: 'Evaluate tool calls', href: '/docs/simulation/guides/evaluate-tool-calls' },
+              {
+                title: 'Running simulations',
+                items: [
+                  { title: 'Create a simulation', href: '/docs/simulation/guides/create-simulation' },
+                  { title: 'Run a voice simulation', href: '/docs/simulation/guides/run-voice-simulation' },
+                  { title: 'Run a chat simulation', href: '/docs/simulation/guides/run-chat-simulation' },
+                  { title: 'Simulate a prompt', href: '/docs/simulation/guides/prompt-simulation' },
+                ]
+              },
+              {
+                title: 'Evaluations in simulation',
+                items: [
+                  { title: 'Edit evals in a simulation', href: '/docs/simulation/guides/edit-evals' },
+                  { title: 'Evaluate tool calls', href: '/docs/simulation/guides/evaluate-tool-calls' },
+                ]
+              },
+              {
+                title: 'Replay simulations',
+                items: [
+                  { title: 'Replay chat sessions', href: '/docs/simulation/guides/replay-chat' },
+                  { title: 'Replay voice calls', href: '/docs/simulation/guides/replay-voice' },
+                ]
+              },
               {
                 title: 'Explore results',
                 items: [
@@ -736,8 +752,13 @@ export const tabNavigation: NavTab[] = [
                 ]
               },
               { title: 'Fix My Agent', href: '/docs/simulation/guides/fix-my-agent' },
-              { title: 'Running optimizations', href: '/docs/simulation/guides/running-optimizations' },
-              { title: 'Optimization runs', href: '/docs/simulation/guides/optimization-runs' },
+              {
+                title: 'Optimize using simulate',
+                items: [
+                  { title: 'Running optimizations', href: '/docs/simulation/guides/running-optimizations' },
+                  { title: 'Optimization runs', href: '/docs/simulation/guides/optimization-runs' },
+                ]
+              },
             ]
           },
           {


### PR DESCRIPTION
## What
Groups the Simulation guides into nested sidebar folders, and adds a new **Create a simulation** guide entry.

- **Running simulations**: Create a simulation (new), Run a voice simulation, Run a chat simulation, Simulate a prompt
- **Evaluations in simulation**: Edit evals in a simulation, Evaluate tool calls
- **Replay simulations**: Replay chat sessions, Replay voice calls
- **Explore results**: unchanged (Overview, Calls & transcripts, Analytics & metrics)
- **Optimize using simulate**: Running optimizations, Optimization runs

Ungrouped at the top level: Connect your agent, Create scenarios, Explore scenarios, Create personas, Fix My Agent.

## Why
The flat list of 17 guides had no shape. Grouping by task puts the related how-tos together and shortens the scan.

## How
Sidebar-only change: page URLs stay flat (`guides/run-voice-simulation`, not `guides/running-simulations/run-voice-simulation`), so no redirects are needed and no inline links in the merged concept pages break. Nested group headers render as plain labels (`Sidebar.astro:283-291`), so the new folders need no index page, matching the existing Explore results folder.

`Create a simulation` (`guides/create-simulation`) is a new page still to be written; its nav entry 404s until it lands, consistent with the other unbuilt guides on this branch.

## Recording
View the Simulation sidebar at `/docs/simulation` on a local dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)