### PR TITLE
docs(simulation): split Explore scenarios into a guides subfolder

### DIFF
--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -718,7 +718,15 @@ export const tabNavigation: NavTab[] = [
             items: [
               { title: 'Connect your agent', href: '/docs/simulation/guides/connect-your-agent' },
               { title: 'Create scenarios', href: '/docs/simulation/guides/create-scenarios' },
-              { title: 'Explore scenarios', href: '/docs/simulation/guides/explore-scenarios' },
+              {
+                title: 'Explore scenarios',
+                items: [
+                  { title: 'Overview', href: '/docs/simulation/guides/explore-scenarios' },
+                  { title: 'Explore scenario graph', href: '/docs/simulation/guides/explore-scenarios/scenario-graph' },
+                  { title: 'Add rows', href: '/docs/simulation/guides/explore-scenarios/add-rows' },
+                  { title: 'Add columns', href: '/docs/simulation/guides/explore-scenarios/add-columns' },
+                ]
+              },
               { title: 'Create personas', href: '/docs/simulation/guides/create-personas' },
               {
                 title: 'Running simulations',


### PR DESCRIPTION
## What
Turns the single **Explore scenarios** guide entry into a four-page subfolder in the Simulation sidebar:

- Overview: `/docs/simulation/guides/explore-scenarios`
- Explore scenario graph: `explore-scenarios/scenario-graph`
- Add rows: `explore-scenarios/add-rows`
- Add columns: `explore-scenarios/add-columns`

## Why
One page was carrying the whole scenario detail view: the graph, the rows table, and column management. Splitting it matches the Explore results subfolder already in this section.

## How
Sidebar-only change, same shape as the Explore results group: the nested header renders as a plain label, so the folder needs no index page beyond its Overview child. Page URLs nest under `explore-scenarios/`, and the three new ones 404 until written, consistent with the other unbuilt guides on this branch. The just-merged Create scenarios guide already links `explore-scenarios/scenario-graph`.

## Recording
View the Simulation sidebar at `/docs/simulation` on a local dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)