### PR TITLE
docs(self-hosting): add Profiles and Launch mode reference pages [TH-7471]

### DIFF
--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -67,6 +67,8 @@ export const tabNavigation: NavTab[] = [
                 items: [
                   { title: 'System configuration', href: '/docs/self-hosting/configuration/system' },
                   { title: 'Environment variables', href: '/docs/self-hosting/configuration/environment' },
+                  { title: 'Profiles', href: '/docs/self-hosting/configuration/profiles' },
+                  { title: 'Launch mode', href: '/docs/self-hosting/configuration/launch-mode' },
                 ]
               },
               {

--- a/src/pages/docs/self-hosting.mdx
+++ b/src/pages/docs/self-hosting.mdx
@@ -3,7 +3,7 @@ title: "Self-hosting Future AGI"
 description: "Run the entire Future AGI platform on your own infrastructure with Docker Compose. Your traces, datasets, evaluations, and model calls stay inside your network"
 ---
 
-Future AGI is fully open-source. Self-hosting runs the **entire stack on your own machines**, so all traces, datasets, evaluations, and model calls stay within your network. The backend is Django, the frontend is React + Vite, and the LLM gateway is Go, all deployed together with Docker Compose
+Future AGI is fully open-source. Self-hosting runs the **entire stack on your own machines**, so all traces, datasets, evaluations, and model calls stay within your network. The backend is Django, the frontend is React + Vite, and the LLM gateway is Go, all deployed together with Docker Compose.
 
 ## When to self-host
 
@@ -16,46 +16,42 @@ The [**cloud hosted version**](https://app.futureagi.com) is the easiest way to 
 
 ## What you deploy
 
-Self-hosting brings up the full platform (around **21 containers, with no external dependencies**) across four layers:
+A default install brings up **13 services**, and that is already a complete instance: you can sign in, send traces, and run evaluations with nothing else enabled. The stack defines 31 services in total, and [profiles](/docs/self-hosting/configuration/profiles) decide which of them you get.
 
 ```
 Browser
   └─ frontend (React/nginx)
-       └─ backend (Django) ──── gateway (Go) ──── OpenAI · Anthropic · Gemini · Bedrock
+       └─ backend (Django) ──── agentcc-gateway (Go) ──── OpenAI · Anthropic · Gemini · Bedrock
             ├── postgres      primary database
-            ├── clickhouse    analytics store
+            ├── clickhouse    trace and analytics store
             ├── redis         cache / pub-sub
+            ├── rabbitmq      task broker
             ├── minio         object storage
             └── temporal ──── worker   background jobs / eval pipelines
 
-postgres ──── PeerDB CDC ──── clickhouse   (continuous replication)
+your agent ──OTLP──> fi-collector ──> clickhouse    spans, written directly
+postgres ──── PeerDB CDC ──────────> clickhouse    mirrored tables, `full` profile only
 ```
 
-- **Application**: `frontend`, `backend`, `worker`, `gateway`, `serving`, `code-executor`
-- **Data**: `postgres`, `clickhouse`, `redis`, `minio`
+Those 13 break down as:
+
+- **Application**: `frontend`, `backend`, `worker`, `agentcc-gateway`, `serving`, `code-executor`
+- **Data**: `postgres`, `clickhouse`, `redis`, `rabbitmq`, `minio`
+- **Ingest**: `fi-collector`, the OTLP receiver that writes spans straight to ClickHouse
 - **Workflow**: `temporal`
-- **CDC**: PeerDB (continuous Postgres → ClickHouse replication)
 
-Everything runs on your machines; nothing leaves your network. The full service-by-service breakdown lives in [Configure](/docs/self-hosting/configuration).
-
-## Deployment options
-
-| Option | Status |
-|---|---|
-| Docker Compose | Available |
-| Helm / Kubernetes | Coming soon |
-| Air-gapped | Coming soon |
+The ten PeerDB replication services sit outside that set and stay off until you ask for them. Everything runs on your machines, and nothing leaves your network apart from the model calls you configure the gateway to make. The service-by-service breakdown lives in [Profiles](/docs/self-hosting/configuration/profiles).
 
 ## Where to go next
 
 <CardGroup cols={3}>
-  <Card title="Configure" icon="gear" href="/docs/self-hosting/configuration">
-    System requirements, prerequisites, environment variables, and setup
+  <Card title="Requirements" icon="server" href="/docs/self-hosting/requirements">
+    Size the host and check your platform before you install
   </Card>
-  <Card title="Troubleshooting & FAQs" icon="wrench" href="/docs/self-hosting/troubleshooting">
-    Fixes for common errors and answers to frequent questions
+  <Card title="Installation" icon="play-circle" href="/docs/self-hosting/installation">
+    Clone the repo and bring the stack up with `./bin/install`
   </Card>
-  <Card title="Support" icon="comments" href="/docs/self-hosting/support">
-    Get help from the Future AGI team and community
+  <Card title="System configuration" icon="gear" href="/docs/self-hosting/configuration/system">
+    Point the LLM gateway at your providers and tune the workers
   </Card>
 </CardGroup>

--- a/src/pages/docs/self-hosting.mdx
+++ b/src/pages/docs/self-hosting.mdx
@@ -3,7 +3,7 @@ title: "Self-hosting Future AGI"
 description: "Run the entire Future AGI platform on your own infrastructure with Docker Compose. Your traces, datasets, evaluations, and model calls stay inside your network"
 ---
 
-Future AGI is fully open-source. Self-hosting runs the **entire stack on your own machines**, so all traces, datasets, evaluations, and model calls stay within your network. The backend is Django, the frontend is React + Vite, and the LLM gateway is Go, all deployed together with Docker Compose.
+Future AGI is [fully open-source](https://github.com/future-agi/future-agi). Self-hosting runs the **entire stack on your own machines**, so all traces, datasets, evaluations, and model calls stay within your network. The backend is Django, the frontend is React + Vite, and the LLM gateway is Go, all deployed together with Docker Compose.
 
 ## When to self-host
 
@@ -14,19 +14,23 @@ The [**cloud hosted version**](https://app.futureagi.com) is the easiest way to 
 - **Cost control at scale**: own the infrastructure
 - **Deep customization**: modify the open-source stack to fit your needs
 
+What it costs you is a host and the operating. Budget 4 CPU cores and 8 GB of RAM for a trial, more for real traffic, and expect to run 13 containers that you patch and back up yourself. [Requirements](/docs/self-hosting/requirements) has the sizing, then `./bin/install` brings the stack up in one command.
+
 ## What you deploy
 
-A default install brings up **13 services**, and that is already a complete instance: you can sign in, send traces, and run evaluations with nothing else enabled. The stack defines 31 services in total, and [profiles](/docs/self-hosting/configuration/profiles) decide which of them you get.
+A default install brings up **13 services**, and that is already a complete instance: you can sign in, send traces, and run evaluations with nothing else enabled.
 
 ```
 Browser
   └─ frontend (React/nginx)
        └─ backend (Django) ──── agentcc-gateway (Go) ──── OpenAI · Anthropic · Gemini · Bedrock
-            ├── postgres      primary database
-            ├── clickhouse    trace and analytics store
-            ├── redis         cache / pub-sub
-            ├── rabbitmq      task broker
-            ├── minio         object storage
+            ├── postgres        primary database
+            ├── clickhouse      trace and analytics store
+            ├── redis           cache / pub-sub
+            ├── rabbitmq        task broker
+            ├── minio           object storage
+            ├── serving         built-in evals and guardrails
+            ├── code-executor   sandbox for custom code evals
             └── temporal ──── worker   background jobs / eval pipelines
 
 your agent ──OTLP──> fi-collector ──> clickhouse    spans, written directly
@@ -40,9 +44,13 @@ Those 13 break down as:
 - **Ingest**: `fi-collector`, the OTLP receiver that writes spans straight to ClickHouse
 - **Workflow**: `temporal`
 
-The ten PeerDB replication services sit outside that set and stay off until you ask for them. Everything runs on your machines, and nothing leaves your network apart from the model calls you configure the gateway to make. The service-by-service breakdown lives in [Profiles](/docs/self-hosting/configuration/profiles).
+Another 18 services ship switched off, which is where the stack's total of 31 comes from: six extra Temporal workers, two Temporal admin tools, and the ten PeerDB replication services that mirror Postgres tables into ClickHouse. You turn a group on with a **profile**, a named bundle you set once in `.env`, and [Profiles](/docs/self-hosting/configuration/profiles) covers what each one adds.
+
+Everything runs on your machines, and nothing leaves your network apart from the model calls you configure the gateway to make.
 
 ## Where to go next
+
+Work these in order the first time through.
 
 <CardGroup cols={3}>
   <Card title="Requirements" icon="server" href="/docs/self-hosting/requirements">

--- a/src/pages/docs/self-hosting/configuration/environment.mdx
+++ b/src/pages/docs/self-hosting/configuration/environment.mdx
@@ -5,7 +5,7 @@ description: "Complete .env reference for a self-hosted Future AGI instance"
 
 ## In this page
 
-Every setting the stack reads at boot comes from a single `.env` file in the repo root. This page is the complete reference, grouped by what each variable does. The stack boots fine with the shipped defaults. The only thing you *must* change before sharing the instance is the `CHANGEME` secrets.
+Every setting the stack reads at boot comes from a single `.env` file in the repo root. This page is the complete reference, grouped by what each variable does. The stack boots fine with the shipped defaults. The one thing you *must* change before sharing the instance is the secrets, which ship with working development values rather than blanks.
 
 ```bash
 cp .env.example .env
@@ -17,7 +17,7 @@ Doing a local trial? Skip to [Installation](/docs/self-hosting/installation). Th
 
 ## Required Secrets
 
-Replace every `CHANGEME` in this group before anyone else can reach the instance. Generate each value with the command shown.
+Every value in this group has a development default that works out of the box, so nothing warns you when you leave it in place. Replace all four before anyone else can reach the instance, generating each with the command shown.
 
 | Variable | Generate with | Used by |
 |---|---|---|
@@ -35,10 +35,10 @@ Replace every `CHANGEME` in this group before anyone else can reach the instance
 | Variable | Default | Notes |
 |---|---|---|
 | `PG_USER` | `futureagi` | PostgreSQL username |
-| `PG_PASSWORD` | `CHANGEME` | **Must change** |
+| `PG_PASSWORD` | `futureagi` | **Must change** |
 | `PG_DB` | `futureagi` | PostgreSQL database name |
 | `MINIO_ROOT_USER` | `futureagi` | MinIO username |
-| `MINIO_ROOT_PASSWORD` | `CHANGEME` | **Must change** |
+| `MINIO_ROOT_PASSWORD` | `futureagi` | **Must change** |
 | `CH_USE_REPLICATED_ENGINES` | `false` | `true` only for multi-node ClickHouse |
 
 ## Ports
@@ -71,7 +71,7 @@ Tuning guidance lives in [System configuration](/docs/self-hosting/configuration
 
 | Variable | Default | Description |
 |---|---|---|
-| `AGENTCC_INTERNAL_API_KEY` | `CHANGEME` | **Must change.** The backend authenticates gateway calls with this shared secret |
+| `AGENTCC_INTERNAL_API_KEY` | `local-dev-only-shared-secret-replace-me` | **Must change.** The backend authenticates gateway calls with this shared secret |
 
 Setting a key here is only half the job. The gateway also needs a `config.yaml` listing the providers it may route to. See [System configuration](/docs/self-hosting/configuration/system#llm-gateway).
 
@@ -100,7 +100,7 @@ Email delivery powers self-service sign-up and password reset. Without it, you c
 ## Frontend Build-Time
 
 <Warning>
-These are baked into the JavaScript bundle at Vite build time. Changing them requires a rebuild: `docker compose build frontend`.
+`VITE_HOST_API` is the exception: the frontend container writes it into `config.js` on start, so changing it needs a restart (`docker compose up -d frontend`), not a rebuild. The rest really are baked into the JavaScript bundle at Vite build time, and the published images are prebuilt, so changing one means building your own frontend image.
 </Warning>
 
 | Variable | Default | Description |
@@ -127,7 +127,7 @@ These are baked into the JavaScript bundle at Vite build time. Changing them req
   <Card title="Profiles" icon="layer-group" href="/docs/self-hosting/configuration/profiles">
     What `COMPOSE_PROFILES` does to the set of services you run
   </Card>
-  <Card title="Launch mode" icon="rocket" href="/docs/self-hosting/configuration/launch-mode">
-    How strictly a fresh install enforces its pre-flight checks
+  <Card title="Production checklist" icon="shield" href="/docs/self-hosting/production/checklist">
+    Replace the shipped secret defaults before the instance carries real traffic
   </Card>
 </CardGroup>

--- a/src/pages/docs/self-hosting/configuration/environment.mdx
+++ b/src/pages/docs/self-hosting/configuration/environment.mdx
@@ -11,6 +11,8 @@ Every setting the stack reads at boot comes from a single `.env` file in the rep
 cp .env.example .env
 ```
 
+Changes apply on the next `docker compose up -d`, which recreates the containers whose environment changed. Two exceptions are called out below: `PG_PASSWORD` only takes on Postgres's very first boot, and the `VITE_*` variables other than `VITE_HOST_API` are baked in at image build time.
+
 <TLDR>
 Doing a local trial? Skip to [Installation](/docs/self-hosting/installation). The defaults work as-is. Come back here when you're ready to set secrets, add LLM provider keys, or turn on email.
 </TLDR>
@@ -35,10 +37,10 @@ Every value in this group has a development default that works out of the box, s
 | Variable | Default | Notes |
 |---|---|---|
 | `PG_USER` | `futureagi` | PostgreSQL username |
-| `PG_PASSWORD` | `futureagi` | **Must change** |
+| `PG_PASSWORD` | `futureagi` | **Must change**, set it in Required Secrets above |
 | `PG_DB` | `futureagi` | PostgreSQL database name |
 | `MINIO_ROOT_USER` | `futureagi` | MinIO username |
-| `MINIO_ROOT_PASSWORD` | `futureagi` | **Must change** |
+| `MINIO_ROOT_PASSWORD` | `futureagi` | **Must change**, set it in Required Secrets above |
 | `CH_USE_REPLICATED_ENGINES` | `false` | `true` only for multi-node ClickHouse |
 
 ## Ports
@@ -71,7 +73,7 @@ Tuning guidance lives in [System configuration](/docs/self-hosting/configuration
 
 | Variable | Default | Description |
 |---|---|---|
-| `AGENTCC_INTERNAL_API_KEY` | `local-dev-only-shared-secret-replace-me` | **Must change.** The backend authenticates gateway calls with this shared secret |
+| `AGENTCC_INTERNAL_API_KEY` | `local-dev-only-shared-secret-replace-me` | **Must change**, set it in Required Secrets above. The backend authenticates gateway calls with this shared secret |
 
 Setting a key here is only half the job. The gateway also needs a `config.yaml` listing the providers it may route to. See [System configuration](/docs/self-hosting/configuration/system#llm-gateway).
 
@@ -100,7 +102,7 @@ Email delivery powers self-service sign-up and password reset. Without it, you c
 ## Frontend Build-Time
 
 <Warning>
-`VITE_HOST_API` is the exception: the frontend container writes it into `config.js` on start, so changing it needs a restart (`docker compose up -d frontend`), not a rebuild. The rest really are baked into the JavaScript bundle at Vite build time, and the published images are prebuilt, so changing one means building your own frontend image.
+These are baked into the JavaScript bundle at Vite build time, and the published images are prebuilt, so changing one means building your own frontend image. `VITE_HOST_API` is the exception: the frontend container writes it into `config.js` on start, so changing that one needs only a restart (`docker compose up -d frontend`).
 </Warning>
 
 | Variable | Default | Description |

--- a/src/pages/docs/self-hosting/configuration/environment.mdx
+++ b/src/pages/docs/self-hosting/configuration/environment.mdx
@@ -120,11 +120,14 @@ These are baked into the JavaScript bundle at Vite build time. Changing them req
 
 ## Dive deeper
 
-<CardGroup cols={2}>
-  <Card title="System Configuration" icon="gear" href="/docs/self-hosting/configuration/system">
+<CardGroup cols={3}>
+  <Card title="System configuration" icon="gear" href="/docs/self-hosting/configuration/system">
     Point the LLM gateway at your providers and set up PeerDB mirrors
   </Card>
-  <Card title="Production hardening" icon="shield" href="/docs/self-hosting/production">
-    Harden the instance before exposing it to users
+  <Card title="Profiles" icon="layer-group" href="/docs/self-hosting/configuration/profiles">
+    What `COMPOSE_PROFILES` does to the set of services you run
+  </Card>
+  <Card title="Launch mode" icon="rocket" href="/docs/self-hosting/configuration/launch-mode">
+    How strictly a fresh install enforces its pre-flight checks
   </Card>
 </CardGroup>

--- a/src/pages/docs/self-hosting/configuration/launch-mode.mdx
+++ b/src/pages/docs/self-hosting/configuration/launch-mode.mdx
@@ -1,0 +1,96 @@
+---
+title: "Launch mode"
+description: "What the setup wizard checks, and how the two modes differ"
+---
+
+## In this page
+
+The first screen a fresh self-hosted install shows at `/setup` asks how you plan to run the instance. That answer is the **launch mode**, and it decides how strictly the pre-flight checks on the next screen are enforced. It changes how a result is reported, never which services run.
+
+<TLDR>
+Production requires every core system and holds you on the setup screen while one is down. Test flight eases the non-critical ones so a partial stack still gets you through. Both run the same twelve checks against the same services.
+</TLDR>
+
+<Mermaid chart={`
+%%{init: {"flowchart": {"curve": "linear"}}}%%
+flowchart TD
+    accTitle: One probe result, reported two ways depending on launch mode
+    accDescr: A non-critical service that is down reads as Failed and holds you on the screen in Production, and as Caution or Optional that never blocks in Test flight.
+    P["A non-critical service is down"] -->|"Production"| L["Failed, holds you here"]
+    P -->|"Test flight"| E["Caution or Optional, never blocks"]
+`} />
+
+## The two modes
+
+You pick one on the first setup screen, and Production is selected by default. The choice is not written to `.env` and nothing reads it later, so it only affects this one run through the wizard.
+
+### Production
+
+For an instance that will carry real traffic. Every core system has to answer before you can continue, and a single failed check holds you on the screen until you fix it. The two feature-level services, the agent fixer and the code execution sandbox, still read as a caution rather than a hard stop.
+
+### Test flight
+
+For trying Future AGI out locally. The same twelve checks still run and you still see every result, but the non-critical ones are downgraded so a partial stack reads as expected rather than broken. Nothing blocks you from continuing.
+
+## The pre-flight checklist
+
+Twelve rows appear on screen. Ten of them probe a service, each with a three-second timeout, in the order below. The two mode columns show what a *down* service reads as.
+
+| Check | If it's down | Production | Test flight |
+|---|---|---|---|
+| Core application database | Nothing loads at all | Failed | Failed |
+| Tracing data warehouse | Traces, spans and dashboards won't load | Failed | Failed |
+| Cache and session store | Sign-ins, caching and rate limits break | Failed | Caution |
+| Websocket connection | Live updates won't reach the browser | Failed | Caution |
+| Object storage service | Dataset uploads, exports and media fail | Failed | Caution |
+| LLM request gateway | Every model call fails | Failed | Failed |
+| Async task engine | Evaluations and scheduled jobs won't run | Failed | Failed |
+| Trace ingestion | Spans sent by the SDK won't arrive | Failed | Failed |
+| Agent fixer (evals + Error Feed) | Built-in evaluations and guardrails won't run | Caution | Optional |
+| Code execution sandbox | Custom code evaluations won't run | Caution | Optional |
+
+The remaining two rows, **Django backend** and **React frontend**, sit between Trace ingestion and Agent fixer on screen. Neither is probed: both are inferred from the page having loaded at all, so they always read Ready.
+
+The results come from `GET /api/setup-checks/`, which needs no authentication and returns 404 on anything that isn't a self-hosted install. Each snapshot is cached for three seconds.
+
+## What each status means
+
+| Status | Meaning |
+|---|---|
+| Ready | The service answered |
+| Caution | It's down, but this mode doesn't require it |
+| Failed | It's down and this mode requires it |
+| Optional | It's down, and this mode doesn't use it anyway |
+| Checking… | The probe hasn't come back yet |
+
+A service that answers always reads Ready, in both modes. Whether it's up is a fact about your deployment and never varies by mode, so only the label on a *down* service changes.
+
+## When Continue is blocked
+
+Three things hold you on the checks screen:
+
+- The instance isn't reachable yet, which is normal on a first boot while containers are still starting
+- The results are still revealing, so you haven't seen them all
+- You're in Production and at least one check reads Failed
+
+Test flight never blocks on results. If a check fails after you've fixed something, **Re-run pre-flight** re-probes everything without reloading the page.
+
+## Launch mode is not a profile
+
+This is not the same as picking a profile. [Profiles](/docs/self-hosting/configuration/profiles) decide which containers run on your host, and you set them in `.env` before the stack starts. Launch mode is a one-off choice in the browser that changes nothing about your deployment, only how the checks report.
+
+The two can't affect each other. Every service the checks probe is one that always runs, so a light install and a `full` one produce identical results. You can't fail pre-flight by running the smaller stack.
+
+## Dive deeper
+
+<CardGroup cols={3}>
+  <Card title="System configuration" icon="gear" href="/docs/self-hosting/configuration/system">
+    Point the LLM gateway at your providers and set up PeerDB mirrors
+  </Card>
+  <Card title="Environment variables" icon="list-check" href="/docs/self-hosting/configuration/environment">
+    Set provider keys, secrets, and runtime flags in `.env`
+  </Card>
+  <Card title="Profiles" icon="layer-group" href="/docs/self-hosting/configuration/profiles">
+    Pick which of the 31 services your instance runs
+  </Card>
+</CardGroup>

--- a/src/pages/docs/self-hosting/configuration/launch-mode.mdx
+++ b/src/pages/docs/self-hosting/configuration/launch-mode.mdx
@@ -32,6 +32,18 @@ For an instance that will carry real traffic. Every core system has to answer be
 
 For trying Future AGI out locally. The same twelve checks still run and you still see every result, but the non-critical ones are downgraded so a partial stack reads as expected rather than broken. Nothing blocks you from continuing.
 
+## What each status means
+
+| Status | Meaning |
+|---|---|
+| Ready | The service answered |
+| Caution | It's down, but this mode doesn't require it |
+| Failed | It's down and this mode requires it |
+| Optional | It's down, and this mode doesn't use it anyway |
+| Checking… | The probe hasn't come back yet |
+
+A service that answers always reads Ready, in both modes. Whether it's up is a fact about your deployment and never varies by mode, so only the label on a *down* service changes. Only **Failed** ever blocks you; the rest are there to be read.
+
 ## The pre-flight checklist
 
 Twelve rows appear on screen. Ten of them probe a service, each with a three-second timeout, in the order below. The two mode columns show what a *down* service reads as, and the container column is what to restart when one fails.
@@ -46,24 +58,14 @@ Twelve rows appear on screen. Ten of them probe a service, each with a three-sec
 | LLM request gateway | `agentcc-gateway` | Every model call fails | Failed | Failed |
 | Async task engine | `temporal` | Evaluations and scheduled jobs won't run | Failed | Failed |
 | Trace ingestion | `fi-collector` | Spans sent by the SDK won't arrive | Failed | Failed |
+| Django backend | `backend` | Not probed, always reads Ready | n/a | n/a |
+| React frontend | `frontend` | Not probed, always reads Ready | n/a | n/a |
 | Agent fixer (evals + Error Feed) | `serving` | Built-in evaluations and guardrails won't run | Caution | Optional |
 | Code execution sandbox | `code-executor` | Custom code evaluations won't run | Caution | Optional |
 
-The remaining two rows, **Django backend** and **React frontend**, sit between Trace ingestion and Agent fixer on screen. Neither is probed: both are inferred from the page having loaded at all, so they always read Ready.
+**Django backend** and **React frontend** are the two unprobed rows: both are inferred from the page having loaded at all, so they can never come back as anything but Ready.
 
-The results come from `GET /api/setup-checks/`, which needs no authentication and returns 404 on anything that isn't a self-hosted install. Each snapshot is cached for three seconds.
-
-## What each status means
-
-| Status | Meaning |
-|---|---|
-| Ready | The service answered |
-| Caution | It's down, but this mode doesn't require it |
-| Failed | It's down and this mode requires it |
-| Optional | It's down, and this mode doesn't use it anyway |
-| Checking… | The probe hasn't come back yet |
-
-A service that answers always reads Ready, in both modes. Whether it's up is a fact about your deployment and never varies by mode, so only the label on a *down* service changes.
+The results come from `GET /api/setup-checks/`, which needs no authentication and returns 404 on anything that isn't a self-hosted install, so you can poll it from a script if you want the same view outside the wizard.
 
 ## When Continue is blocked
 
@@ -73,7 +75,9 @@ Three things hold you on the checks screen:
 - The results are still revealing, so you haven't seen them all
 - You're in Production and at least one check reads Failed
 
-Test flight never blocks on results. If a check fails after you've fixed something, **Re-run pre-flight** re-probes everything without reloading the page.
+Test flight never blocks on results. If a check fails after you've fixed something, **Re-run pre-flight** re-probes everything without reloading the page. Snapshots are cached for three seconds, so give it a moment rather than clicking repeatedly.
+
+The fix for a Failed row is almost always restarting the container named in its **Container** column, for example `docker compose up -d clickhouse`. If it keeps coming back red, [Troubleshooting](/docs/self-hosting/troubleshooting) covers the common causes service by service.
 
 ## Launch mode is not a profile
 

--- a/src/pages/docs/self-hosting/configuration/launch-mode.mdx
+++ b/src/pages/docs/self-hosting/configuration/launch-mode.mdx
@@ -5,7 +5,7 @@ description: "What the setup wizard checks, and how the two modes differ"
 
 ## In this page
 
-The first screen a fresh self-hosted install shows at `/setup` asks how you plan to run the instance. That answer is the **launch mode**, and it decides how strictly the pre-flight checks on the next screen are enforced. It changes how a result is reported, never which services run.
+The first screen a fresh [self-hosted install](/docs/self-hosting/installation) shows at `/setup` asks how you plan to run the instance. That answer is the **launch mode**, and it decides how strictly the pre-flight checks on the next screen are enforced. It changes how a result is reported, never which services run.
 
 <TLDR>
 Production requires every core system and holds you on the setup screen while one is down. Test flight eases the non-critical ones so a partial stack still gets you through. Both run the same twelve checks against the same services.
@@ -22,7 +22,7 @@ flowchart TD
 
 ## The two modes
 
-You pick one on the first setup screen, and Production is selected by default. The choice is not written to `.env` and nothing reads it later, so it only affects this one run through the wizard.
+You pick one on the first setup screen, and Production is selected by default. The choice is not written to [`.env`](/docs/self-hosting/configuration/environment) and nothing reads it later, so it only affects this one run through the wizard.
 
 ### Production
 
@@ -34,20 +34,20 @@ For trying Future AGI out locally. The same twelve checks still run and you stil
 
 ## The pre-flight checklist
 
-Twelve rows appear on screen. Ten of them probe a service, each with a three-second timeout, in the order below. The two mode columns show what a *down* service reads as.
+Twelve rows appear on screen. Ten of them probe a service, each with a three-second timeout, in the order below. The two mode columns show what a *down* service reads as, and the container column is what to restart when one fails.
 
-| Check | If it's down | Production | Test flight |
-|---|---|---|---|
-| Core application database | Nothing loads at all | Failed | Failed |
-| Tracing data warehouse | Traces, spans and dashboards won't load | Failed | Failed |
-| Cache and session store | Sign-ins, caching and rate limits break | Failed | Caution |
-| Websocket connection | Live updates won't reach the browser | Failed | Caution |
-| Object storage service | Dataset uploads, exports and media fail | Failed | Caution |
-| LLM request gateway | Every model call fails | Failed | Failed |
-| Async task engine | Evaluations and scheduled jobs won't run | Failed | Failed |
-| Trace ingestion | Spans sent by the SDK won't arrive | Failed | Failed |
-| Agent fixer (evals + Error Feed) | Built-in evaluations and guardrails won't run | Caution | Optional |
-| Code execution sandbox | Custom code evaluations won't run | Caution | Optional |
+| Check | Container | What breaks | Production | Test flight |
+|---|---|---|---|---|
+| Core application database | `postgres` | Nothing loads at all | Failed | Failed |
+| Tracing data warehouse | `clickhouse` | Traces, spans and dashboards won't load | Failed | Failed |
+| Cache and session store | `redis` | Sign-ins, caching and rate limits break | Failed | Caution |
+| Websocket connection | `rabbitmq` | Live updates won't reach the browser | Failed | Caution |
+| Object storage service | `minio` | Dataset uploads, exports and media fail | Failed | Caution |
+| LLM request gateway | `agentcc-gateway` | Every model call fails | Failed | Failed |
+| Async task engine | `temporal` | Evaluations and scheduled jobs won't run | Failed | Failed |
+| Trace ingestion | `fi-collector` | Spans sent by the SDK won't arrive | Failed | Failed |
+| Agent fixer (evals + Error Feed) | `serving` | Built-in evaluations and guardrails won't run | Caution | Optional |
+| Code execution sandbox | `code-executor` | Custom code evaluations won't run | Caution | Optional |
 
 The remaining two rows, **Django backend** and **React frontend**, sit between Trace ingestion and Agent fixer on screen. Neither is probed: both are inferred from the page having loaded at all, so they always read Ready.
 
@@ -77,9 +77,7 @@ Test flight never blocks on results. If a check fails after you've fixed somethi
 
 ## Launch mode is not a profile
 
-This is not the same as picking a profile. [Profiles](/docs/self-hosting/configuration/profiles) decide which containers run on your host, and you set them in `.env` before the stack starts. Launch mode is a one-off choice in the browser that changes nothing about your deployment, only how the checks report.
-
-The two can't affect each other. Every service the checks probe is one that always runs, so a light install and a `full` one produce identical results. You can't fail pre-flight by running the smaller stack.
+Every container the checks probe is one of the always-on 13, so a light install and a `full` one produce identical results. You can't fail pre-flight by running the smaller stack. [Profiles](/docs/self-hosting/configuration/profiles) decide which containers run at all and are set in `.env` before the stack starts. Launch mode is a one-off choice in the browser that changes nothing about your deployment.
 
 ## Dive deeper
 
@@ -87,10 +85,10 @@ The two can't affect each other. Every service the checks probe is one that alwa
   <Card title="System configuration" icon="gear" href="/docs/self-hosting/configuration/system">
     Point the LLM gateway at your providers and set up PeerDB mirrors
   </Card>
-  <Card title="Environment variables" icon="list-check" href="/docs/self-hosting/configuration/environment">
-    Set provider keys, secrets, and runtime flags in `.env`
+  <Card title="Production checklist" icon="shield" href="/docs/self-hosting/production/checklist">
+    Harden the instance before it carries real traffic
   </Card>
-  <Card title="Profiles" icon="layer-group" href="/docs/self-hosting/configuration/profiles">
-    Pick which of the 31 services your instance runs
+  <Card title="Troubleshooting & FAQs" icon="wrench" href="/docs/self-hosting/troubleshooting">
+    What to do when a check keeps coming back Failed
   </Card>
 </CardGroup>

--- a/src/pages/docs/self-hosting/configuration/profiles.mdx
+++ b/src/pages/docs/self-hosting/configuration/profiles.mdx
@@ -5,7 +5,7 @@ description: "Choosing which of the 31 services your self-hosted instance actual
 
 ## In this page
 
-The self-hosted stack defines 31 services, but a working instance only needs 13 of them. The rest are opt-in: extra Temporal workers, a workflow dashboard, and the replication pipeline that feeds analytics. A **profile** is the tag that decides which group you get, set once in `.env` and read by every `docker compose` command after that.
+The self-hosted stack defines 31 services, but a working instance only needs 13 of them. The rest are opt-in: extra Temporal workers, a workflow dashboard, and the replication pipeline that feeds analytics. A **profile** is the tag that decides which group you get, set once in the [`.env` file](/docs/self-hosting/configuration/environment) and read by every `docker compose` command after that.
 
 <TLDR>
 An empty `.env` gives you 13 services, which is a complete, usable instance. Three profiles add to that: `workers`, `observability`, and `full`. Name them in `COMPOSE_PROFILES` and their additions stack.
@@ -21,9 +21,18 @@ flowchart TD
     C -->|"full"| F["Ten PeerDB services"]
 `} />
 
+## The core stack
+
+Thirteen services carry no profile, so they always run:
+
+- **Application:** `frontend`, `backend`, `worker`, `agentcc-gateway`, `serving`, `code-executor`
+- **Data layer:** `postgres`, `clickhouse`, `redis`, `rabbitmq`, `minio`, `temporal`, `fi-collector`
+
+This is a complete instance. You can sign in, send traces, and run evaluations with nothing else enabled.
+
 ## The profiles
 
-Leave `COMPOSE_PROFILES` unset and you get the core 13 services. Three profiles exist to add to that, each one independent.
+Leave `COMPOSE_PROFILES` unset and you get those 13. Three profiles exist to add to them, each one independent.
 
 | Profile | What it adds | Total services |
 |---|---|---|
@@ -32,10 +41,6 @@ Leave `COMPOSE_PROFILES` unset and you get the core 13 services. Three profiles 
 | `full` | The ten-service PeerDB replication stack | 23 |
 
 Combine them with commas, and the additions stack: `COMPOSE_PROFILES=workers,observability` runs 21 services, and naming all three runs all 31.
-
-### The core stack
-
-Thirteen services carry no profile, so they always run: `frontend`, `backend`, `worker`, `agentcc-gateway`, `serving`, `code-executor`, and the data layer of `postgres`, `clickhouse`, `redis`, `rabbitmq`, `minio`, `temporal`, and `fi-collector`. This is a complete instance. You can sign in, send traces, and run evaluations with nothing else enabled.
 
 ### workers
 
@@ -47,7 +52,9 @@ Adds `temporal-ui` on port 8085 and `temporal-admin-tools`, a shell with the `tc
 
 ### full
 
-Adds the ten PeerDB services that replicate Postgres tables into ClickHouse through change data capture, including datasets, prompts, simulation runs, and trace metadata. It's the heaviest option, roughly doubling your container count, and `./bin/install --full` is the shortcut for turning it on.
+Adds the ten PeerDB services that replicate Postgres tables into ClickHouse through change data capture, covering datasets, prompts, simulation runs, and trace metadata. It's the heaviest option, roughly doubling your container count, and `./bin/install --full` is the shortcut for turning it on during [installation](/docs/self-hosting/installation).
+
+Stay light and those ClickHouse copies never get written, so the dataset and simulation-run dashboards built on them have nothing to read. Tracing is unaffected either way: `fi-collector` writes spans straight to ClickHouse, and it's one of the always-on 13.
 
 ## Setting a profile
 
@@ -79,17 +86,15 @@ docker compose --profile workers --profile observability up -d
 
 ## Where profiles catch people out
 
-<Warning>
 **`full` does not mean everything.** It adds only the PeerDB stack, taking you to 23 services. It does not enable `workers` or `observability`. For all 31, list every profile: `COMPOSE_PROFILES=workers,observability,full`.
-</Warning>
 
 **There is no `peerdb` profile.** The PeerDB services are tagged `full`, so `COMPOSE_PROFILES=peerdb` matches nothing and silently leaves you on the default 13. Compose reports no error for an unknown profile name.
 
 **The all-queue `worker` always runs.** It carries no profile and polls every queue via `TEMPORAL_ALL_QUEUES`, which defaults to true. Enabling `workers` does not replace it, so the six dedicated workers run *alongside* it. Setting `TEMPORAL_ALL_QUEUES=false` doesn't take it out of the picture either: the service sets no `TEMPORAL_TASK_QUEUE`, so it falls back to polling `default` on its own, overlapping `worker-default` instead of every queue.
 
-**A profile is not a launch mode.** The choice the first-run screen asks you to make is a [launch mode](/docs/self-hosting/configuration/launch-mode), and it can't change which services run.
-
 **The dev overlay ignores profiles completely.** `docker-compose.dev.yml` resets the profile tag on all 18 tagged services, so `docker compose -f docker-compose.yml -f docker-compose.dev.yml up` starts all 33 services unconditionally, including `pgbouncer` and `docker-proxy`. `COMPOSE_PROFILES` has no effect in this mode.
+
+**A profile is not a launch mode.** The choice the first-run screen asks you to make is a [launch mode](/docs/self-hosting/configuration/launch-mode), and it can't change which services run.
 
 ## Checking what will run
 
@@ -105,13 +110,13 @@ Counting the second command's output is the quickest way to confirm you're getti
 ## Dive deeper
 
 <CardGroup cols={3}>
+  <Card title="Launch mode" icon="rocket" href="/docs/self-hosting/configuration/launch-mode">
+    The checks a fresh install runs before it lets you in
+  </Card>
   <Card title="System configuration" icon="gear" href="/docs/self-hosting/configuration/system">
     Tune worker concurrency and set up PeerDB replication
   </Card>
-  <Card title="Environment variables" icon="list-check" href="/docs/self-hosting/configuration/environment">
-    The full `.env` reference, including where `COMPOSE_PROFILES` sits
-  </Card>
-  <Card title="Launch mode" icon="rocket" href="/docs/self-hosting/configuration/launch-mode">
-    The pre-flight checks a fresh install runs before sign-in
+  <Card title="Troubleshooting & FAQs" icon="wrench" href="/docs/self-hosting/troubleshooting">
+    Fixes for gateway, PeerDB, and Temporal errors
   </Card>
 </CardGroup>

--- a/src/pages/docs/self-hosting/configuration/profiles.mdx
+++ b/src/pages/docs/self-hosting/configuration/profiles.mdx
@@ -1,0 +1,117 @@
+---
+title: "Profiles"
+description: "Choosing which of the 31 services your self-hosted instance actually runs"
+---
+
+## In this page
+
+The self-hosted stack defines 31 services, but a working instance only needs 13 of them. The rest are opt-in: extra Temporal workers, a workflow dashboard, and the replication pipeline that feeds analytics. A **profile** is the tag that decides which group you get, set once in `.env` and read by every `docker compose` command after that.
+
+<TLDR>
+An empty `.env` gives you 13 services, which is a complete, usable instance. Three profiles add to that: `workers`, `observability`, and `full`. Name them in `COMPOSE_PROFILES` and their additions stack.
+</TLDR>
+
+<Mermaid chart={`
+%%{init: {"flowchart": {"curve": "linear"}}}%%
+flowchart TD
+    accTitle: Three optional profiles stack on top of the always-on core
+    accDescr: The core stack of 13 services always runs, and the workers, observability and full profiles each add more services on top of it.
+    C["Core stack: 13 services, always on"] -->|"workers"| W["Six per-queue workers"]
+    C -->|"observability"| O["Temporal UI and admin tools"]
+    C -->|"full"| F["Ten PeerDB services"]
+`} />
+
+## The profiles
+
+Leave `COMPOSE_PROFILES` unset and you get the core 13 services. Three profiles exist to add to that, each one independent.
+
+| Profile | What it adds | Total services |
+|---|---|---|
+| `workers` | Six per-queue Temporal workers | 19 |
+| `observability` | Temporal UI and admin tools | 15 |
+| `full` | The ten-service PeerDB replication stack | 23 |
+
+Combine them with commas, and the additions stack: `COMPOSE_PROFILES=workers,observability` runs 21 services, and naming all three runs all 31.
+
+### The core stack
+
+Thirteen services carry no profile, so they always run: `frontend`, `backend`, `worker`, `agentcc-gateway`, `serving`, `code-executor`, and the data layer of `postgres`, `clickhouse`, `redis`, `rabbitmq`, `minio`, `temporal`, and `fi-collector`. This is a complete instance. You can sign in, send traces, and run evaluations with nothing else enabled.
+
+### workers
+
+Adds six Temporal workers, each pinned to a single task queue: `default`, `tasks_s`, `tasks_l`, `tasks_xl`, `trace_ingestion`, and `agent_compass`. Each carries its own concurrency limit, so a handful of very large jobs can't starve everything else. Reach for this when one slow job type is holding up the rest. The per-queue limits are listed under [System configuration](/docs/self-hosting/configuration/system#temporal-workers).
+
+### observability
+
+Adds `temporal-ui` on port 8085 and `temporal-admin-tools`, a shell with the `tctl` CLI. Both are for inspecting workflow state when a background job misbehaves. Nothing depends on them, so they're safe to enable and disable at will.
+
+### full
+
+Adds the ten PeerDB services that replicate Postgres tables into ClickHouse through change data capture, including datasets, prompts, simulation runs, and trace metadata. It's the heaviest option, roughly doubling your container count, and `./bin/install --full` is the shortcut for turning it on.
+
+## Setting a profile
+
+Any of these work. The `.env` entry is the one that persists.
+
+<Tabs>
+<Tab title=".env">
+```bash
+# Applies to every docker compose command in this directory
+COMPOSE_PROFILES=full
+```
+</Tab>
+<Tab title="Inline">
+```bash
+COMPOSE_PROFILES=workers,observability docker compose up -d
+```
+</Tab>
+<Tab title="Flag">
+```bash
+docker compose --profile workers --profile observability up -d
+```
+</Tab>
+<Tab title="Installer">
+```bash
+./bin/install --full    # writes COMPOSE_PROFILES=full into .env
+```
+</Tab>
+</Tabs>
+
+## Where profiles catch people out
+
+<Warning>
+**`full` does not mean everything.** It adds only the PeerDB stack, taking you to 23 services. It does not enable `workers` or `observability`. For all 31, list every profile: `COMPOSE_PROFILES=workers,observability,full`.
+</Warning>
+
+**There is no `peerdb` profile.** The PeerDB services are tagged `full`, so `COMPOSE_PROFILES=peerdb` matches nothing and silently leaves you on the default 13. Compose reports no error for an unknown profile name.
+
+**The all-queue `worker` always runs.** It carries no profile and polls every queue via `TEMPORAL_ALL_QUEUES`, which defaults to true. Enabling `workers` does not replace it, so the six dedicated workers run *alongside* it. Setting `TEMPORAL_ALL_QUEUES=false` doesn't take it out of the picture either: the service sets no `TEMPORAL_TASK_QUEUE`, so it falls back to polling `default` on its own, overlapping `worker-default` instead of every queue.
+
+**A profile is not a launch mode.** The choice the first-run screen asks you to make is a [launch mode](/docs/self-hosting/configuration/launch-mode), and it can't change which services run.
+
+**The dev overlay ignores profiles completely.** `docker-compose.dev.yml` resets the profile tag on all 18 tagged services, so `docker compose -f docker-compose.yml -f docker-compose.dev.yml up` starts all 33 services unconditionally, including `pgbouncer` and `docker-proxy`. `COMPOSE_PROFILES` has no effect in this mode.
+
+## Checking what will run
+
+Both commands read the config only, so they work with the stack down.
+
+```bash
+docker compose config --profiles                          # list every profile name
+COMPOSE_PROFILES=full docker compose config --services    # resolve a profile set to services
+```
+
+Counting the second command's output is the quickest way to confirm you're getting what you expect before pulling images.
+
+## Dive deeper
+
+<CardGroup cols={3}>
+  <Card title="System configuration" icon="gear" href="/docs/self-hosting/configuration/system">
+    Tune worker concurrency and set up PeerDB replication
+  </Card>
+  <Card title="Environment variables" icon="list-check" href="/docs/self-hosting/configuration/environment">
+    The full `.env` reference, including where `COMPOSE_PROFILES` sits
+  </Card>
+  <Card title="Launch mode" icon="rocket" href="/docs/self-hosting/configuration/launch-mode">
+    The pre-flight checks a fresh install runs before sign-in
+  </Card>
+</CardGroup>

--- a/src/pages/docs/self-hosting/configuration/profiles.mdx
+++ b/src/pages/docs/self-hosting/configuration/profiles.mdx
@@ -84,15 +84,22 @@ docker compose --profile workers --profile observability up -d
 </Tab>
 </Tabs>
 
+A changed profile takes effect on the next `docker compose up -d`. Containers from a profile you removed are not stopped for you, so take them down first if you want them gone:
+
+```bash
+docker compose --profile observability down    # stop what that profile started
+docker compose up -d                           # bring the rest back on the new set
+```
+
 ## Where profiles catch people out
 
 **`full` does not mean everything.** It adds only the PeerDB stack, taking you to 23 services. It does not enable `workers` or `observability`. For all 31, list every profile: `COMPOSE_PROFILES=workers,observability,full`.
 
 **There is no `peerdb` profile.** The PeerDB services are tagged `full`, so `COMPOSE_PROFILES=peerdb` matches nothing and silently leaves you on the default 13. Compose reports no error for an unknown profile name.
 
-**The all-queue `worker` always runs.** It carries no profile and polls every queue via `TEMPORAL_ALL_QUEUES`, which defaults to true. Enabling `workers` does not replace it, so the six dedicated workers run *alongside* it. Setting `TEMPORAL_ALL_QUEUES=false` doesn't take it out of the picture either: the service sets no `TEMPORAL_TASK_QUEUE`, so it falls back to polling `default` on its own, overlapping `worker-default` instead of every queue.
+**The all-queue `worker` always runs.** It carries no profile and polls every queue via `TEMPORAL_ALL_QUEUES`, which defaults to true. Enabling `workers` does not replace it, so the six dedicated workers run *alongside* it. Setting `TEMPORAL_ALL_QUEUES=false` doesn't take it out of the picture either: the service sets no `TEMPORAL_TASK_QUEUE`, so it falls back to polling `default` on its own, overlapping `worker-default` instead of every queue. The overlap is wasteful rather than harmful, since Temporal hands each task to one worker, but it does mean the `default` queue gets two pollers and no queue gets none. Leave `TEMPORAL_ALL_QUEUES` at its default unless you're running the `workers` profile.
 
-**The dev overlay ignores profiles completely.** `docker-compose.dev.yml` resets the profile tag on all 18 tagged services, so `docker compose -f docker-compose.yml -f docker-compose.dev.yml up` starts all 33 services unconditionally, including `pgbouncer` and `docker-proxy`. `COMPOSE_PROFILES` has no effect in this mode.
+**The dev overlay ignores profiles completely.** `docker-compose.dev.yml` resets the profile tag on all 18 tagged services, so `docker compose -f docker-compose.yml -f docker-compose.dev.yml up` starts every service unconditionally: all 31, plus two that exist only in the overlay, `pgbouncer` and `docker-proxy`, for 33. `COMPOSE_PROFILES` has no effect in this mode.
 
 **A profile is not a launch mode.** The choice the first-run screen asks you to make is a [launch mode](/docs/self-hosting/configuration/launch-mode), and it can't change which services run.
 

--- a/src/pages/docs/self-hosting/configuration/system.mdx
+++ b/src/pages/docs/self-hosting/configuration/system.mdx
@@ -106,7 +106,7 @@ PeerDB continuously replicates Postgres tables into ClickHouse (change-data-capt
 
 ```bash
 docker compose logs -f backend                       # wait for "Application startup complete"
-docker compose run --rm peerdb-init bash /setup.sh   # re-run init
+docker compose run --rm peerdb-init                  # re-run init
 ```
 </Warning>
 
@@ -118,7 +118,7 @@ Temporal runs the platform's background jobs and evaluation pipelines. How those
 
 **All-queue (default).** One worker polls every task queue. Controlled by `TEMPORAL_ALL_QUEUES=true` in `.env`. This is the right setup for most self-hosted deployments.
 
-**Per-queue (dev overlay).** Six dedicated workers, one per queue, brought up by the [dev overlay](/docs/self-hosting/installation#other-ways-to-run-it):
+**Per-queue.** Six dedicated workers, one per queue, brought up by the `workers` [profile](/docs/self-hosting/configuration/profiles) or by the [dev overlay](/docs/self-hosting/installation#other-ways-to-run-it):
 
 | Service | Queue | Typical concurrency |
 |---|---|---|
@@ -129,18 +129,18 @@ Temporal runs the platform's background jobs and evaluation pipelines. How those
 | `worker-trace-ingestion` | `trace_ingestion` | 100 |
 | `worker-agent-compass` | `agent_compass` | 50 |
 
-Tune throughput with `TEMPORAL_MAX_CONCURRENT_ACTIVITIES` and `TEMPORAL_MAX_CONCURRENT_WORKFLOW_TASKS` in `.env`. The Temporal UI is available in dev mode at [http://localhost:8085](http://localhost:8085).
+Tune throughput with `TEMPORAL_MAX_CONCURRENT_ACTIVITIES` and `TEMPORAL_MAX_CONCURRENT_WORKFLOW_TASKS` in `.env`. The Temporal UI runs at [http://localhost:8085](http://localhost:8085) under the `observability` profile, and in dev mode.
 
 ## Dive Deeper
 
 <CardGroup cols={3}>
-  <Card title="Environment variables" icon="list-check" href="/docs/self-hosting/configuration/environment">
-    Set provider keys, secrets, and runtime flags in `.env`
-  </Card>
   <Card title="Profiles" icon="layer-group" href="/docs/self-hosting/configuration/profiles">
     PeerDB and the per-queue workers only run under the right profile
   </Card>
   <Card title="Launch mode" icon="rocket" href="/docs/self-hosting/configuration/launch-mode">
-    The pre-flight checks a fresh install runs before sign-in
+    The checks a fresh install runs before it lets you in
+  </Card>
+  <Card title="Production checklist" icon="shield" href="/docs/self-hosting/production/checklist">
+    Harden the instance before it carries real traffic
   </Card>
 </CardGroup>

--- a/src/pages/docs/self-hosting/configuration/system.mdx
+++ b/src/pages/docs/self-hosting/configuration/system.mdx
@@ -133,11 +133,14 @@ Tune throughput with `TEMPORAL_MAX_CONCURRENT_ACTIVITIES` and `TEMPORAL_MAX_CONC
 
 ## Dive Deeper
 
-<CardGroup cols={2}>
-  <Card title="Production Checklist" icon="shield" href="/docs/self-hosting/production/checklist">
-    Hardening, backups, and monitoring before going live.
+<CardGroup cols={3}>
+  <Card title="Environment variables" icon="list-check" href="/docs/self-hosting/configuration/environment">
+    Set provider keys, secrets, and runtime flags in `.env`
   </Card>
-  <Card title="Troubleshooting" icon="wrench" href="/docs/self-hosting/troubleshooting">
-    Fixes for gateway, PeerDB, and Temporal errors.
+  <Card title="Profiles" icon="layer-group" href="/docs/self-hosting/configuration/profiles">
+    PeerDB and the per-queue workers only run under the right profile
+  </Card>
+  <Card title="Launch mode" icon="rocket" href="/docs/self-hosting/configuration/launch-mode">
+    The pre-flight checks a fresh install runs before sign-in
   </Card>
 </CardGroup>

--- a/src/pages/docs/self-hosting/configuration/system.mdx
+++ b/src/pages/docs/self-hosting/configuration/system.mdx
@@ -9,7 +9,7 @@ A few parts of the stack are configured outside `.env`: the LLM gateway needs a 
 
 ## LLM Gateway
 
-The gateway is a Go proxy that routes every model call the platform makes. It reads a `config.yaml` that lists which providers it may use and which models each exposes.
+The gateway is a Go proxy that routes every model call the platform makes. Its compose service is `agentcc-gateway` and its files live in `agentcc-gateway/`. It reads a `config.yaml` that lists which providers it may use and which models each exposes.
 
 <Warning>
 Model calls fail until this file exists. The gateway ships with `config.example.yaml` (OpenAI enabled) but **not** a live `config.yaml`. You create one in the steps below.
@@ -28,15 +28,23 @@ Edit `config.yaml`: uncomment the providers you want and reference their keys wi
 </Step>
 
 <Step title="Mount the Config and Restart">
-Point the gateway volume at your `config.yaml` in `docker-compose.yml`:
+Point the gateway volume at your `config.yaml` under the `agentcc-gateway` service in `docker-compose.yml`, adding a `volumes:` block if it has none:
 
 ```yaml
-volumes:
-  - ./agentcc-gateway/config.yaml:/app/config.yaml:ro
+services:
+  agentcc-gateway:
+    volumes:
+      - ./agentcc-gateway/config.yaml:/app/config.yaml:ro
 ```
 
 ```bash
 docker compose up -d --force-recreate gateway
+```
+
+Confirm it came back with the config loaded:
+
+```bash
+curl -sf http://localhost:8090/healthz && docker compose logs --tail=20 agentcc-gateway
 ```
 </Step>
 </Steps>
@@ -99,7 +107,7 @@ For routing rules, rate limits, caching, and the full config reference, see [Age
 
 ## PeerDB Replication
 
-PeerDB continuously replicates Postgres tables into ClickHouse (change-data-capture) so trace and eval analytics stay fast. It runs on its own. The only thing you typically touch is a first-boot timing fix.
+PeerDB only runs under the `full` [profile](/docs/self-hosting/configuration/profiles), so if none of this appears on your host, that's why. When it is on, it continuously replicates Postgres tables into ClickHouse (change-data-capture) so dataset and simulation analytics stay fast. It runs on its own, and the only thing you typically touch is a first-boot timing fix.
 
 <Warning>
 **First-boot timing.** `peerdb-init` runs the moment the stack starts, sometimes before Django has finished its migrations. If mirrors show "not started" in the PeerDB UI, re-run init once the backend is up:
@@ -118,7 +126,7 @@ Temporal runs the platform's background jobs and evaluation pipelines. How those
 
 **All-queue (default).** One worker polls every task queue. Controlled by `TEMPORAL_ALL_QUEUES=true` in `.env`. This is the right setup for most self-hosted deployments.
 
-**Per-queue.** Six dedicated workers, one per queue, brought up by the `workers` [profile](/docs/self-hosting/configuration/profiles) or by the [dev overlay](/docs/self-hosting/installation#other-ways-to-run-it):
+**Per-queue.** Reach for this when one slow job type is holding up the rest. It takes both settings: start the `workers` [profile](/docs/self-hosting/configuration/profiles) (or the [dev overlay](/docs/self-hosting/installation#other-ways-to-run-it)) to create the six dedicated workers, and set `TEMPORAL_ALL_QUEUES=false` so the always-on `worker` stops polling every queue alongside them.
 
 | Service | Queue | Typical concurrency |
 |---|---|---|
@@ -129,7 +137,7 @@ Temporal runs the platform's background jobs and evaluation pipelines. How those
 | `worker-trace-ingestion` | `trace_ingestion` | 100 |
 | `worker-agent-compass` | `agent_compass` | 50 |
 
-Tune throughput with `TEMPORAL_MAX_CONCURRENT_ACTIVITIES` and `TEMPORAL_MAX_CONCURRENT_WORKFLOW_TASKS` in `.env`. The Temporal UI runs at [http://localhost:8085](http://localhost:8085) under the `observability` profile, and in dev mode.
+The concurrency column shows each service's shipped default. `TEMPORAL_MAX_CONCURRENT_ACTIVITIES` and `TEMPORAL_MAX_CONCURRENT_WORKFLOW_TASKS` in `.env` apply to every worker at once, so use them to move the whole fleet rather than one queue. The Temporal UI runs at [http://localhost:8085](http://localhost:8085) under the `observability` profile, and in dev mode.
 
 ## Dive Deeper
 

--- a/src/pages/docs/self-hosting/installation.mdx
+++ b/src/pages/docs/self-hosting/installation.mdx
@@ -20,6 +20,10 @@ First boot pulls every image from Docker Hub, nothing is built locally, so give 
 Run `git clone https://github.com/future-agi/future-agi.git && cd future-agi && ./bin/install`, then open [http://localhost:3000](http://localhost:3000).
 </TLDR>
 
+<Note>
+**On arm64, do this first.** The backend image (`futureagi/future-agi`) is amd64 only. On Linux arm64 such as Graviton, install `qemu-user-static` before you install, or `backend` and `worker` won't start at all. On Apple Silicon they run under Rosetta 2 automatically. Details in the note below the steps.
+</Note>
+
 ## Install
 
 <Steps>
@@ -27,8 +31,10 @@ Run `git clone https://github.com/future-agi/future-agi.git && cd future-agi && 
 ```bash
 git clone https://github.com/future-agi/future-agi.git
 cd future-agi
-./bin/install          # Windows: bin\install.ps1
+./bin/install
 ```
+
+On Windows, run `bin\install.ps1` instead. The other `bin/` scripts have `.ps1` equivalents too.
 
 The stack boots fine against an empty `.env`, so you can take the defaults for a local trial.
 
@@ -36,13 +42,15 @@ By default the installer brings up the standard stack of 13 services. Add `--ful
 </Step>
 
 <Step title="Create your first user">
-The installer prompts you at the end. If you passed `--skip-user-creation`, create the account from the CLI instead:
+The installer prompts you at the end for an email, full name, and password. That's the whole step on the default path.
+
+If you passed `--skip-user-creation`, create the account from the CLI instead:
 
 ```bash
 docker compose exec backend python manage.py create_user
 ```
 
-You will be asked for an email, full name, and password. To script it, pass them inline:
+It asks for the same three values. To script it, pass them inline:
 
 ```bash
 docker compose exec backend python manage.py create_user \
@@ -82,11 +90,15 @@ cp .env.example .env       # optional; an empty .env works for local
 docker compose up -d
 ```
 
-Then create the first user with the same `create_user` command shown above.
+Then create the first user:
+
+```bash
+docker compose exec backend python manage.py create_user
+```
 
 ## Verify the stack
 
-Check that every service is healthy before you log in. Under-provisioned RAM is the most common reason the backend never finishes booting, so confirm the [requirements](/docs/self-hosting/requirements) if it stalls, and see [Troubleshooting](/docs/self-hosting/troubleshooting) for anything else that comes up red.
+Check that every service is healthy before you log in. The failure you're most likely to hit is the backend never printing `Application startup complete` and the container restarting in a loop, which is almost always under-provisioned RAM: confirm the [requirements](/docs/self-hosting/requirements) if you see that, and [Troubleshooting](/docs/self-hosting/troubleshooting) covers anything else that comes up red.
 
 ```bash
 docker compose ps                 # every service should read "running" or "healthy"
@@ -98,7 +110,7 @@ The instance is ready when `/health/` returns OK. That's the same check `./bin/i
 
 ## Everyday operations
 
-A short reference for the commands you will use most:
+A short reference for the commands you will use most. Upgrades have their own page, [Upgrades & rollback](/docs/self-hosting/production/upgrades-rollback).
 
 ```bash
 # Tail logs
@@ -110,6 +122,9 @@ docker compose exec postgres psql -U futureagi -d futureagi
 
 # Stop the stack (data persists in named volumes)
 ./bin/uninstall                # or: docker compose down
+
+# Update to a new release (full procedure: Upgrades & rollback)
+docker compose pull && docker compose up -d
 
 # Wipe all data and start clean
 ./bin/uninstall --wipe-data    # or: docker compose down -v
@@ -128,7 +143,7 @@ docker compose exec postgres psql -U futureagi -d futureagi
 | Frontend only | `docker compose -f docker-compose.frontend.yml up -d` | Pointing a local UI at a backend that runs elsewhere |
 
 <Warning>
-For a frontend-only deploy, set `VITE_HOST_API` to the backend URL the browser can reach. It is applied when the container starts, so changing it needs only a restart of the frontend container, not a rebuild.
+For a frontend-only deploy, set `VITE_HOST_API` in `.env` to the backend URL the browser can reach. It is applied when the container starts, so changing it needs only a restart of the frontend container, not a rebuild.
 </Warning>
 
 ## Dive deeper

--- a/src/pages/docs/self-hosting/installation.mdx
+++ b/src/pages/docs/self-hosting/installation.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Installation"
-description: "Install a self-hosted Future AGI instance with Docker Compose."
+description: "Install a self-hosted Future AGI instance with Docker Compose"
 ---
 
 Docker Compose is the supported way to run a self-hosted Future AGI instance.
@@ -14,7 +14,7 @@ Confirm your host meets the [requirements](/docs/self-hosting/requirements) firs
 - Waits for the backend health check
 - Prompts you to create the first user
 
-First boot pulls the app images from Docker Hub and builds the small fi-collector image from source, so give it a few minutes the first time.
+First boot pulls every image from Docker Hub, nothing is built locally, so give it a few minutes the first time.
 
 <TLDR>
 Run `git clone https://github.com/future-agi/future-agi.git && cd future-agi && ./bin/install`, then open [http://localhost:3000](http://localhost:3000).
@@ -70,7 +70,7 @@ On a fresh install the app opens a short setup wizard before the sign-in screen,
 | `--new-instance` | Start a fresh instance when existing volumes are detected |
 
 <Note>
-**Apple Silicon and arm64 hosts.** Prebuilt images are `linux/amd64`. On M-series Macs they run under Rosetta 2 (auto-enabled on Docker Desktop 4.16+), which is fine for evaluation with a 20 to 50 percent performance cost. For native arm64, build locally with `docker compose build` instead of pulling. On Linux arm64 such as Graviton, install `qemu-user-static`.
+**Apple Silicon and arm64 hosts.** Five of the six first-party images ship `linux/arm64` alongside `linux/amd64`, so they run native. The exception is `futureagi/future-agi`, which is amd64 only and backs both `backend` and `worker`. On M-series Macs those two run under Rosetta 2 (auto-enabled on Docker Desktop 4.16+), which is fine for evaluation at a 20 to 50 percent performance cost on those containers. On Linux arm64 such as Graviton, install `qemu-user-static` so they can start at all.
 </Note>
 
 ## Install without the script
@@ -86,7 +86,7 @@ Then create the first user with the same `create_user` command shown above.
 
 ## Verify the stack
 
-Check that every service is healthy before you log in. Under-provisioned RAM is the most common reason the backend never finishes booting, so confirm the [requirements](/docs/self-hosting/requirements) if it stalls.
+Check that every service is healthy before you log in. Under-provisioned RAM is the most common reason the backend never finishes booting, so confirm the [requirements](/docs/self-hosting/requirements) if it stalls, and see [Troubleshooting](/docs/self-hosting/troubleshooting) for anything else that comes up red.
 
 ```bash
 docker compose ps                 # every service should read "running" or "healthy"
@@ -114,7 +114,8 @@ docker compose exec postgres psql -U futureagi -d futureagi
 # Wipe all data and start clean
 ./bin/uninstall --wipe-data    # or: docker compose down -v
 
-# Remove everything: containers, volumes, .env, and built images
+# Also remove .env, logs, and any locally built images
+# (pulled images stay; remove those with docker rmi)
 ./bin/uninstall --purge
 ```
 

--- a/src/pages/docs/self-hosting/installation.mdx
+++ b/src/pages/docs/self-hosting/installation.mdx
@@ -32,7 +32,7 @@ cd future-agi
 
 The stack boots fine against an empty `.env`, so you can take the defaults for a local trial.
 
-By default the installer brings up the standard stack (around 12 containers). Add `--full` to include the PeerDB CDC stack (around 22 containers) that populates the analytics views.
+By default the installer brings up the standard stack of 13 services. Add `--full` to include the PeerDB CDC stack, taking you to 23. See [Profiles](/docs/self-hosting/configuration/profiles) for what each one adds.
 </Step>
 
 <Step title="Create your first user">
@@ -54,6 +54,8 @@ docker compose exec backend python manage.py create_user \
 
 <Step title="Open the app">
 Log in at [http://localhost:3000](http://localhost:3000) with the user you just created. The backend API is at [http://localhost:8000](http://localhost:8000).
+
+On a fresh install the app opens a short setup wizard before the sign-in screen, where you pick a [launch mode](/docs/self-hosting/configuration/launch-mode) and watch it probe your services. It runs once per browser.
 </Step>
 </Steps>
 
@@ -61,7 +63,7 @@ Log in at [http://localhost:3000](http://localhost:3000) with the user you just 
 
 | Flag | What it does |
 |---|---|
-| `--full` | Add the PeerDB CDC stack (around 22 containers) so the analytics views populate |
+| `--full` | Add the PeerDB CDC stack, taking the stack from 13 services to 23 |
 | `--skip-user-creation` | Skip the first-user prompt; create the account later with `create_user` |
 | `--no-up` | Bootstrap `.env` only, without starting the stack |
 | `--wipe-volumes` | Remove stale project volumes before starting (destroys existing data) |
@@ -130,11 +132,14 @@ For a frontend-only deploy, set `VITE_HOST_API` to the backend URL the browser c
 
 ## Dive deeper
 
-<CardGroup cols={2}>
+<CardGroup cols={3}>
+  <Card title="Launch mode" icon="rocket" href="/docs/self-hosting/configuration/launch-mode">
+    What the first-run wizard checks before it lets you in
+  </Card>
   <Card title="Environment variables" icon="list-check" href="/docs/self-hosting/configuration/environment">
     Set provider keys, secrets, and runtime flags in `.env`
   </Card>
-  <Card title="System configuration" icon="gear" href="/docs/self-hosting/configuration">
+  <Card title="System configuration" icon="gear" href="/docs/self-hosting/configuration/system">
     Tune the gateway, PeerDB, and Temporal workers
   </Card>
 </CardGroup>

--- a/src/pages/docs/self-hosting/production.mdx
+++ b/src/pages/docs/self-hosting/production.mdx
@@ -1,15 +1,15 @@
 ---
 title: "Production"
-description: "What to harden before a self-hosted Future AGI instance goes live"
+description: "Hardening, backups, monitoring, and upgrades for a self-hosted instance"
 ---
 
-Everything past a local trial happens here. The default Docker Compose stack boots with development secrets that work out of the box, no TLS, and compose-managed data stores. That's fine on a laptop. Before real traffic reaches the instance, work through the two go-live pages below, then keep the rest as runbooks.
+Before real traffic reaches the instance, work through the two go-live pages below, then keep the rest as runbooks. These pages assume a working Compose install from [Installation](/docs/self-hosting/installation).
 
-## In this page
+<Warning>
+The default stack is not safe to expose. It boots with **development secrets** that work out of the box, **no TLS**, and compose-managed data stores. Nothing fails or warns you if you leave it that way.
+</Warning>
 
-Production readiness for a self-hosted instance breaks into five pages. Do the first two in order before you go live, and keep the other three to hand once it is.
-
-**Before you go live**
+## Before you go live
 
 <CardGroup cols={2}>
   <Card title="Checklist" icon="list-check" href="/docs/self-hosting/production/checklist">
@@ -20,7 +20,7 @@ Production readiness for a self-hosted instance breaks into five pages. Do the f
   </Card>
 </CardGroup>
 
-**Operating it**
+## Operating it
 
 <CardGroup cols={3}>
   <Card title="Backups & restore" icon="database" href="/docs/self-hosting/production/backups-restore">

--- a/src/pages/docs/self-hosting/production.mdx
+++ b/src/pages/docs/self-hosting/production.mdx
@@ -3,11 +3,11 @@ title: "Production"
 description: "What to harden before a self-hosted Future AGI instance goes live"
 ---
 
-Everything past a local trial happens here. The default Docker Compose stack boots with placeholder secrets, no TLS, and compose-managed data stores. That's fine on a laptop. Before real traffic reaches the instance, work through the flow below in order, then keep each page as a runbook.
+Everything past a local trial happens here. The default Docker Compose stack boots with development secrets that work out of the box, no TLS, and compose-managed data stores. That's fine on a laptop. Before real traffic reaches the instance, work through the two go-live pages below, then keep the rest as runbooks.
 
 ## In this page
 
-Production readiness for a self-hosted instance breaks into five steps. Do them in order the first time.
+Production readiness for a self-hosted instance breaks into five pages. Do the first two in order before you go live, and keep the other three to hand once it is.
 
 **Before you go live**
 

--- a/src/pages/docs/self-hosting/production/backups-restore.mdx
+++ b/src/pages/docs/self-hosting/production/backups-restore.mdx
@@ -5,20 +5,22 @@ description: "Back up and restore the data stores behind a self-hosted instance"
 
 A self-hosted instance keeps state in a few stores: Postgres for application data, ClickHouse for the observability records (spans and traces), and MinIO for object storage. Those three are the ones to back up. Redis is a cache (sign-ins, locks, rate limits, pub/sub), so it rebuilds on its own. RabbitMQ holds the task queue: losing it drops in-flight background jobs, so drain it before planned downtime rather than backing it up.
 
+If you've already moved to [managed data stores](/docs/self-hosting/production/checklist#move-to-managed-data-stores), your provider's backup tooling replaces everything below.
+
 ## The named volumes
 
 The compose project name is `futureagi`, so every volume is prefixed `futureagi_`:
 
-| Volume | Holds |
-|---|---|
-| `futureagi_postgres-data` | Postgres application data |
-| `futureagi_clickhouse-data` | ClickHouse spans and traces |
-| `futureagi_minio-data` | MinIO objects |
-| `futureagi_rabbitmq-data` | RabbitMQ task queue |
-| `futureagi_redis-data` | Redis cache (rebuildable) |
-| `futureagi_peerdb-catalog-data` | PeerDB replication catalog |
-| `futureagi_peerdb-minio-data` | PeerDB staging objects |
-| `futureagi_fi-collector-data` | Spans the collector couldn't write to ClickHouse |
+| Volume | Holds | Back up? |
+|---|---|---|
+| `futureagi_postgres-data` | Postgres application data | Yes |
+| `futureagi_clickhouse-data` | ClickHouse spans and traces | Yes |
+| `futureagi_minio-data` | MinIO objects | Yes |
+| `futureagi_fi-collector-data` | Spans the collector couldn't write to ClickHouse | Don't delete it |
+| `futureagi_rabbitmq-data` | RabbitMQ task queue | No, drain instead |
+| `futureagi_redis-data` | Redis cache | No, rebuildable |
+| `futureagi_peerdb-catalog-data` | PeerDB replication catalog | No, rebuilt by re-running init |
+| `futureagi_peerdb-minio-data` | PeerDB staging objects | No, transient |
 
 <Note>
 `futureagi_fi-collector-data` is a dead-letter queue, not a cache. It holds spans that failed to reach ClickHouse, usually while ClickHouse was briefly down, and they're replayed once it's back. Deleting the volume drops that telemetry for good, so don't prune it with the rebuildable ones.
@@ -26,7 +28,7 @@ The compose project name is `futureagi`, so every volume is prefixed `futureagi_
 
 ## Postgres
 
-Postgres holds the application data, so back it up on a schedule. Use the custom format, and pass `-T` so `docker compose exec` doesn't allocate a TTY and mangle the binary dump:
+Postgres holds the application data, so back it up on a schedule. Use the custom format, and pass `-T` so `docker compose exec` doesn't allocate a TTY and mangle the binary dump. Stop the backend and workers before restoring, since `--clean` drops objects the running app may be holding open:
 
 ```bash
 # Backup
@@ -42,10 +44,18 @@ docker compose exec -T postgres \
 
 ## ClickHouse
 
-ClickHouse is not just a replica anymore. Since the CH25 cutover (`CH25_DROP_LEGACY_CDC_CHAIN` defaults to `true`), the fi-collector writes `spans` straight to ClickHouse and Django dual-writes `traces`. PeerDB only rebuilds the tables it mirrors from Postgres, so if you lose ClickHouse the observability data does **not** come back from a PeerDB re-init. Back it up on its own:
+ClickHouse holds data that exists nowhere else. The fi-collector writes `spans` straight into it and Django dual-writes `traces`, so neither is recoverable from Postgres. Back it up on its own schedule:
 
-```sql
-BACKUP DATABASE default TO S3('s3://your-bucket/ch-backup/', 'KEY', 'SECRET');
+```bash
+docker compose exec -T clickhouse clickhouse-client --query \
+  "BACKUP DATABASE default TO S3('s3://your-bucket/ch-backup/', 'KEY', 'SECRET')"
+```
+
+Restore the same way, with the path of the backup you took:
+
+```bash
+docker compose exec -T clickhouse clickhouse-client --query \
+  "RESTORE DATABASE default FROM S3('s3://your-bucket/ch-backup/', 'KEY', 'SECRET')"
 ```
 
 <Warning>
@@ -59,10 +69,10 @@ Mirror the MinIO bucket to S3 with the MinIO client:
 ```bash
 mc alias set local http://localhost:9005 futureagi <MINIO_ROOT_PASSWORD>
 mc alias set s3 https://s3.amazonaws.com <AWS_KEY> <AWS_SECRET>
-mc mirror local/ s3/your-bucket/
-```
 
-If you've already moved to [managed data stores](/docs/self-hosting/production/checklist), your provider's own backup tooling replaces these commands.
+mc mirror local/ s3/your-bucket/     # back up
+mc mirror s3/your-bucket/ local/     # restore
+```
 
 ## Dive deeper
 

--- a/src/pages/docs/self-hosting/production/backups-restore.mdx
+++ b/src/pages/docs/self-hosting/production/backups-restore.mdx
@@ -3,7 +3,26 @@ title: "Backups & restore"
 description: "Back up and restore the data stores behind a self-hosted instance"
 ---
 
-A self-hosted instance keeps state in a few stores: Postgres for application data, ClickHouse for the observability records (spans and traces), and MinIO for object storage. Redis is a cache (sessions, locks, rate limits, pub/sub), so it rebuilds on its own and doesn't need a backup. RabbitMQ holds the task queue: losing it drops in-flight background jobs, so drain it before planned downtime rather than backing it up.
+A self-hosted instance keeps state in a few stores: Postgres for application data, ClickHouse for the observability records (spans and traces), and MinIO for object storage. Those three are the ones to back up. Redis is a cache (sign-ins, locks, rate limits, pub/sub), so it rebuilds on its own. RabbitMQ holds the task queue: losing it drops in-flight background jobs, so drain it before planned downtime rather than backing it up.
+
+## The named volumes
+
+The compose project name is `futureagi`, so every volume is prefixed `futureagi_`:
+
+| Volume | Holds |
+|---|---|
+| `futureagi_postgres-data` | Postgres application data |
+| `futureagi_clickhouse-data` | ClickHouse spans and traces |
+| `futureagi_minio-data` | MinIO objects |
+| `futureagi_rabbitmq-data` | RabbitMQ task queue |
+| `futureagi_redis-data` | Redis cache (rebuildable) |
+| `futureagi_peerdb-catalog-data` | PeerDB replication catalog |
+| `futureagi_peerdb-minio-data` | PeerDB staging objects |
+| `futureagi_fi-collector-data` | Spans the collector couldn't write to ClickHouse |
+
+<Note>
+`futureagi_fi-collector-data` is a dead-letter queue, not a cache. It holds spans that failed to reach ClickHouse, usually while ClickHouse was briefly down, and they're replayed once it's back. Deleting the volume drops that telemetry for good, so don't prune it with the rebuildable ones.
+</Note>
 
 ## Postgres
 
@@ -20,19 +39,6 @@ docker compose exec -T postgres \
   pg_restore -U futureagi -d futureagi --clean --if-exists \
   < backup-2026-04-22.dump
 ```
-
-The named volumes that hold state. The compose project name is `futureagi`, so every volume is prefixed `futureagi_`:
-
-| Volume | Holds |
-|---|---|
-| `futureagi_postgres-data` | Postgres application data |
-| `futureagi_clickhouse-data` | ClickHouse spans and traces |
-| `futureagi_minio-data` | MinIO objects |
-| `futureagi_rabbitmq-data` | RabbitMQ task queue |
-| `futureagi_redis-data` | Redis cache (rebuildable) |
-| `futureagi_peerdb-catalog-data` | PeerDB replication catalog |
-| `futureagi_peerdb-minio-data` | PeerDB staging objects |
-| `futureagi_fi-collector-data` | fi-collector buffer |
 
 ## ClickHouse
 

--- a/src/pages/docs/self-hosting/production/checklist.mdx
+++ b/src/pages/docs/self-hosting/production/checklist.mdx
@@ -38,9 +38,11 @@ Set these runtime flags before going live:
 
 | Variable | Go-live value | Why |
 |---|---|---|
-| `ENV_TYPE` | `prod` | Disables debug output and runs Django `check --deploy` |
-| `FAST_STARTUP` | `false` | Always applies migrations on restart |
+| `ENV_TYPE` | `prod` | Defaults to `development`. Disables debug output and runs Django `check --deploy` |
 | `GRANIAN_WORKERS` | your CPU count | One worker per core, up from the default `1` |
+| `FAST_STARTUP` | leave unset | Already `false`. Setting it `true` skips migrations and DB checks at boot, which you never want here |
+
+`check --deploy` warns and continues rather than refusing to start, so a failing deployment check won't stop the container. Read the backend logs on your first `prod` boot instead of assuming a clean start means a clean report.
 
 ## Move to managed data stores
 

--- a/src/pages/docs/self-hosting/production/checklist.mdx
+++ b/src/pages/docs/self-hosting/production/checklist.mdx
@@ -3,17 +3,25 @@ title: "Checklist"
 description: "The go-live pass before a self-hosted instance takes real traffic"
 ---
 
-Run through this once before the stack is reachable by anyone else. Three things separate a laptop trial from a real deployment:
+Run through this once before the stack is reachable by anyone else. It assumes a working Compose install from [Installation](/docs/self-hosting/installation). Three things separate a laptop trial from a real deployment:
 
-- Replace the dev-only secret defaults
-- Bring the stack up with the production overlay, so it refuses to boot until those secrets are set
+- Replace the dev-only secret defaults, and bring the stack up with the production overlay so it refuses to boot until they're set
+- Switch the backend to production mode
 - Move the compose-managed data stores to managed services
 
 ## Replace the dev-only secrets
 
 The stack boots with dev-only placeholders baked into `docker-compose.yml`, values like `local-dev-only-not-for-production-replace-me`, and `futureagi` for the database passwords. It runs fine with them, which is the point on a laptop and the danger in production.
 
-What forces real secrets is the production overlay, `deploy/docker-compose.production.yml`. It re-binds each one with `${VAR:?}`, so the stack won't start until you've set them. Bring the stack up with that overlay and set, at minimum:
+What forces real secrets is the production overlay, `deploy/docker-compose.production.yml`. It re-binds each one with `${VAR:?}`, so the stack won't start until you've set them.
+
+These values go in `deploy/.env.production`, not the root `.env`. Copy the shipped example and fill it in:
+
+```bash
+cp deploy/.env.production.example deploy/.env.production
+```
+
+Set, at minimum:
 
 - `SECRET_KEY`
 - `AGENTCC_INTERNAL_API_KEY`
@@ -27,6 +35,15 @@ What forces real secrets is the production overlay, `deploy/docker-compose.produ
 openssl rand -hex 32     # SECRET_KEY, AGENTCC_INTERNAL_API_KEY, AGENTCC_ADMIN_TOKEN
 openssl rand -base64 24  # PG_PASSWORD, MINIO_ROOT_PASSWORD, RABBITMQ_PASSWORD
 ```
+
+Then bring the stack up with both files:
+
+```bash
+docker compose --env-file deploy/.env.production \
+  -f docker-compose.yml -f deploy/docker-compose.production.yml up -d
+```
+
+Miss one and compose refuses to start, naming the variable it wanted. That's the overlay doing its job, not a broken install.
 
 <Warning>
 `PG_PASSWORD` is baked into the Postgres volume on the **first** boot, so set it before your first `docker compose up`. `MINIO_ROOT_PASSWORD` is read from the environment on every boot, so that one you can change and restart. The full field list is in [Environment variables](/docs/self-hosting/configuration/environment).

--- a/src/pages/docs/self-hosting/production/monitoring.mdx
+++ b/src/pages/docs/self-hosting/production/monitoring.mdx
@@ -3,11 +3,11 @@ title: "Monitoring"
 description: "Watch a self-hosted instance with the health signals it actually exposes"
 ---
 
-The stack has no Prometheus `/metrics` endpoint yet (the fi-collector lists a metrics exporter as a TODO), so monitoring today is built from what the containers already expose: their Docker health checks, the fi-collector's admin health endpoint, and the PeerDB console. This page covers those and the signals worth watching.
+The stack has no Prometheus `/metrics` endpoint yet (the fi-collector lists a metrics exporter as a TODO), so monitoring today is built from what the containers already expose: their Docker health checks, the backend and collector health endpoints, and the PeerDB console. This page covers those and the signals worth watching.
 
 ## Container health
 
-The data stores (Postgres, ClickHouse, Redis, RabbitMQ, MinIO, Temporal) ship Docker health checks; the application services just show `running`. Either way, `docker compose ps` is the fastest read on what's up:
+The data stores (Postgres, ClickHouse, Redis, RabbitMQ, MinIO, Temporal) ship Docker health checks. The application services declare none, so they only ever read `running`, which is why the two endpoints below matter. Either way, `docker compose ps` is the fastest read on what's up:
 
 ```bash
 docker compose ps        # STATUS shows healthy / unhealthy per service
@@ -16,13 +16,23 @@ docker stats             # live CPU and memory per container
 
 Watch memory on `clickhouse` and the Temporal `worker` first. They're the resource drivers, and an OOM there is the most common cause of a stall.
 
+## Backend health
+
+The backend serves an unauthenticated health check at `/health/`. It's the same endpoint `./bin/install` polls while it waits for the stack, so it's the one signal that tells you the application layer is actually serving rather than merely running:
+
+```bash
+curl -sf http://localhost:8000/health/
+```
+
 ## fi-collector health
 
-The fi-collector exposes an admin endpoint on `127.0.0.1:9464` (`FI_COLLECTOR_ADMIN_PORT`), which serves a health check. Hit it to confirm the collector is up:
+The fi-collector exposes an admin endpoint on `127.0.0.1:9464` (`FI_COLLECTOR_ADMIN_PORT`):
 
 ```bash
 curl -s http://localhost:9464/healthz
 ```
+
+This one is worth alerting on rather than just checking. It returns 200 unless the collector's dead-letter rate crosses its threshold, so a non-200 means spans are failing to reach ClickHouse and piling up in [`futureagi_fi-collector-data`](/docs/self-hosting/production/backups-restore) instead of being queryable.
 
 ## PeerDB replication
 

--- a/src/pages/docs/self-hosting/production/monitoring.mdx
+++ b/src/pages/docs/self-hosting/production/monitoring.mdx
@@ -3,7 +3,7 @@ title: "Monitoring"
 description: "Watch a self-hosted instance with the health signals it actually exposes"
 ---
 
-The stack has no Prometheus `/metrics` endpoint yet (the fi-collector lists a metrics exporter as a TODO), so monitoring today is built from what the containers already expose: their Docker health checks, the backend and collector health endpoints, and the PeerDB console. This page covers those and the signals worth watching.
+Four things are worth watching on a self-hosted instance: container health, the backend's health endpoint, the collector's, and the PeerDB replication console. This page covers each, what a bad reading looks like, and where to go when you get one.
 
 ## Container health
 
@@ -14,7 +14,7 @@ docker compose ps        # STATUS shows healthy / unhealthy per service
 docker stats             # live CPU and memory per container
 ```
 
-Watch memory on `clickhouse` and the Temporal `worker` first. They're the resource drivers, and an OOM there is the most common cause of a stall.
+Watch memory on `clickhouse` and the Temporal `worker` first. They're the resource drivers, each sitting around 1 GB at steady state, and an OOM there is the most common cause of a stall. The tell is a container cycling through `Restarting` in `docker compose ps`: raise the host's memory to the [requirements](/docs/self-hosting/requirements) floor if you see it.
 
 ## Backend health
 
@@ -36,10 +36,10 @@ This one is worth alerting on rather than just checking. It returns 200 unless t
 
 ## PeerDB replication
 
-The Postgres-to-ClickHouse pipeline has its own console at [localhost:3001](http://localhost:3001). Mirror status there tells you whether trace analytics are keeping up with Postgres. A mirror in anything other than `running` means the dashboard is reading stale.
+The Postgres-to-ClickHouse pipeline has its own console at [localhost:3001](http://localhost:3001). Mirror status there tells you whether trace analytics are keeping up with Postgres. A mirror in anything other than `running` means the dashboard is reading stale. Re-running init usually clears it, and [Troubleshooting](/docs/self-hosting/troubleshooting) has the command and the first-boot race that causes most of these.
 
 <Note>
-A Prometheus metrics exporter is on the fi-collector roadmap. When it lands, scrape it here. Until then, the checks above are what the stack actually exposes.
+There is no Prometheus `/metrics` endpoint yet: an exporter is on the fi-collector roadmap, and until it lands the checks above are what the stack actually exposes.
 </Note>
 
 ## Dive deeper

--- a/src/pages/docs/self-hosting/production/security-tls.mdx
+++ b/src/pages/docs/self-hosting/production/security-tls.mdx
@@ -27,6 +27,14 @@ api.yourcompany.com  { reverse_proxy localhost:8000 }
     docker compose up -d frontend
     ```
   </Step>
+  <Step title="Close the plaintext ports">
+    The frontend and backend publish on every interface, so `:3000` and `:8000` stay reachable in plaintext once the proxy is live and anyone can bypass TLS by going straight to them. Firewall both at the host, or bind them to loopback so only the proxy can reach them:
+
+    ```bash
+    FRONTEND_PORT=127.0.0.1:3000
+    BACKEND_PORT=127.0.0.1:8000
+    ```
+  </Step>
 </Steps>
 
 <Warning>
@@ -53,7 +61,7 @@ Rotate the dev-only default secrets from the [Checklist](/docs/self-hosting/prod
   <Card title="Backups & restore" icon="database" href="/docs/self-hosting/production/backups-restore">
     Protect the data behind the proxy
   </Card>
-  <Card title="System configuration" icon="gear" href="/docs/self-hosting/configuration">
+  <Card title="System configuration" icon="gear" href="/docs/self-hosting/configuration/system">
     Tune the gateway, PeerDB, and Temporal workers
   </Card>
 </CardGroup>

--- a/src/pages/docs/self-hosting/production/security-tls.mdx
+++ b/src/pages/docs/self-hosting/production/security-tls.mdx
@@ -3,57 +3,66 @@ title: "Security & TLS"
 description: "Terminate TLS in front of a self-hosted instance and lock down its secrets"
 ---
 
-Neither the frontend nor the backend terminates TLS. In production you put a reverse proxy in front of the stack to handle certificates, then point the frontend at the HTTPS endpoint. This page covers both, plus where production secrets should live.
+Neither the frontend nor the backend terminates TLS. In production you put a reverse proxy in front of the stack to handle certificates, then point the frontend at the HTTPS endpoint. This page covers both, plus where production secrets should live and why the code executor needs its own host.
 
 ## Terminate TLS with a reverse proxy
 
-Run Caddy, nginx, or Traefik in front of the stack. Caddy is the shortest path because it issues and renews Let's Encrypt certificates on its own:
-
-```
-# Caddyfile
-app.yourcompany.com  { reverse_proxy localhost:3000 }
-api.yourcompany.com  { reverse_proxy localhost:8000 }
-```
+Run Caddy, nginx, or Traefik in front of the stack. Caddy is the shortest path because it issues and renews Let's Encrypt certificates on its own.
 
 <Steps>
-  <Step title="Put the proxy in front">
-    Point the proxy at the frontend on `localhost:3000` and the backend on `localhost:8000`. The full port list is in [Requirements](/docs/self-hosting/requirements#network-ports).
+  <Step title="Run the proxy">
+    Put a `Caddyfile` next to your compose file, pointing each hostname at the port the stack already publishes. The full port list is in [Requirements](/docs/self-hosting/requirements#network-ports).
+
+    ```
+    # Caddyfile
+    app.yourcompany.com  { reverse_proxy localhost:3000 }
+    api.yourcompany.com  { reverse_proxy localhost:8000 }
+    ```
+
+    Then start Caddy on the host, from the same directory:
+
+    ```bash
+    caddy run --config ./Caddyfile
+    ```
+
+    Both hostnames have to resolve to this machine before Caddy can complete the Let's Encrypt challenge.
   </Step>
   <Step title="Point the frontend at HTTPS">
-    Set `VITE_HOST_API=https://api.yourcompany.com` in `.env`. The frontend container reads it on start and writes it into `config.js`, so no rebuild is needed.
-  </Step>
-  <Step title="Restart the frontend">
-    ```bash
-    docker compose up -d frontend
-    ```
+    Set `VITE_HOST_API=https://api.yourcompany.com` in `.env`. The frontend container reads it on start and writes it into `config.js`, so no rebuild is needed. Nothing on the backend needs to know about the new origin.
   </Step>
   <Step title="Close the plaintext ports">
-    The frontend and backend publish on every interface, so `:3000` and `:8000` stay reachable in plaintext once the proxy is live and anyone can bypass TLS by going straight to them. Firewall both at the host, or bind them to loopback so only the proxy can reach them:
+    The frontend and backend publish on every interface, so `:3000` and `:8000` stay reachable in plaintext once the proxy is live and anyone can bypass TLS by going straight to them. Firewall both at the host, or bind them to loopback in the same `.env` so only the proxy can reach them:
 
     ```bash
     FRONTEND_PORT=127.0.0.1:3000
     BACKEND_PORT=127.0.0.1:8000
     ```
   </Step>
+  <Step title="Apply and verify">
+    Recreate the containers so both the new origin and the new bindings take:
+
+    ```bash
+    docker compose up -d
+    curl -sI https://app.yourcompany.com | head -1     # expect HTTP/2 200
+    ```
+
+    If the browser still calls the old host, the frontend container wasn't recreated: run `docker compose up -d frontend` again.
+  </Step>
 </Steps>
 
-<Warning>
-`VITE_HOST_API` is applied when the frontend container starts, not at build time. If the browser still calls the old host after you change it, the container wasn't recreated: rerun `docker compose up -d frontend`.
-</Warning>
+## Keep secrets out of `.env`
 
-## Keep secrets out of the compose file
-
-For anything past a single trial host, store secrets in a dedicated manager instead of a plain `.env`:
+For anything past a single trial host, store the nine production secrets in a dedicated manager instead of a plain file on disk:
 
 - AWS Secrets Manager
 - HashiCorp Vault
 - GCP Secret Manager
 
-Rotate the dev-only default secrets from the [Checklist](/docs/self-hosting/production/checklist) first, then move them into the manager and inject them at deploy time.
+Rotate the dev-only defaults first: the [Checklist](/docs/self-hosting/production/checklist) lists all nine and the overlay that refuses to boot without them. Then move those values into the manager and inject them as environment variables at deploy time.
 
 ## Isolate the code executor
 
-`code-executor` runs with `privileged: true` so it can sandbox evaluation code. Keep it on a host you control, an EC2 or GCE instance, never a managed-container platform that can't grant that flag.
+`code-executor` runs with `privileged: true` so it can sandbox evaluation code. Keep it on a host you control, an EC2 or GCE instance, never a managed-container platform that can't grant that flag. If your platform can't, the rest of the stack still runs without it and you lose only code-based evaluations.
 
 ## Dive deeper
 

--- a/src/pages/docs/self-hosting/production/upgrades-rollback.mdx
+++ b/src/pages/docs/self-hosting/production/upgrades-rollback.mdx
@@ -3,17 +3,19 @@ title: "Upgrades & rollback"
 description: "Pull a new release, run migrations, and roll back when one goes wrong"
 ---
 
-Upgrades are a git pull and a rebuild, and migrations run automatically on boot. This page covers the routine upgrade, the two cases that need a manual step, and how to roll back.
+Nothing in the stack is built locally: every service runs a published image, tagged by version variables in `.env`. So an upgrade is a pull of new images, and a rollback is pinning those variables back. Migrations run automatically on boot either way. This page covers the routine upgrade, the two cases that need a manual step, and how to roll back.
 
 ## Upgrade to a new release
 
 <Steps>
-  <Step title="Pull and rebuild">
+  <Step title="Pull the new images">
     ```bash
-    git pull
-    docker compose build
+    git pull              # picks up compose file changes
+    docker compose pull   # fetch the new images
     docker compose up -d
     ```
+
+    `docker compose up -d` won't fetch anything on its own when the tag is already present locally, which is why `pull` is its own step.
   </Step>
   <Step title="Let migrations run">
     Database migrations run automatically on backend startup. If one fails, run it by hand:
@@ -35,13 +37,22 @@ PeerDB init only rebuilds the tables it mirrors from Postgres. It does **not** r
 
 ## Roll back a bad release
 
-Roll back to the previous commit and rebuild:
+Rolling back is a version pin, not a `git checkout`. Set each image back to the previous release tag in `.env`, then bring the stack up again:
 
 ```bash
-git log --oneline -5
-git checkout <previous-hash>
-docker compose build && docker compose up -d
+# .env (release tags are vX.Y.Z, matching the repo's git tags)
+FUTURE_AGI_VERSION=v1.25.0
+FRONTEND_VERSION=v1.25.0
+AGENTCC_GATEWAY_VERSION=v1.25.0
+SERVING_VERSION=v1.25.0
+CODE_EXECUTOR_VERSION=v1.25.0
 ```
+
+```bash
+docker compose up -d
+```
+
+`FUTURE_AGI_VERSION` covers `backend`, `worker` and `fi-collector`, which all share one image. Leaving a variable empty means `:latest`, so for anything carrying real traffic, pin all five rather than floating.
 
 <Warning>
 Checking out older code does not undo a migration that already ran. If a release applied a migration you need to reverse, roll it back before you switch code, or restore Postgres from a backup.

--- a/src/pages/docs/self-hosting/production/upgrades-rollback.mdx
+++ b/src/pages/docs/self-hosting/production/upgrades-rollback.mdx
@@ -7,6 +7,8 @@ Nothing in the stack is built locally: every service runs a published image, tag
 
 ## Upgrade to a new release
 
+Take a Postgres backup before you start. Migrations run on boot and a `git checkout` won't reverse them, so a backup is the only thing that gets you back if one goes wrong. [Backups & restore](/docs/self-hosting/production/backups-restore) has the command.
+
 <Steps>
   <Step title="Pull the new images">
     ```bash
@@ -18,13 +20,19 @@ Nothing in the stack is built locally: every service runs a published image, tag
     `docker compose up -d` won't fetch anything on its own when the tag is already present locally, which is why `pull` is its own step.
   </Step>
   <Step title="Let migrations run">
-    Database migrations run automatically on backend startup. If one fails, run it by hand:
+    Database migrations run automatically on backend startup, so watch the backend come up rather than assuming it worked:
+
+    ```bash
+    docker compose logs -f backend    # look for "Application startup complete"
+    ```
+
+    If a migration failed, the backend won't reach that line. Run it by hand to see the error:
     ```bash
     docker compose exec backend python manage.py migrate
     ```
   </Step>
   <Step title="Re-run PeerDB init if the release notes say so">
-    When a release changes which Postgres tables are mirrored, re-run init. The container's entrypoint is already `bash /setup.sh`, so no arguments are needed:
+    When a release changes which Postgres tables are mirrored, re-run init. The [release notes](https://github.com/future-agi/future-agi/releases) say when that applies. The container's entrypoint is already `bash /setup.sh`, so no arguments are needed:
     ```bash
     docker compose run --rm peerdb-init
     ```
@@ -37,7 +45,17 @@ PeerDB init only rebuilds the tables it mirrors from Postgres. It does **not** r
 
 ## Roll back a bad release
 
-Rolling back is a version pin, not a `git checkout`. Set each image back to the previous release tag in `.env`, then bring the stack up again:
+<Warning>
+Checking out older code does not undo a migration that already ran. If the release you're leaving applied one you need reversed, roll that back or restore Postgres from a backup *before* you pin the old images, or you'll be running an old binary against a newer schema.
+</Warning>
+
+Rolling back is a version pin, not a `git checkout`. First find the tags you're on:
+
+```bash
+docker compose images    # IMAGE and TAG per running service
+```
+
+Then set each one back to the previous release in `.env` and bring the stack up again:
 
 ```bash
 # .env (release tags are vX.Y.Z, matching the repo's git tags)
@@ -53,10 +71,6 @@ docker compose up -d
 ```
 
 `FUTURE_AGI_VERSION` covers `backend`, `worker` and `fi-collector`, which all share one image. Leaving a variable empty means `:latest`, so for anything carrying real traffic, pin all five rather than floating.
-
-<Warning>
-Checking out older code does not undo a migration that already ran. If a release applied a migration you need to reverse, roll it back before you switch code, or restore Postgres from a backup.
-</Warning>
 
 ## Dive deeper
 

--- a/src/pages/docs/self-hosting/requirements.mdx
+++ b/src/pages/docs/self-hosting/requirements.mdx
@@ -5,16 +5,17 @@ description: "System requirements and support for self-hosting Future AGI"
 
 ## In this page
 
-Check three things before you install:
+Check four things before you install:
 
 - A host that meets the sizing for your usage
 - The required software: Docker and Git
-- A supported platform
+- A platform that allows privileged containers
+- Host ports that are free, or remapped
 
 Get these right and the [Installation](/docs/self-hosting/installation) run works on the first try.
 
 <TLDR>
-For a local trial: **4 CPU cores, 8 GB RAM, 20 GB disk**, Docker Engine 24+, Docker Compose v2.24+, and Git.
+For a local trial: **4 CPU cores, 8 GB RAM, 20 GB disk**, Docker Engine 24+, Docker Compose v2.24+, and Git. The host must allow **privileged containers**, which rules out Fargate, Cloud Run, and most managed container platforms.
 </TLDR>
 
 ## Hardware tiers
@@ -30,7 +31,7 @@ Pick the row that matches how you'll use the instance. The stack runs on the Eva
 ClickHouse and the Temporal worker each hold ~1 GB RAM at steady state. ClickHouse grows with trace volume over time; Postgres stays small. Pulling the images takes a few GB of disk on the first run.
 
 <Tip>
-On Docker Desktop for Mac, raise the limits in **Settings → Resources**: RAM ≥ 8 GB, disk ≥ 64 GB. The defaults (2-4 GB RAM) will OOM-kill ClickHouse or the backend before the stack finishes booting. On Windows those sliders don't apply, so set the limit in `.wslconfig` as shown in the Windows tab below.
+Docker Desktop only. On Mac, raise the limits in **Settings → Resources**: RAM ≥ 8 GB, disk ≥ 64 GB. That disk number is the whole Docker VM, not the 20 GB this stack uses, so it has to cover every image and volume on the machine. The defaults (2-4 GB RAM) will OOM-kill ClickHouse or the backend before the stack finishes booting. On Windows those sliders don't apply, so set the limit in `.wslconfig` as shown in the Windows tab below.
 </Tip>
 
 ## Software
@@ -78,12 +79,12 @@ Future AGI runs on any host that allows **privileged containers**. The `code-exe
 | Platform | Supported | Notes |
 |---|---|---|
 | Linux bare metal / EC2 / GCE / Azure VM | Yes | Full support |
-| GKE / EKS with privileged enabled | Yes | Needs a Pod Security Admission exception on the namespace |
+| GKE / EKS nodes with privileged enabled | Yes | Compose on a node, not Kubernetes manifests. Needs a Pod Security Admission exception |
 | ECS Fargate | No | `privileged: true` not supported |
 | Google Cloud Run | No | Same |
 | Render / Railway / Fly.io | No | Managed platforms block privileged mode |
 
-Helm/Kubernetes support is on the roadmap. Docker Compose is the supported path today.
+There are no Helm charts or Kubernetes manifests: that support is on the roadmap, and Docker Compose is the only supported path today. The GKE/EKS row above means the *host* is capable, so you'd run Compose on a node rather than deploy the stack as Kubernetes workloads.
 
 ## Network ports
 
@@ -106,15 +107,23 @@ Make sure these host ports are free before you install, or remap any that collid
 | MinIO API | `9005` | `127.0.0.1` | `MINIO_API_PORT` |
 | MinIO console | `9006` | `127.0.0.1` | `MINIO_CONSOLE_PORT` |
 | Temporal | `7233` | `127.0.0.1` | `TEMPORAL_PORT` |
-| Temporal UI | `8085` | `0.0.0.0` | `TEMPORAL_UI_PORT` |
-| PeerDB server | `9900` | `127.0.0.1` | `PEERDB_PORT` |
-| PeerDB UI | `3001` | `0.0.0.0` | `PEERDB_UI_PORT` |
+| Temporal UI (`observability`) | `8085` | `0.0.0.0` | `TEMPORAL_UI_PORT` |
+| PeerDB server (`full`) | `9900` | `127.0.0.1` | `PEERDB_PORT` |
+| PeerDB UI (`full`) | `3001` | `0.0.0.0` | `PEERDB_UI_PORT` |
 
 Anything on `127.0.0.1` is reachable from the host but not from the network, which covers the data stores and the collector's three ports. The user-facing services bind to `0.0.0.0`.
 
 Watch `4317` in particular: it's the default OTLP port, so it collides with any other OpenTelemetry collector already on the host, and it's where the SDK sends your traces.
 
-Three of these rows are [profile](/docs/self-hosting/configuration/profiles)-gated and free otherwise: Temporal UI needs `observability`, and the two PeerDB ports need `full`.
+The three rows tagged with a profile name only run under that [profile](/docs/self-hosting/configuration/profiles) and are free otherwise.
+
+To find a collision before you install, check the ports you care about:
+
+```bash
+lsof -i :3000 -i :8000 -i :4317    # anything listed is already taken
+```
+
+If one is busy, compose fails at startup with a bind error naming the port. Remap it in `.env`, which the installer creates for you from `.env.example`.
 
 ## Dive deeper
 

--- a/src/pages/docs/self-hosting/requirements.mdx
+++ b/src/pages/docs/self-hosting/requirements.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Requirements"
-description: "System requirements and support for self-hosting Future AGI."
+description: "System requirements and support for self-hosting Future AGI"
 ---
 
 ## In this page
@@ -14,7 +14,7 @@ Check three things before you install:
 Get these right and the [Installation](/docs/self-hosting/installation) run works on the first try.
 
 <TLDR>
-For a local trial: **4 CPU cores, 8 GB RAM, 20 GB disk**, Docker Engine 24+, Docker Compose v2.20+, and Git.
+For a local trial: **4 CPU cores, 8 GB RAM, 20 GB disk**, Docker Engine 24+, Docker Compose v2.24+, and Git.
 </TLDR>
 
 ## Hardware tiers
@@ -30,7 +30,7 @@ Pick the row that matches how you'll use the instance. The stack runs on the Eva
 ClickHouse and the Temporal worker each hold ~1 GB RAM at steady state. ClickHouse grows with trace volume over time; Postgres stays small. Pulling the images takes a few GB of disk on the first run.
 
 <Tip>
-On Docker Desktop (Mac/Windows), raise the limits in **Settings → Resources**: RAM ≥ 8 GB, disk ≥ 64 GB. The defaults (2-4 GB RAM) will OOM-kill ClickHouse or the backend before the stack finishes booting.
+On Docker Desktop for Mac, raise the limits in **Settings → Resources**: RAM ≥ 8 GB, disk ≥ 64 GB. The defaults (2-4 GB RAM) will OOM-kill ClickHouse or the backend before the stack finishes booting. On Windows those sliders don't apply, so set the limit in `.wslconfig` as shown in the Windows tab below.
 </Tip>
 
 ## Software
@@ -38,8 +38,10 @@ On Docker Desktop (Mac/Windows), raise the limits in **Settings → Resources**:
 | Requirement | Minimum | Verify |
 |---|---|---|
 | Docker Engine | 24.0+ | `docker --version` |
-| Docker Compose | v2.20+ | `docker compose version` |
+| Docker Compose | v2.24+ | `docker compose version` |
 | Git | 2.0+ | `git --version` |
+
+Compose v2.24 is a hard floor, not a recommendation: `docker-compose.yml` declares its env files with the long `path` / `required` form, which older Compose can't parse. On v2.23 or below the stack fails at parse time, before a single image is pulled.
 
 <Tabs>
 <Tab title="macOS">
@@ -76,7 +78,7 @@ Future AGI runs on any host that allows **privileged containers**. The `code-exe
 | Platform | Supported | Notes |
 |---|---|---|
 | Linux bare metal / EC2 / GCE / Azure VM | Yes | Full support |
-| GKE / EKS with privileged enabled | Yes | Requires a PodSecurityPolicy exception |
+| GKE / EKS with privileged enabled | Yes | Needs a Pod Security Admission exception on the namespace |
 | ECS Fargate | No | `privileged: true` not supported |
 | Google Cloud Run | No | Same |
 | Render / Railway / Fly.io | No | Managed platforms block privileged mode |
@@ -94,6 +96,9 @@ Make sure these host ports are free before you install, or remap any that collid
 | Gateway | `8090` | `0.0.0.0` | `AGENTCC_GATEWAY_PORT` |
 | Model serving | `8080` | `0.0.0.0` | `SERVING_PORT` |
 | Code executor | `8060` | `0.0.0.0` | `CODE_EXECUTOR_PORT` |
+| Collector OTLP gRPC | `4317` | `127.0.0.1` | `FI_COLLECTOR_OTLP_PORT` |
+| Collector OTLP HTTP | `4318` | `127.0.0.1` | `FI_COLLECTOR_OTLP_HTTP_PORT` |
+| Collector admin | `9464` | `127.0.0.1` | `FI_COLLECTOR_ADMIN_PORT` |
 | Postgres | `5432` | `127.0.0.1` | `PG_PORT` |
 | ClickHouse HTTP | `8123` | `127.0.0.1` | `CH_HTTP_PORT` |
 | ClickHouse TCP | `9000` | `127.0.0.1` | `CH_PORT` |
@@ -101,16 +106,24 @@ Make sure these host ports are free before you install, or remap any that collid
 | MinIO API | `9005` | `127.0.0.1` | `MINIO_API_PORT` |
 | MinIO console | `9006` | `127.0.0.1` | `MINIO_CONSOLE_PORT` |
 | Temporal | `7233` | `127.0.0.1` | `TEMPORAL_PORT` |
+| Temporal UI | `8085` | `0.0.0.0` | `TEMPORAL_UI_PORT` |
 | PeerDB server | `9900` | `127.0.0.1` | `PEERDB_PORT` |
 | PeerDB UI | `3001` | `0.0.0.0` | `PEERDB_UI_PORT` |
 
-The data stores (Postgres, ClickHouse, Redis, MinIO, Temporal) bind to `127.0.0.1`; the application services bind to `0.0.0.0`. PeerDB server and UI only run when you enable the CDC stack with `COMPOSE_PROFILES=full`, so those two ports are only in use in that mode.
+Anything on `127.0.0.1` is reachable from the host but not from the network, which covers the data stores and the collector's three ports. The user-facing services bind to `0.0.0.0`.
+
+Watch `4317` in particular: it's the default OTLP port, so it collides with any other OpenTelemetry collector already on the host, and it's where the SDK sends your traces.
+
+Three of these rows are [profile](/docs/self-hosting/configuration/profiles)-gated and free otherwise: Temporal UI needs `observability`, and the two PeerDB ports need `full`.
 
 ## Dive deeper
 
-<CardGroup cols={2}>
+<CardGroup cols={3}>
   <Card title="Installation" icon="play-circle" href="/docs/self-hosting/installation">
     Clone the repo and bring the stack up with `./bin/install`
+  </Card>
+  <Card title="Profiles" icon="layer-group" href="/docs/self-hosting/configuration/profiles">
+    Decide how many of the 31 services you actually need
   </Card>
   <Card title="Environment variables" icon="list-check" href="/docs/self-hosting/configuration/environment">
     Set provider keys, secrets, and runtime flags in `.env`

--- a/src/pages/docs/self-hosting/support.mdx
+++ b/src/pages/docs/self-hosting/support.mdx
@@ -16,6 +16,10 @@ Running the open-source stack and hit something these pages don't cover? Here's 
   </Card>
 </CardGroup>
 
+## Reporting a security issue
+
+A vulnerability doesn't go in a public GitHub issue. Report it privately to [security@futureagi.com](mailto:security@futureagi.com) instead, which is what the repo's `SECURITY.md` asks for. You'll get an acknowledgement inside 24 hours on weekdays, and disclosure is coordinated with you rather than announced.
+
 ## Before you post
 
 A self-hosting question is easier to answer with the basics attached:
@@ -24,6 +28,7 @@ A self-hosting question is easier to answer with the basics attached:
 - Output of `docker compose ps` so the team can see which service is down
 - Logs from the failing service: `docker compose logs <service> --tail=100`
 - Your platform (Linux host, EC2, GCE) and whether you're on managed data stores
+- The release you're running: the version variables from `.env`, or `docker compose images` if you're floating on `latest`
 
 Most self-hosting questions are already answered in [Troubleshooting & FAQs](/docs/self-hosting/troubleshooting). Check there first.
 

--- a/src/pages/docs/self-hosting/support.mdx
+++ b/src/pages/docs/self-hosting/support.mdx
@@ -5,6 +5,8 @@ description: "Where to get help running a self-hosted Future AGI instance"
 
 Running the open-source stack and hit something these pages don't cover? Here's where to reach the team and the community, and what to include so you get a useful answer fast.
 
+Most self-hosting questions are already answered in [Troubleshooting & FAQs](/docs/self-hosting/troubleshooting), so start there. If it isn't covered, here's where to reach us.
+
 ## Where to get help
 
 <CardGroup cols={2}>
@@ -12,25 +14,25 @@ Running the open-source stack and hit something these pages don't cover? Here's 
     Ask the community and the team in the Future AGI Discord
   </Card>
   <Card title="GitHub issues" icon="github" href="https://github.com/future-agi/future-agi/issues">
-    Report a bug or request a feature on the open-source repo
+    Report a bug or request a feature. Not for vulnerabilities, see below
   </Card>
 </CardGroup>
 
 ## Reporting a security issue
 
-A vulnerability doesn't go in a public GitHub issue. Report it privately to [security@futureagi.com](mailto:security@futureagi.com) instead, which is what the repo's `SECURITY.md` asks for. You'll get an acknowledgement inside 24 hours on weekdays, and disclosure is coordinated with you rather than announced.
+<Warning>
+**A vulnerability never goes in a public GitHub issue.** Report it privately to [security@futureagi.com](mailto:security@futureagi.com), which is what the repo's `SECURITY.md` asks for. You'll get an acknowledgement inside 24 hours on weekdays, and disclosure is coordinated with you rather than announced.
+</Warning>
 
 ## Before you post
 
-A self-hosting question is easier to answer with the basics attached:
+On the Compose deployment, a question is easier to answer with the basics attached:
 
 - What you ran and what happened, with the exact error
 - Output of `docker compose ps` so the team can see which service is down
 - Logs from the failing service: `docker compose logs <service> --tail=100`
 - Your platform (Linux host, EC2, GCE) and whether you're on managed data stores
-- The release you're running: the version variables from `.env`, or `docker compose images` if you're floating on `latest`
-
-Most self-hosting questions are already answered in [Troubleshooting & FAQs](/docs/self-hosting/troubleshooting). Check there first.
+- The release you're running: `FUTURE_AGI_VERSION`, `FRONTEND_VERSION`, `AGENTCC_GATEWAY_VERSION`, `SERVING_VERSION` and `CODE_EXECUTOR_VERSION` from `.env`, or `docker compose images` if you're floating on `latest`
 
 ## Commercial support
 

--- a/src/pages/docs/self-hosting/troubleshooting.mdx
+++ b/src/pages/docs/self-hosting/troubleshooting.mdx
@@ -12,19 +12,19 @@ Symptoms, causes, and fixes for the errors most commonly hit when self-hosting. 
 ```bash
 docker compose ps                    # what's running / what's restarting
 docker compose logs -f backend       # most informative starting point
-docker compose exec backend bash     # shell into any container
+docker compose exec backend bash     # shell in, swap "backend" for any service
 ```
 
 ---
 
 ## Startup errors
 
-**`Cannot connect to the Docker daemon`**
+### `Cannot connect to the Docker daemon`
 Docker isn't running. Start Docker Desktop (Mac/Windows) or `sudo systemctl start docker` (Linux).
 
 ---
 
-**First boot takes 15+ min or looks stuck**
+### First boot takes 15+ min or looks stuck
 Normal. First boot pulls every image from Docker Hub, a few GB in total, and nothing is built locally so there's no compile step to hang on. Watch the pull actually progressing:
 ```bash
 docker compose logs -f
@@ -33,43 +33,44 @@ docker compose pull        # re-run to resume an interrupted pull
 
 ---
 
-**`ERROR: not enough free space`**
+### `ERROR: not enough free space`
 Docker Desktop's virtual disk is full. Settings → Resources → Disk image size → raise to 100 GB+. Or reclaim space from unused images: `docker system prune -af`
 
 ---
 
-**Port already in use**
+### Port already in use
 ```bash
-lsof -i :3000   # find the conflicting process
-# or override in .env:
+lsof -i :3000                # swap 3000 for whichever port the error named
+# then override it in .env:
 FRONTEND_PORT=3100
 BACKEND_PORT=8100
+docker compose up -d         # recreate so the new binding takes
 ```
 
 ---
 
-**Backend never reaches `Application startup complete`**
+### Backend never reaches `Application startup complete`
 - Check RAM: `docker info | grep -i memory` (Docker needs ≥ 8 GB)
 - Check for migration errors: `docker compose logs backend | grep -i error`
 - Run migrations manually: `docker compose exec backend python manage.py migrate`
 
 ---
 
-**`FATAL: password authentication failed for user "futureagi"`**
+### `FATAL: password authentication failed for user "futureagi"`
 `PG_PASSWORD` was changed after the Postgres volume was initialized. Postgres sets the password only on first boot.
 - Option 1: revert `PG_PASSWORD` to the original value
 - Option 2 (data loss): `docker compose down -v && docker compose up -d`
 
 ---
 
-**`code-executor` crashes with `clone: Operation not permitted`**
+### `code-executor` crashes with `clone: Operation not permitted`
 Host platform blocks `privileged: true`. Won't work on Fargate, Cloud Run, or restricted Kubernetes. Use EC2, GCE, or bare metal. The rest of the stack runs, and only code-based eval features are unavailable.
 
 ---
 
 ## Network and UI errors
 
-**Frontend blank page or CORS errors**
+### Frontend blank page or CORS errors
 `VITE_HOST_API` in `.env` doesn't match the current backend URL. It's written into `config.js` when the frontend container starts, so recreating the container is enough and no rebuild is involved:
 ```bash
 docker compose up -d frontend
@@ -77,14 +78,14 @@ docker compose up -d frontend
 
 ---
 
-**API calls fail with 502**
+### API calls fail with 502
 Backend isn't healthy. Check: `docker compose logs backend` and `docker compose ps backend`.
 
 ---
 
 ## PeerDB errors
 
-**Mirrors show "not started" or don't appear**
+### Mirrors show "not started" or don't appear
 PeerDB init ran before Django migrations completed. Fix:
 ```bash
 docker compose logs -f backend      # wait for "Application startup complete"
@@ -94,8 +95,8 @@ Verify at [http://localhost:3001](http://localhost:3001), where mirrors should s
 
 ---
 
-**Analytics data is stale**
-PeerDB replication has fallen behind. Check mirror lag in the PeerDB UI. Re-run init if a mirror shows an error:
+### Analytics data is stale
+PeerDB replication has fallen behind. Check mirror lag in the PeerDB UI at [http://localhost:3001](http://localhost:3001). Re-run init if a mirror shows an error:
 ```bash
 docker compose run --rm peerdb-init
 ```
@@ -104,23 +105,32 @@ docker compose run --rm peerdb-init
 
 ## Temporal errors
 
-**`temporal-server` keeps restarting**
+### `temporal-server` keeps restarting
 Almost always a Postgres issue. Check: `docker compose logs postgres`. If Postgres is OOM-killing, raise Docker RAM to ≥ 8 GB. If Postgres is healthy: `docker compose restart postgres temporal`
 
 ---
 
 ## After an upgrade
 
-**Migration fails after `git pull`**
+### Migration fails after `git pull`
 ```bash
 docker compose exec backend python manage.py migrate
 ```
 If a conflict persists, check the release notes for manual steps.
 
-**Everything worked before the upgrade, now it doesn't**
+---
+
+### Everything worked before the upgrade, now it doesn't
 Roll back by pinning the image versions in `.env` to the previous release tag, then bringing the stack up again. Nothing is built locally, so a `git checkout` on its own changes no running code. The full procedure is in [Upgrades & rollback](/docs/self-hosting/production/upgrades-rollback).
 ```bash
-FUTURE_AGI_VERSION=v1.25.0    # and the other four version variables
+# .env, pin all five to the previous release tag
+FUTURE_AGI_VERSION=v1.25.0
+FRONTEND_VERSION=v1.25.0
+AGENTCC_GATEWAY_VERSION=v1.25.0
+SERVING_VERSION=v1.25.0
+CODE_EXECUTOR_VERSION=v1.25.0
+```
+```bash
 docker compose up -d
 ```
 
@@ -128,7 +138,7 @@ docker compose up -d
 
 ## Still stuck?
 
-Open an issue at [github.com/future-agi/future-agi/issues](https://github.com/future-agi/future-agi/issues) with:
+Open an issue at [github.com/future-agi/future-agi/issues](https://github.com/future-agi/future-agi/issues) and attach `all-logs.txt`. Scrub any credentials before you upload it, since the dump includes container environments.
 ```bash
 docker compose logs > all-logs.txt 2>&1
 docker compose ps >> all-logs.txt

--- a/src/pages/docs/self-hosting/troubleshooting.mdx
+++ b/src/pages/docs/self-hosting/troubleshooting.mdx
@@ -1,9 +1,9 @@
 ---
-title: "Troubleshooting and FAQs"
-description: "Debug self-hosted Future AGI — symptoms, causes, and fixes for startup failures, network issues, PeerDB CDC errors, Temporal worker problems, and post-upgrade breaks."
+title: "Troubleshooting & FAQs"
+description: "Symptoms, causes, and fixes for a self-hosted instance"
 ---
 
-## About
+## In this page
 
 Symptoms, causes, and fixes for the errors most commonly hit when self-hosting. Grouped by where they show up: startup, network, PeerDB, Temporal, and post-upgrade.
 
@@ -24,16 +24,17 @@ Docker isn't running. Start Docker Desktop (Mac/Windows) or `sudo systemctl star
 
 ---
 
-**First build takes 15+ min or hangs on `uv pip install`**
-Normal on first boot. If stuck >20 min, cancel and retry:
+**First boot takes 15+ min or looks stuck**
+Normal. First boot pulls every image from Docker Hub, a few GB in total, and nothing is built locally so there's no compile step to hang on. Watch the pull actually progressing:
 ```bash
-docker compose build --no-cache backend
+docker compose logs -f
+docker compose pull        # re-run to resume an interrupted pull
 ```
 
 ---
 
 **`ERROR: not enough free space`**
-Docker Desktop's virtual disk is full. Settings → Resources → Disk image size → raise to 100 GB+. Or prune: `docker system prune -af && docker builder prune -af`
+Docker Desktop's virtual disk is full. Settings → Resources → Disk image size → raise to 100 GB+. Or reclaim space from unused images: `docker system prune -af`
 
 ---
 
@@ -48,7 +49,7 @@ BACKEND_PORT=8100
 ---
 
 **Backend never reaches `Application startup complete`**
-- Check RAM: `docker info | grep -i memory` — Docker needs ≥ 8 GB
+- Check RAM: `docker info | grep -i memory` (Docker needs ≥ 8 GB)
 - Check for migration errors: `docker compose logs backend | grep -i error`
 - Run migrations manually: `docker compose exec backend python manage.py migrate`
 
@@ -62,16 +63,15 @@ BACKEND_PORT=8100
 ---
 
 **`code-executor` crashes with `clone: Operation not permitted`**
-Host platform blocks `privileged: true`. Won't work on Fargate, Cloud Run, or restricted Kubernetes. Use EC2, GCE, or bare metal. The rest of the stack runs — only code-based eval features are unavailable.
+Host platform blocks `privileged: true`. Won't work on Fargate, Cloud Run, or restricted Kubernetes. Use EC2, GCE, or bare metal. The rest of the stack runs, and only code-based eval features are unavailable.
 
 ---
 
 ## Network and UI errors
 
 **Frontend blank page or CORS errors**
-`VITE_HOST_API` in `.env` doesn't match the current backend URL. Rebuild:
+`VITE_HOST_API` in `.env` doesn't match the current backend URL. It's written into `config.js` when the frontend container starts, so recreating the container is enough and no rebuild is involved:
 ```bash
-docker compose build --no-cache frontend
 docker compose up -d frontend
 ```
 
@@ -88,16 +88,16 @@ Backend isn't healthy. Check: `docker compose logs backend` and `docker compose 
 PeerDB init ran before Django migrations completed. Fix:
 ```bash
 docker compose logs -f backend      # wait for "Application startup complete"
-docker compose run --rm peerdb-init bash /setup.sh
+docker compose run --rm peerdb-init
 ```
-Verify at [http://localhost:3001](http://localhost:3001) — mirrors should show `running`.
+Verify at [http://localhost:3001](http://localhost:3001), where mirrors should show `running`.
 
 ---
 
 **Analytics data is stale**
 PeerDB replication has fallen behind. Check mirror lag in the PeerDB UI. Re-run init if a mirror shows an error:
 ```bash
-docker compose run --rm peerdb-init bash /setup.sh
+docker compose run --rm peerdb-init
 ```
 
 ---
@@ -118,10 +118,10 @@ docker compose exec backend python manage.py migrate
 If a conflict persists, check the release notes for manual steps.
 
 **Everything worked before the upgrade, now it doesn't**
+Roll back by pinning the image versions in `.env` to the previous release tag, then bringing the stack up again. Nothing is built locally, so a `git checkout` on its own changes no running code. The full procedure is in [Upgrades & rollback](/docs/self-hosting/production/upgrades-rollback).
 ```bash
-git log --oneline -5
-git checkout <previous-hash>
-docker compose build && docker compose up -d
+FUTURE_AGI_VERSION=v1.25.0    # and the other four version variables
+docker compose up -d
 ```
 
 ---
@@ -134,13 +134,13 @@ docker compose logs > all-logs.txt 2>&1
 docker compose ps >> all-logs.txt
 ```
 
-## Next Steps
+## Dive deeper
 
 <CardGroup cols={2}>
   <Card title="Requirements" icon="server" href="/docs/self-hosting/requirements">
-    Verify your platform and resources meet the minimums.
+    Verify your platform and resources meet the minimums
   </Card>
   <Card title="Production" icon="shield" href="/docs/self-hosting/production">
-    Hardening, backups, and monitoring once the stack is stable.
+    Hardening, backups, and monitoring once the stack is stable
   </Card>
 </CardGroup>


### PR DESCRIPTION
**Ticket:** [TH-7471](https://linear.app/future-agi/issue/TH-7471/docs-self-hosting-add-profiles-and-launch-mode-reference-pages-under) — Closes TH-7471

## What was missing

Two self-hosting topics had no documentation at all.

**Compose profiles.** `COMPOSE_PROFILES` appeared exactly once across all 698 pages, as a half-sentence on the requirements page. A self-hoster had no way to find out what the light-vs-`full` choice costs them, or that `full` isn't everything.

**The OSS first-run wizard.** Shipped in TH-7217 / future-agi/future-agi#1919 and entirely undocumented. It's the first screen anyone sees after `./bin/install`.

## What changes have been done

- `src/pages/docs/self-hosting/configuration/profiles.mdx` — new. The three profiles, what each adds, how to set one, and four ways they catch people out
- `src/pages/docs/self-hosting/configuration/launch-mode.mdx` — new. The two launch modes, the twelve pre-flight checks with per-mode behaviour, the five status labels, and when Continue is blocked
- `src/lib/navigation.ts` — both pages added under Configuration
- `src/pages/docs/self-hosting/installation.mdx` — container counts corrected to 13 and 23; inline pointer to the wizard in the "Open the app" step; System configuration card repointed off the stale `configuration.mdx` duplicate
- `src/pages/docs/self-hosting/configuration/system.mdx` and `environment.mdx` — Dive deeper cards now route to the new siblings

## Why the changes

Everything factual was resolved against `origin/main` of the monorepo using `docker compose config`, not by reading YAML, so services inheriting a profile through a merge key are counted correctly. That turned up several things the existing docs and my own first draft got wrong:

- **There is no `peerdb` profile.** Only three exist. `COMPOSE_PROFILES=peerdb` matches nothing, silently leaves you on the default 13, and Compose exits 0 with no stderr
- **`full` is not everything.** It tags only the 10 PeerDB services, giving 23. It does not enable `workers` or `observability`
- **The dev overlay resets every profile** (`!reset` on all 18 tagged services), so you get all 33 unconditionally and `COMPOSE_PROFILES` is inert
- **`TEMPORAL_ALL_QUEUES=false` does not stand the all-queue worker down.** The service sets no `TEMPORAL_TASK_QUEUE`, so it falls back to polling `default` and overlaps `worker-default`
- **Launch mode and profiles cannot interact.** All 12 probed services are in the always-on 13, so a light install and a `full` one produce identical check results
- **`backend` and `frontend` are never probed.** Both are `"probe": lambda: True` and always read Ready
- `installation.mdx` said "around 12" and "around 22" containers, inherited from a stale `bin/install` comment

## Test cases — what each scenario covers

| # | Scenario | Expected |
|---|----------|----------|
| 1 | `node scripts/audit-links.mjs` | 0 broken nav links, 0 broken content links |
| 2 | Both new pages load | 200, Mermaid renders, tables complete |
| 3 | Sidebar under Configuration | System configuration, Environment variables, Profiles, Launch mode |
| 4 | Every Dive deeper card on the four Configuration pages | 3 cards at `cols={3}`, all links 200, all icons exist in `Card.astro` |
| 5 | `COMPOSE_PROFILES` counts on `origin/main` | 13 / 19 / 15 / 23 / 21 / 31, matching the page |
| 6 | Pre-flight matrix vs `setup_checks.py` | All 12 rows' per-mode behaviour match |

## Commands

```bash
# Link audit, the CI gate for this repo
node scripts/audit-links.mjs

# Reproduce the verified service counts against what users clone
git show origin/main:docker-compose.yml > /tmp/dc/docker-compose.yml
cd /tmp/dc && COMPOSE_PROFILES=full docker compose config --services | wc -l   # 23
```

## Known limitation, please read before merging

`launch-mode.mdx` uses the copy from **future-agi/future-agi#2023**, which is open and unmerged: Production / Test flight, and Ready / Caution / Failed / Optional. `origin/main` still ships "Live implementation" / "Just experimenting" and "Validated / Warning".

The twelve-check table is correct either way, because `setup_checks.py` is byte-identical on `main` and that branch. But the **"When Continue is blocked"** section describes #2023 behaviour only. On main today nothing gates Continue at all, so that section is wrong until #2023 lands.

**Merge this after future-agi/future-agi#2023.**

## Follow-ups deliberately not in this PR

- No screenshots on either page. `launch-mode.mdx` describes a UI screen end to end and should get annotated captures once the tooling is to hand
- `self-hosting/configuration.mdx` is a stale near-duplicate of `configuration/system.mdx`, unreachable from the sidebar, still using the banned `## About` heading
- `system.mdx:121` and `configuration.mdx:115` both claim the six per-queue workers are dev-overlay only. They're also available via `COMPOSE_PROFILES=workers`

## Videos and screenshots

![pr-profiles](https://github.com/user-attachments/assets/53644230-955f-4812-a270-c774d950d162)

![pr-launch-mode](https://github.com/user-attachments/assets/1595fc5c-4ad4-4f6a-b232-c3af9af7fb4f)
