### PR TITLE
docs(self-hosting): correct build, secrets, and rollback claims across the section [TH-7471]

### DIFF
--- a/src/pages/docs/self-hosting.mdx
+++ b/src/pages/docs/self-hosting.mdx
@@ -3,7 +3,7 @@ title: "Self-hosting Future AGI"
 description: "Run the entire Future AGI platform on your own infrastructure with Docker Compose. Your traces, datasets, evaluations, and model calls stay inside your network"
 ---
 
-Future AGI is fully open-source. Self-hosting runs the **entire stack on your own machines**, so all traces, datasets, evaluations, and model calls stay within your network. The backend is Django, the frontend is React + Vite, and the LLM gateway is Go, all deployed together with Docker Compose
+Future AGI is fully open-source. Self-hosting runs the **entire stack on your own machines**, so all traces, datasets, evaluations, and model calls stay within your network. The backend is Django, the frontend is React + Vite, and the LLM gateway is Go, all deployed together with Docker Compose.
 
 ## When to self-host
 
@@ -16,46 +16,42 @@ The [**cloud hosted version**](https://app.futureagi.com) is the easiest way to 
 
 ## What you deploy
 
-Self-hosting brings up the full platform (around **21 containers, with no external dependencies**) across four layers:
+A default install brings up **13 services**, and that is already a complete instance: you can sign in, send traces, and run evaluations with nothing else enabled. The stack defines 31 services in total, and [profiles](/docs/self-hosting/configuration/profiles) decide which of them you get.
 
 ```
 Browser
   └─ frontend (React/nginx)
-       └─ backend (Django) ──── gateway (Go) ──── OpenAI · Anthropic · Gemini · Bedrock
+       └─ backend (Django) ──── agentcc-gateway (Go) ──── OpenAI · Anthropic · Gemini · Bedrock
             ├── postgres      primary database
-            ├── clickhouse    analytics store
+            ├── clickhouse    trace and analytics store
             ├── redis         cache / pub-sub
+            ├── rabbitmq      task broker
             ├── minio         object storage
             └── temporal ──── worker   background jobs / eval pipelines
 
-postgres ──── PeerDB CDC ──── clickhouse   (continuous replication)
+your agent ──OTLP──> fi-collector ──> clickhouse    spans, written directly
+postgres ──── PeerDB CDC ──────────> clickhouse    mirrored tables, `full` profile only
 ```
 
-- **Application**: `frontend`, `backend`, `worker`, `gateway`, `serving`, `code-executor`
-- **Data**: `postgres`, `clickhouse`, `redis`, `minio`
+Those 13 break down as:
+
+- **Application**: `frontend`, `backend`, `worker`, `agentcc-gateway`, `serving`, `code-executor`
+- **Data**: `postgres`, `clickhouse`, `redis`, `rabbitmq`, `minio`
+- **Ingest**: `fi-collector`, the OTLP receiver that writes spans straight to ClickHouse
 - **Workflow**: `temporal`
-- **CDC**: PeerDB (continuous Postgres → ClickHouse replication)
 
-Everything runs on your machines; nothing leaves your network. The full service-by-service breakdown lives in [Configure](/docs/self-hosting/configuration).
-
-## Deployment options
-
-| Option | Status |
-|---|---|
-| Docker Compose | Available |
-| Helm / Kubernetes | Coming soon |
-| Air-gapped | Coming soon |
+The ten PeerDB replication services sit outside that set and stay off until you ask for them. Everything runs on your machines, and nothing leaves your network apart from the model calls you configure the gateway to make. The service-by-service breakdown lives in [Profiles](/docs/self-hosting/configuration/profiles).
 
 ## Where to go next
 
 <CardGroup cols={3}>
-  <Card title="Configure" icon="gear" href="/docs/self-hosting/configuration">
-    System requirements, prerequisites, environment variables, and setup
+  <Card title="Requirements" icon="server" href="/docs/self-hosting/requirements">
+    Size the host and check your platform before you install
   </Card>
-  <Card title="Troubleshooting & FAQs" icon="wrench" href="/docs/self-hosting/troubleshooting">
-    Fixes for common errors and answers to frequent questions
+  <Card title="Installation" icon="play-circle" href="/docs/self-hosting/installation">
+    Clone the repo and bring the stack up with `./bin/install`
   </Card>
-  <Card title="Support" icon="comments" href="/docs/self-hosting/support">
-    Get help from the Future AGI team and community
+  <Card title="System configuration" icon="gear" href="/docs/self-hosting/configuration/system">
+    Point the LLM gateway at your providers and tune the workers
   </Card>
 </CardGroup>

--- a/src/pages/docs/self-hosting/configuration/environment.mdx
+++ b/src/pages/docs/self-hosting/configuration/environment.mdx
@@ -5,7 +5,7 @@ description: "Complete .env reference for a self-hosted Future AGI instance"
 
 ## In this page
 
-Every setting the stack reads at boot comes from a single `.env` file in the repo root. This page is the complete reference, grouped by what each variable does. The stack boots fine with the shipped defaults. The only thing you *must* change before sharing the instance is the `CHANGEME` secrets.
+Every setting the stack reads at boot comes from a single `.env` file in the repo root. This page is the complete reference, grouped by what each variable does. The stack boots fine with the shipped defaults. The one thing you *must* change before sharing the instance is the secrets, which ship with working development values rather than blanks.
 
 ```bash
 cp .env.example .env
@@ -17,7 +17,7 @@ Doing a local trial? Skip to [Installation](/docs/self-hosting/installation). Th
 
 ## Required Secrets
 
-Replace every `CHANGEME` in this group before anyone else can reach the instance. Generate each value with the command shown.
+Every value in this group has a development default that works out of the box, so nothing warns you when you leave it in place. Replace all four before anyone else can reach the instance, generating each with the command shown.
 
 | Variable | Generate with | Used by |
 |---|---|---|
@@ -35,10 +35,10 @@ Replace every `CHANGEME` in this group before anyone else can reach the instance
 | Variable | Default | Notes |
 |---|---|---|
 | `PG_USER` | `futureagi` | PostgreSQL username |
-| `PG_PASSWORD` | `CHANGEME` | **Must change** |
+| `PG_PASSWORD` | `futureagi` | **Must change** |
 | `PG_DB` | `futureagi` | PostgreSQL database name |
 | `MINIO_ROOT_USER` | `futureagi` | MinIO username |
-| `MINIO_ROOT_PASSWORD` | `CHANGEME` | **Must change** |
+| `MINIO_ROOT_PASSWORD` | `futureagi` | **Must change** |
 | `CH_USE_REPLICATED_ENGINES` | `false` | `true` only for multi-node ClickHouse |
 
 ## Ports
@@ -71,7 +71,7 @@ Tuning guidance lives in [System configuration](/docs/self-hosting/configuration
 
 | Variable | Default | Description |
 |---|---|---|
-| `AGENTCC_INTERNAL_API_KEY` | `CHANGEME` | **Must change.** The backend authenticates gateway calls with this shared secret |
+| `AGENTCC_INTERNAL_API_KEY` | `local-dev-only-shared-secret-replace-me` | **Must change.** The backend authenticates gateway calls with this shared secret |
 
 Setting a key here is only half the job. The gateway also needs a `config.yaml` listing the providers it may route to. See [System configuration](/docs/self-hosting/configuration/system#llm-gateway).
 
@@ -100,7 +100,7 @@ Email delivery powers self-service sign-up and password reset. Without it, you c
 ## Frontend Build-Time
 
 <Warning>
-These are baked into the JavaScript bundle at Vite build time. Changing them requires a rebuild: `docker compose build frontend`.
+`VITE_HOST_API` is the exception: the frontend container writes it into `config.js` on start, so changing it needs a restart (`docker compose up -d frontend`), not a rebuild. The rest really are baked into the JavaScript bundle at Vite build time, and the published images are prebuilt, so changing one means building your own frontend image.
 </Warning>
 
 | Variable | Default | Description |
@@ -127,7 +127,7 @@ These are baked into the JavaScript bundle at Vite build time. Changing them req
   <Card title="Profiles" icon="layer-group" href="/docs/self-hosting/configuration/profiles">
     What `COMPOSE_PROFILES` does to the set of services you run
   </Card>
-  <Card title="Launch mode" icon="rocket" href="/docs/self-hosting/configuration/launch-mode">
-    How strictly a fresh install enforces its pre-flight checks
+  <Card title="Production checklist" icon="shield" href="/docs/self-hosting/production/checklist">
+    Replace the shipped secret defaults before the instance carries real traffic
   </Card>
 </CardGroup>

--- a/src/pages/docs/self-hosting/configuration/launch-mode.mdx
+++ b/src/pages/docs/self-hosting/configuration/launch-mode.mdx
@@ -5,7 +5,7 @@ description: "What the setup wizard checks, and how the two modes differ"
 
 ## In this page
 
-The first screen a fresh self-hosted install shows at `/setup` asks how you plan to run the instance. That answer is the **launch mode**, and it decides how strictly the pre-flight checks on the next screen are enforced. It changes how a result is reported, never which services run.
+The first screen a fresh [self-hosted install](/docs/self-hosting/installation) shows at `/setup` asks how you plan to run the instance. That answer is the **launch mode**, and it decides how strictly the pre-flight checks on the next screen are enforced. It changes how a result is reported, never which services run.
 
 <TLDR>
 Production requires every core system and holds you on the setup screen while one is down. Test flight eases the non-critical ones so a partial stack still gets you through. Both run the same twelve checks against the same services.
@@ -22,7 +22,7 @@ flowchart TD
 
 ## The two modes
 
-You pick one on the first setup screen, and Production is selected by default. The choice is not written to `.env` and nothing reads it later, so it only affects this one run through the wizard.
+You pick one on the first setup screen, and Production is selected by default. The choice is not written to [`.env`](/docs/self-hosting/configuration/environment) and nothing reads it later, so it only affects this one run through the wizard.
 
 ### Production
 
@@ -34,20 +34,20 @@ For trying Future AGI out locally. The same twelve checks still run and you stil
 
 ## The pre-flight checklist
 
-Twelve rows appear on screen. Ten of them probe a service, each with a three-second timeout, in the order below. The two mode columns show what a *down* service reads as.
+Twelve rows appear on screen. Ten of them probe a service, each with a three-second timeout, in the order below. The two mode columns show what a *down* service reads as, and the container column is what to restart when one fails.
 
-| Check | If it's down | Production | Test flight |
-|---|---|---|---|
-| Core application database | Nothing loads at all | Failed | Failed |
-| Tracing data warehouse | Traces, spans and dashboards won't load | Failed | Failed |
-| Cache and session store | Sign-ins, caching and rate limits break | Failed | Caution |
-| Websocket connection | Live updates won't reach the browser | Failed | Caution |
-| Object storage service | Dataset uploads, exports and media fail | Failed | Caution |
-| LLM request gateway | Every model call fails | Failed | Failed |
-| Async task engine | Evaluations and scheduled jobs won't run | Failed | Failed |
-| Trace ingestion | Spans sent by the SDK won't arrive | Failed | Failed |
-| Agent fixer (evals + Error Feed) | Built-in evaluations and guardrails won't run | Caution | Optional |
-| Code execution sandbox | Custom code evaluations won't run | Caution | Optional |
+| Check | Container | What breaks | Production | Test flight |
+|---|---|---|---|---|
+| Core application database | `postgres` | Nothing loads at all | Failed | Failed |
+| Tracing data warehouse | `clickhouse` | Traces, spans and dashboards won't load | Failed | Failed |
+| Cache and session store | `redis` | Sign-ins, caching and rate limits break | Failed | Caution |
+| Websocket connection | `rabbitmq` | Live updates won't reach the browser | Failed | Caution |
+| Object storage service | `minio` | Dataset uploads, exports and media fail | Failed | Caution |
+| LLM request gateway | `agentcc-gateway` | Every model call fails | Failed | Failed |
+| Async task engine | `temporal` | Evaluations and scheduled jobs won't run | Failed | Failed |
+| Trace ingestion | `fi-collector` | Spans sent by the SDK won't arrive | Failed | Failed |
+| Agent fixer (evals + Error Feed) | `serving` | Built-in evaluations and guardrails won't run | Caution | Optional |
+| Code execution sandbox | `code-executor` | Custom code evaluations won't run | Caution | Optional |
 
 The remaining two rows, **Django backend** and **React frontend**, sit between Trace ingestion and Agent fixer on screen. Neither is probed: both are inferred from the page having loaded at all, so they always read Ready.
 
@@ -77,9 +77,7 @@ Test flight never blocks on results. If a check fails after you've fixed somethi
 
 ## Launch mode is not a profile
 
-This is not the same as picking a profile. [Profiles](/docs/self-hosting/configuration/profiles) decide which containers run on your host, and you set them in `.env` before the stack starts. Launch mode is a one-off choice in the browser that changes nothing about your deployment, only how the checks report.
-
-The two can't affect each other. Every service the checks probe is one that always runs, so a light install and a `full` one produce identical results. You can't fail pre-flight by running the smaller stack.
+Every container the checks probe is one of the always-on 13, so a light install and a `full` one produce identical results. You can't fail pre-flight by running the smaller stack. [Profiles](/docs/self-hosting/configuration/profiles) decide which containers run at all and are set in `.env` before the stack starts. Launch mode is a one-off choice in the browser that changes nothing about your deployment.
 
 ## Dive deeper
 
@@ -87,10 +85,10 @@ The two can't affect each other. Every service the checks probe is one that alwa
   <Card title="System configuration" icon="gear" href="/docs/self-hosting/configuration/system">
     Point the LLM gateway at your providers and set up PeerDB mirrors
   </Card>
-  <Card title="Environment variables" icon="list-check" href="/docs/self-hosting/configuration/environment">
-    Set provider keys, secrets, and runtime flags in `.env`
+  <Card title="Production checklist" icon="shield" href="/docs/self-hosting/production/checklist">
+    Harden the instance before it carries real traffic
   </Card>
-  <Card title="Profiles" icon="layer-group" href="/docs/self-hosting/configuration/profiles">
-    Pick which of the 31 services your instance runs
+  <Card title="Troubleshooting & FAQs" icon="wrench" href="/docs/self-hosting/troubleshooting">
+    What to do when a check keeps coming back Failed
   </Card>
 </CardGroup>

--- a/src/pages/docs/self-hosting/configuration/profiles.mdx
+++ b/src/pages/docs/self-hosting/configuration/profiles.mdx
@@ -5,7 +5,7 @@ description: "Choosing which of the 31 services your self-hosted instance actual
 
 ## In this page
 
-The self-hosted stack defines 31 services, but a working instance only needs 13 of them. The rest are opt-in: extra Temporal workers, a workflow dashboard, and the replication pipeline that feeds analytics. A **profile** is the tag that decides which group you get, set once in `.env` and read by every `docker compose` command after that.
+The self-hosted stack defines 31 services, but a working instance only needs 13 of them. The rest are opt-in: extra Temporal workers, a workflow dashboard, and the replication pipeline that feeds analytics. A **profile** is the tag that decides which group you get, set once in the [`.env` file](/docs/self-hosting/configuration/environment) and read by every `docker compose` command after that.
 
 <TLDR>
 An empty `.env` gives you 13 services, which is a complete, usable instance. Three profiles add to that: `workers`, `observability`, and `full`. Name them in `COMPOSE_PROFILES` and their additions stack.
@@ -21,9 +21,18 @@ flowchart TD
     C -->|"full"| F["Ten PeerDB services"]
 `} />
 
+## The core stack
+
+Thirteen services carry no profile, so they always run:
+
+- **Application:** `frontend`, `backend`, `worker`, `agentcc-gateway`, `serving`, `code-executor`
+- **Data layer:** `postgres`, `clickhouse`, `redis`, `rabbitmq`, `minio`, `temporal`, `fi-collector`
+
+This is a complete instance. You can sign in, send traces, and run evaluations with nothing else enabled.
+
 ## The profiles
 
-Leave `COMPOSE_PROFILES` unset and you get the core 13 services. Three profiles exist to add to that, each one independent.
+Leave `COMPOSE_PROFILES` unset and you get those 13. Three profiles exist to add to them, each one independent.
 
 | Profile | What it adds | Total services |
 |---|---|---|
@@ -32,10 +41,6 @@ Leave `COMPOSE_PROFILES` unset and you get the core 13 services. Three profiles 
 | `full` | The ten-service PeerDB replication stack | 23 |
 
 Combine them with commas, and the additions stack: `COMPOSE_PROFILES=workers,observability` runs 21 services, and naming all three runs all 31.
-
-### The core stack
-
-Thirteen services carry no profile, so they always run: `frontend`, `backend`, `worker`, `agentcc-gateway`, `serving`, `code-executor`, and the data layer of `postgres`, `clickhouse`, `redis`, `rabbitmq`, `minio`, `temporal`, and `fi-collector`. This is a complete instance. You can sign in, send traces, and run evaluations with nothing else enabled.
 
 ### workers
 
@@ -47,7 +52,9 @@ Adds `temporal-ui` on port 8085 and `temporal-admin-tools`, a shell with the `tc
 
 ### full
 
-Adds the ten PeerDB services that replicate Postgres tables into ClickHouse through change data capture, including datasets, prompts, simulation runs, and trace metadata. It's the heaviest option, roughly doubling your container count, and `./bin/install --full` is the shortcut for turning it on.
+Adds the ten PeerDB services that replicate Postgres tables into ClickHouse through change data capture, covering datasets, prompts, simulation runs, and trace metadata. It's the heaviest option, roughly doubling your container count, and `./bin/install --full` is the shortcut for turning it on during [installation](/docs/self-hosting/installation).
+
+Stay light and those ClickHouse copies never get written, so the dataset and simulation-run dashboards built on them have nothing to read. Tracing is unaffected either way: `fi-collector` writes spans straight to ClickHouse, and it's one of the always-on 13.
 
 ## Setting a profile
 
@@ -79,17 +86,15 @@ docker compose --profile workers --profile observability up -d
 
 ## Where profiles catch people out
 
-<Warning>
 **`full` does not mean everything.** It adds only the PeerDB stack, taking you to 23 services. It does not enable `workers` or `observability`. For all 31, list every profile: `COMPOSE_PROFILES=workers,observability,full`.
-</Warning>
 
 **There is no `peerdb` profile.** The PeerDB services are tagged `full`, so `COMPOSE_PROFILES=peerdb` matches nothing and silently leaves you on the default 13. Compose reports no error for an unknown profile name.
 
 **The all-queue `worker` always runs.** It carries no profile and polls every queue via `TEMPORAL_ALL_QUEUES`, which defaults to true. Enabling `workers` does not replace it, so the six dedicated workers run *alongside* it. Setting `TEMPORAL_ALL_QUEUES=false` doesn't take it out of the picture either: the service sets no `TEMPORAL_TASK_QUEUE`, so it falls back to polling `default` on its own, overlapping `worker-default` instead of every queue.
 
-**A profile is not a launch mode.** The choice the first-run screen asks you to make is a [launch mode](/docs/self-hosting/configuration/launch-mode), and it can't change which services run.
-
 **The dev overlay ignores profiles completely.** `docker-compose.dev.yml` resets the profile tag on all 18 tagged services, so `docker compose -f docker-compose.yml -f docker-compose.dev.yml up` starts all 33 services unconditionally, including `pgbouncer` and `docker-proxy`. `COMPOSE_PROFILES` has no effect in this mode.
+
+**A profile is not a launch mode.** The choice the first-run screen asks you to make is a [launch mode](/docs/self-hosting/configuration/launch-mode), and it can't change which services run.
 
 ## Checking what will run
 
@@ -105,13 +110,13 @@ Counting the second command's output is the quickest way to confirm you're getti
 ## Dive deeper
 
 <CardGroup cols={3}>
+  <Card title="Launch mode" icon="rocket" href="/docs/self-hosting/configuration/launch-mode">
+    The checks a fresh install runs before it lets you in
+  </Card>
   <Card title="System configuration" icon="gear" href="/docs/self-hosting/configuration/system">
     Tune worker concurrency and set up PeerDB replication
   </Card>
-  <Card title="Environment variables" icon="list-check" href="/docs/self-hosting/configuration/environment">
-    The full `.env` reference, including where `COMPOSE_PROFILES` sits
-  </Card>
-  <Card title="Launch mode" icon="rocket" href="/docs/self-hosting/configuration/launch-mode">
-    The pre-flight checks a fresh install runs before sign-in
+  <Card title="Troubleshooting & FAQs" icon="wrench" href="/docs/self-hosting/troubleshooting">
+    Fixes for gateway, PeerDB, and Temporal errors
   </Card>
 </CardGroup>

--- a/src/pages/docs/self-hosting/configuration/system.mdx
+++ b/src/pages/docs/self-hosting/configuration/system.mdx
@@ -106,7 +106,7 @@ PeerDB continuously replicates Postgres tables into ClickHouse (change-data-capt
 
 ```bash
 docker compose logs -f backend                       # wait for "Application startup complete"
-docker compose run --rm peerdb-init bash /setup.sh   # re-run init
+docker compose run --rm peerdb-init                  # re-run init
 ```
 </Warning>
 
@@ -118,7 +118,7 @@ Temporal runs the platform's background jobs and evaluation pipelines. How those
 
 **All-queue (default).** One worker polls every task queue. Controlled by `TEMPORAL_ALL_QUEUES=true` in `.env`. This is the right setup for most self-hosted deployments.
 
-**Per-queue (dev overlay).** Six dedicated workers, one per queue, brought up by the [dev overlay](/docs/self-hosting/installation#other-ways-to-run-it):
+**Per-queue.** Six dedicated workers, one per queue, brought up by the `workers` [profile](/docs/self-hosting/configuration/profiles) or by the [dev overlay](/docs/self-hosting/installation#other-ways-to-run-it):
 
 | Service | Queue | Typical concurrency |
 |---|---|---|
@@ -129,18 +129,18 @@ Temporal runs the platform's background jobs and evaluation pipelines. How those
 | `worker-trace-ingestion` | `trace_ingestion` | 100 |
 | `worker-agent-compass` | `agent_compass` | 50 |
 
-Tune throughput with `TEMPORAL_MAX_CONCURRENT_ACTIVITIES` and `TEMPORAL_MAX_CONCURRENT_WORKFLOW_TASKS` in `.env`. The Temporal UI is available in dev mode at [http://localhost:8085](http://localhost:8085).
+Tune throughput with `TEMPORAL_MAX_CONCURRENT_ACTIVITIES` and `TEMPORAL_MAX_CONCURRENT_WORKFLOW_TASKS` in `.env`. The Temporal UI runs at [http://localhost:8085](http://localhost:8085) under the `observability` profile, and in dev mode.
 
 ## Dive Deeper
 
 <CardGroup cols={3}>
-  <Card title="Environment variables" icon="list-check" href="/docs/self-hosting/configuration/environment">
-    Set provider keys, secrets, and runtime flags in `.env`
-  </Card>
   <Card title="Profiles" icon="layer-group" href="/docs/self-hosting/configuration/profiles">
     PeerDB and the per-queue workers only run under the right profile
   </Card>
   <Card title="Launch mode" icon="rocket" href="/docs/self-hosting/configuration/launch-mode">
-    The pre-flight checks a fresh install runs before sign-in
+    The checks a fresh install runs before it lets you in
+  </Card>
+  <Card title="Production checklist" icon="shield" href="/docs/self-hosting/production/checklist">
+    Harden the instance before it carries real traffic
   </Card>
 </CardGroup>

--- a/src/pages/docs/self-hosting/installation.mdx
+++ b/src/pages/docs/self-hosting/installation.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Installation"
-description: "Install a self-hosted Future AGI instance with Docker Compose."
+description: "Install a self-hosted Future AGI instance with Docker Compose"
 ---
 
 Docker Compose is the supported way to run a self-hosted Future AGI instance.
@@ -14,7 +14,7 @@ Confirm your host meets the [requirements](/docs/self-hosting/requirements) firs
 - Waits for the backend health check
 - Prompts you to create the first user
 
-First boot pulls the app images from Docker Hub and builds the small fi-collector image from source, so give it a few minutes the first time.
+First boot pulls every image from Docker Hub, nothing is built locally, so give it a few minutes the first time.
 
 <TLDR>
 Run `git clone https://github.com/future-agi/future-agi.git && cd future-agi && ./bin/install`, then open [http://localhost:3000](http://localhost:3000).
@@ -70,7 +70,7 @@ On a fresh install the app opens a short setup wizard before the sign-in screen,
 | `--new-instance` | Start a fresh instance when existing volumes are detected |
 
 <Note>
-**Apple Silicon and arm64 hosts.** Prebuilt images are `linux/amd64`. On M-series Macs they run under Rosetta 2 (auto-enabled on Docker Desktop 4.16+), which is fine for evaluation with a 20 to 50 percent performance cost. For native arm64, build locally with `docker compose build` instead of pulling. On Linux arm64 such as Graviton, install `qemu-user-static`.
+**Apple Silicon and arm64 hosts.** Five of the six first-party images ship `linux/arm64` alongside `linux/amd64`, so they run native. The exception is `futureagi/future-agi`, which is amd64 only and backs both `backend` and `worker`. On M-series Macs those two run under Rosetta 2 (auto-enabled on Docker Desktop 4.16+), which is fine for evaluation at a 20 to 50 percent performance cost on those containers. On Linux arm64 such as Graviton, install `qemu-user-static` so they can start at all.
 </Note>
 
 ## Install without the script
@@ -86,7 +86,7 @@ Then create the first user with the same `create_user` command shown above.
 
 ## Verify the stack
 
-Check that every service is healthy before you log in. Under-provisioned RAM is the most common reason the backend never finishes booting, so confirm the [requirements](/docs/self-hosting/requirements) if it stalls.
+Check that every service is healthy before you log in. Under-provisioned RAM is the most common reason the backend never finishes booting, so confirm the [requirements](/docs/self-hosting/requirements) if it stalls, and see [Troubleshooting](/docs/self-hosting/troubleshooting) for anything else that comes up red.
 
 ```bash
 docker compose ps                 # every service should read "running" or "healthy"
@@ -114,7 +114,8 @@ docker compose exec postgres psql -U futureagi -d futureagi
 # Wipe all data and start clean
 ./bin/uninstall --wipe-data    # or: docker compose down -v
 
-# Remove everything: containers, volumes, .env, and built images
+# Also remove .env, logs, and any locally built images
+# (pulled images stay; remove those with docker rmi)
 ./bin/uninstall --purge
 ```
 

--- a/src/pages/docs/self-hosting/production.mdx
+++ b/src/pages/docs/self-hosting/production.mdx
@@ -3,11 +3,11 @@ title: "Production"
 description: "What to harden before a self-hosted Future AGI instance goes live"
 ---
 
-Everything past a local trial happens here. The default Docker Compose stack boots with placeholder secrets, no TLS, and compose-managed data stores. That's fine on a laptop. Before real traffic reaches the instance, work through the flow below in order, then keep each page as a runbook.
+Everything past a local trial happens here. The default Docker Compose stack boots with development secrets that work out of the box, no TLS, and compose-managed data stores. That's fine on a laptop. Before real traffic reaches the instance, work through the two go-live pages below, then keep the rest as runbooks.
 
 ## In this page
 
-Production readiness for a self-hosted instance breaks into five steps. Do them in order the first time.
+Production readiness for a self-hosted instance breaks into five pages. Do the first two in order before you go live, and keep the other three to hand once it is.
 
 **Before you go live**
 

--- a/src/pages/docs/self-hosting/production/backups-restore.mdx
+++ b/src/pages/docs/self-hosting/production/backups-restore.mdx
@@ -3,7 +3,26 @@ title: "Backups & restore"
 description: "Back up and restore the data stores behind a self-hosted instance"
 ---
 
-A self-hosted instance keeps state in a few stores: Postgres for application data, ClickHouse for the observability records (spans and traces), and MinIO for object storage. Redis is a cache (sessions, locks, rate limits, pub/sub), so it rebuilds on its own and doesn't need a backup. RabbitMQ holds the task queue: losing it drops in-flight background jobs, so drain it before planned downtime rather than backing it up.
+A self-hosted instance keeps state in a few stores: Postgres for application data, ClickHouse for the observability records (spans and traces), and MinIO for object storage. Those three are the ones to back up. Redis is a cache (sign-ins, locks, rate limits, pub/sub), so it rebuilds on its own. RabbitMQ holds the task queue: losing it drops in-flight background jobs, so drain it before planned downtime rather than backing it up.
+
+## The named volumes
+
+The compose project name is `futureagi`, so every volume is prefixed `futureagi_`:
+
+| Volume | Holds |
+|---|---|
+| `futureagi_postgres-data` | Postgres application data |
+| `futureagi_clickhouse-data` | ClickHouse spans and traces |
+| `futureagi_minio-data` | MinIO objects |
+| `futureagi_rabbitmq-data` | RabbitMQ task queue |
+| `futureagi_redis-data` | Redis cache (rebuildable) |
+| `futureagi_peerdb-catalog-data` | PeerDB replication catalog |
+| `futureagi_peerdb-minio-data` | PeerDB staging objects |
+| `futureagi_fi-collector-data` | Spans the collector couldn't write to ClickHouse |
+
+<Note>
+`futureagi_fi-collector-data` is a dead-letter queue, not a cache. It holds spans that failed to reach ClickHouse, usually while ClickHouse was briefly down, and they're replayed once it's back. Deleting the volume drops that telemetry for good, so don't prune it with the rebuildable ones.
+</Note>
 
 ## Postgres
 
@@ -20,19 +39,6 @@ docker compose exec -T postgres \
   pg_restore -U futureagi -d futureagi --clean --if-exists \
   < backup-2026-04-22.dump
 ```
-
-The named volumes that hold state. The compose project name is `futureagi`, so every volume is prefixed `futureagi_`:
-
-| Volume | Holds |
-|---|---|
-| `futureagi_postgres-data` | Postgres application data |
-| `futureagi_clickhouse-data` | ClickHouse spans and traces |
-| `futureagi_minio-data` | MinIO objects |
-| `futureagi_rabbitmq-data` | RabbitMQ task queue |
-| `futureagi_redis-data` | Redis cache (rebuildable) |
-| `futureagi_peerdb-catalog-data` | PeerDB replication catalog |
-| `futureagi_peerdb-minio-data` | PeerDB staging objects |
-| `futureagi_fi-collector-data` | fi-collector buffer |
 
 ## ClickHouse
 

--- a/src/pages/docs/self-hosting/production/checklist.mdx
+++ b/src/pages/docs/self-hosting/production/checklist.mdx
@@ -38,9 +38,11 @@ Set these runtime flags before going live:
 
 | Variable | Go-live value | Why |
 |---|---|---|
-| `ENV_TYPE` | `prod` | Disables debug output and runs Django `check --deploy` |
-| `FAST_STARTUP` | `false` | Always applies migrations on restart |
+| `ENV_TYPE` | `prod` | Defaults to `development`. Disables debug output and runs Django `check --deploy` |
 | `GRANIAN_WORKERS` | your CPU count | One worker per core, up from the default `1` |
+| `FAST_STARTUP` | leave unset | Already `false`. Setting it `true` skips migrations and DB checks at boot, which you never want here |
+
+`check --deploy` warns and continues rather than refusing to start, so a failing deployment check won't stop the container. Read the backend logs on your first `prod` boot instead of assuming a clean start means a clean report.
 
 ## Move to managed data stores
 

--- a/src/pages/docs/self-hosting/production/monitoring.mdx
+++ b/src/pages/docs/self-hosting/production/monitoring.mdx
@@ -3,11 +3,11 @@ title: "Monitoring"
 description: "Watch a self-hosted instance with the health signals it actually exposes"
 ---
 
-The stack has no Prometheus `/metrics` endpoint yet (the fi-collector lists a metrics exporter as a TODO), so monitoring today is built from what the containers already expose: their Docker health checks, the fi-collector's admin health endpoint, and the PeerDB console. This page covers those and the signals worth watching.
+The stack has no Prometheus `/metrics` endpoint yet (the fi-collector lists a metrics exporter as a TODO), so monitoring today is built from what the containers already expose: their Docker health checks, the backend and collector health endpoints, and the PeerDB console. This page covers those and the signals worth watching.
 
 ## Container health
 
-The data stores (Postgres, ClickHouse, Redis, RabbitMQ, MinIO, Temporal) ship Docker health checks; the application services just show `running`. Either way, `docker compose ps` is the fastest read on what's up:
+The data stores (Postgres, ClickHouse, Redis, RabbitMQ, MinIO, Temporal) ship Docker health checks. The application services declare none, so they only ever read `running`, which is why the two endpoints below matter. Either way, `docker compose ps` is the fastest read on what's up:
 
 ```bash
 docker compose ps        # STATUS shows healthy / unhealthy per service
@@ -16,13 +16,23 @@ docker stats             # live CPU and memory per container
 
 Watch memory on `clickhouse` and the Temporal `worker` first. They're the resource drivers, and an OOM there is the most common cause of a stall.
 
+## Backend health
+
+The backend serves an unauthenticated health check at `/health/`. It's the same endpoint `./bin/install` polls while it waits for the stack, so it's the one signal that tells you the application layer is actually serving rather than merely running:
+
+```bash
+curl -sf http://localhost:8000/health/
+```
+
 ## fi-collector health
 
-The fi-collector exposes an admin endpoint on `127.0.0.1:9464` (`FI_COLLECTOR_ADMIN_PORT`), which serves a health check. Hit it to confirm the collector is up:
+The fi-collector exposes an admin endpoint on `127.0.0.1:9464` (`FI_COLLECTOR_ADMIN_PORT`):
 
 ```bash
 curl -s http://localhost:9464/healthz
 ```
+
+This one is worth alerting on rather than just checking. It returns 200 unless the collector's dead-letter rate crosses its threshold, so a non-200 means spans are failing to reach ClickHouse and piling up in [`futureagi_fi-collector-data`](/docs/self-hosting/production/backups-restore) instead of being queryable.
 
 ## PeerDB replication
 

--- a/src/pages/docs/self-hosting/production/security-tls.mdx
+++ b/src/pages/docs/self-hosting/production/security-tls.mdx
@@ -27,6 +27,14 @@ api.yourcompany.com  { reverse_proxy localhost:8000 }
     docker compose up -d frontend
     ```
   </Step>
+  <Step title="Close the plaintext ports">
+    The frontend and backend publish on every interface, so `:3000` and `:8000` stay reachable in plaintext once the proxy is live and anyone can bypass TLS by going straight to them. Firewall both at the host, or bind them to loopback so only the proxy can reach them:
+
+    ```bash
+    FRONTEND_PORT=127.0.0.1:3000
+    BACKEND_PORT=127.0.0.1:8000
+    ```
+  </Step>
 </Steps>
 
 <Warning>
@@ -53,7 +61,7 @@ Rotate the dev-only default secrets from the [Checklist](/docs/self-hosting/prod
   <Card title="Backups & restore" icon="database" href="/docs/self-hosting/production/backups-restore">
     Protect the data behind the proxy
   </Card>
-  <Card title="System configuration" icon="gear" href="/docs/self-hosting/configuration">
+  <Card title="System configuration" icon="gear" href="/docs/self-hosting/configuration/system">
     Tune the gateway, PeerDB, and Temporal workers
   </Card>
 </CardGroup>

--- a/src/pages/docs/self-hosting/production/upgrades-rollback.mdx
+++ b/src/pages/docs/self-hosting/production/upgrades-rollback.mdx
@@ -3,17 +3,19 @@ title: "Upgrades & rollback"
 description: "Pull a new release, run migrations, and roll back when one goes wrong"
 ---
 
-Upgrades are a git pull and a rebuild, and migrations run automatically on boot. This page covers the routine upgrade, the two cases that need a manual step, and how to roll back.
+Nothing in the stack is built locally: every service runs a published image, tagged by version variables in `.env`. So an upgrade is a pull of new images, and a rollback is pinning those variables back. Migrations run automatically on boot either way. This page covers the routine upgrade, the two cases that need a manual step, and how to roll back.
 
 ## Upgrade to a new release
 
 <Steps>
-  <Step title="Pull and rebuild">
+  <Step title="Pull the new images">
     ```bash
-    git pull
-    docker compose build
+    git pull              # picks up compose file changes
+    docker compose pull   # fetch the new images
     docker compose up -d
     ```
+
+    `docker compose up -d` won't fetch anything on its own when the tag is already present locally, which is why `pull` is its own step.
   </Step>
   <Step title="Let migrations run">
     Database migrations run automatically on backend startup. If one fails, run it by hand:
@@ -35,13 +37,22 @@ PeerDB init only rebuilds the tables it mirrors from Postgres. It does **not** r
 
 ## Roll back a bad release
 
-Roll back to the previous commit and rebuild:
+Rolling back is a version pin, not a `git checkout`. Set each image back to the previous release tag in `.env`, then bring the stack up again:
 
 ```bash
-git log --oneline -5
-git checkout <previous-hash>
-docker compose build && docker compose up -d
+# .env (release tags are vX.Y.Z, matching the repo's git tags)
+FUTURE_AGI_VERSION=v1.25.0
+FRONTEND_VERSION=v1.25.0
+AGENTCC_GATEWAY_VERSION=v1.25.0
+SERVING_VERSION=v1.25.0
+CODE_EXECUTOR_VERSION=v1.25.0
 ```
+
+```bash
+docker compose up -d
+```
+
+`FUTURE_AGI_VERSION` covers `backend`, `worker` and `fi-collector`, which all share one image. Leaving a variable empty means `:latest`, so for anything carrying real traffic, pin all five rather than floating.
 
 <Warning>
 Checking out older code does not undo a migration that already ran. If a release applied a migration you need to reverse, roll it back before you switch code, or restore Postgres from a backup.

--- a/src/pages/docs/self-hosting/requirements.mdx
+++ b/src/pages/docs/self-hosting/requirements.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Requirements"
-description: "System requirements and support for self-hosting Future AGI."
+description: "System requirements and support for self-hosting Future AGI"
 ---
 
 ## In this page
@@ -14,7 +14,7 @@ Check three things before you install:
 Get these right and the [Installation](/docs/self-hosting/installation) run works on the first try.
 
 <TLDR>
-For a local trial: **4 CPU cores, 8 GB RAM, 20 GB disk**, Docker Engine 24+, Docker Compose v2.20+, and Git.
+For a local trial: **4 CPU cores, 8 GB RAM, 20 GB disk**, Docker Engine 24+, Docker Compose v2.24+, and Git.
 </TLDR>
 
 ## Hardware tiers
@@ -30,7 +30,7 @@ Pick the row that matches how you'll use the instance. The stack runs on the Eva
 ClickHouse and the Temporal worker each hold ~1 GB RAM at steady state. ClickHouse grows with trace volume over time; Postgres stays small. Pulling the images takes a few GB of disk on the first run.
 
 <Tip>
-On Docker Desktop (Mac/Windows), raise the limits in **Settings → Resources**: RAM ≥ 8 GB, disk ≥ 64 GB. The defaults (2-4 GB RAM) will OOM-kill ClickHouse or the backend before the stack finishes booting.
+On Docker Desktop for Mac, raise the limits in **Settings → Resources**: RAM ≥ 8 GB, disk ≥ 64 GB. The defaults (2-4 GB RAM) will OOM-kill ClickHouse or the backend before the stack finishes booting. On Windows those sliders don't apply, so set the limit in `.wslconfig` as shown in the Windows tab below.
 </Tip>
 
 ## Software
@@ -38,8 +38,10 @@ On Docker Desktop (Mac/Windows), raise the limits in **Settings → Resources**:
 | Requirement | Minimum | Verify |
 |---|---|---|
 | Docker Engine | 24.0+ | `docker --version` |
-| Docker Compose | v2.20+ | `docker compose version` |
+| Docker Compose | v2.24+ | `docker compose version` |
 | Git | 2.0+ | `git --version` |
+
+Compose v2.24 is a hard floor, not a recommendation: `docker-compose.yml` declares its env files with the long `path` / `required` form, which older Compose can't parse. On v2.23 or below the stack fails at parse time, before a single image is pulled.
 
 <Tabs>
 <Tab title="macOS">
@@ -76,7 +78,7 @@ Future AGI runs on any host that allows **privileged containers**. The `code-exe
 | Platform | Supported | Notes |
 |---|---|---|
 | Linux bare metal / EC2 / GCE / Azure VM | Yes | Full support |
-| GKE / EKS with privileged enabled | Yes | Requires a PodSecurityPolicy exception |
+| GKE / EKS with privileged enabled | Yes | Needs a Pod Security Admission exception on the namespace |
 | ECS Fargate | No | `privileged: true` not supported |
 | Google Cloud Run | No | Same |
 | Render / Railway / Fly.io | No | Managed platforms block privileged mode |
@@ -94,6 +96,9 @@ Make sure these host ports are free before you install, or remap any that collid
 | Gateway | `8090` | `0.0.0.0` | `AGENTCC_GATEWAY_PORT` |
 | Model serving | `8080` | `0.0.0.0` | `SERVING_PORT` |
 | Code executor | `8060` | `0.0.0.0` | `CODE_EXECUTOR_PORT` |
+| Collector OTLP gRPC | `4317` | `127.0.0.1` | `FI_COLLECTOR_OTLP_PORT` |
+| Collector OTLP HTTP | `4318` | `127.0.0.1` | `FI_COLLECTOR_OTLP_HTTP_PORT` |
+| Collector admin | `9464` | `127.0.0.1` | `FI_COLLECTOR_ADMIN_PORT` |
 | Postgres | `5432` | `127.0.0.1` | `PG_PORT` |
 | ClickHouse HTTP | `8123` | `127.0.0.1` | `CH_HTTP_PORT` |
 | ClickHouse TCP | `9000` | `127.0.0.1` | `CH_PORT` |
@@ -101,16 +106,24 @@ Make sure these host ports are free before you install, or remap any that collid
 | MinIO API | `9005` | `127.0.0.1` | `MINIO_API_PORT` |
 | MinIO console | `9006` | `127.0.0.1` | `MINIO_CONSOLE_PORT` |
 | Temporal | `7233` | `127.0.0.1` | `TEMPORAL_PORT` |
+| Temporal UI | `8085` | `0.0.0.0` | `TEMPORAL_UI_PORT` |
 | PeerDB server | `9900` | `127.0.0.1` | `PEERDB_PORT` |
 | PeerDB UI | `3001` | `0.0.0.0` | `PEERDB_UI_PORT` |
 
-The data stores (Postgres, ClickHouse, Redis, MinIO, Temporal) bind to `127.0.0.1`; the application services bind to `0.0.0.0`. PeerDB server and UI only run when you enable the CDC stack with `COMPOSE_PROFILES=full`, so those two ports are only in use in that mode.
+Anything on `127.0.0.1` is reachable from the host but not from the network, which covers the data stores and the collector's three ports. The user-facing services bind to `0.0.0.0`.
+
+Watch `4317` in particular: it's the default OTLP port, so it collides with any other OpenTelemetry collector already on the host, and it's where the SDK sends your traces.
+
+Three of these rows are [profile](/docs/self-hosting/configuration/profiles)-gated and free otherwise: Temporal UI needs `observability`, and the two PeerDB ports need `full`.
 
 ## Dive deeper
 
-<CardGroup cols={2}>
+<CardGroup cols={3}>
   <Card title="Installation" icon="play-circle" href="/docs/self-hosting/installation">
     Clone the repo and bring the stack up with `./bin/install`
+  </Card>
+  <Card title="Profiles" icon="layer-group" href="/docs/self-hosting/configuration/profiles">
+    Decide how many of the 31 services you actually need
   </Card>
   <Card title="Environment variables" icon="list-check" href="/docs/self-hosting/configuration/environment">
     Set provider keys, secrets, and runtime flags in `.env`

--- a/src/pages/docs/self-hosting/support.mdx
+++ b/src/pages/docs/self-hosting/support.mdx
@@ -16,6 +16,10 @@ Running the open-source stack and hit something these pages don't cover? Here's 
   </Card>
 </CardGroup>
 
+## Reporting a security issue
+
+A vulnerability doesn't go in a public GitHub issue. Report it privately to [security@futureagi.com](mailto:security@futureagi.com) instead, which is what the repo's `SECURITY.md` asks for. You'll get an acknowledgement inside 24 hours on weekdays, and disclosure is coordinated with you rather than announced.
+
 ## Before you post
 
 A self-hosting question is easier to answer with the basics attached:
@@ -24,6 +28,7 @@ A self-hosting question is easier to answer with the basics attached:
 - Output of `docker compose ps` so the team can see which service is down
 - Logs from the failing service: `docker compose logs <service> --tail=100`
 - Your platform (Linux host, EC2, GCE) and whether you're on managed data stores
+- The release you're running: the version variables from `.env`, or `docker compose images` if you're floating on `latest`
 
 Most self-hosting questions are already answered in [Troubleshooting & FAQs](/docs/self-hosting/troubleshooting). Check there first.
 

--- a/src/pages/docs/self-hosting/troubleshooting.mdx
+++ b/src/pages/docs/self-hosting/troubleshooting.mdx
@@ -1,9 +1,9 @@
 ---
-title: "Troubleshooting and FAQs"
-description: "Debug self-hosted Future AGI — symptoms, causes, and fixes for startup failures, network issues, PeerDB CDC errors, Temporal worker problems, and post-upgrade breaks."
+title: "Troubleshooting & FAQs"
+description: "Symptoms, causes, and fixes for a self-hosted instance"
 ---
 
-## About
+## In this page
 
 Symptoms, causes, and fixes for the errors most commonly hit when self-hosting. Grouped by where they show up: startup, network, PeerDB, Temporal, and post-upgrade.
 
@@ -24,16 +24,17 @@ Docker isn't running. Start Docker Desktop (Mac/Windows) or `sudo systemctl star
 
 ---
 
-**First build takes 15+ min or hangs on `uv pip install`**
-Normal on first boot. If stuck >20 min, cancel and retry:
+**First boot takes 15+ min or looks stuck**
+Normal. First boot pulls every image from Docker Hub, a few GB in total, and nothing is built locally so there's no compile step to hang on. Watch the pull actually progressing:
 ```bash
-docker compose build --no-cache backend
+docker compose logs -f
+docker compose pull        # re-run to resume an interrupted pull
 ```
 
 ---
 
 **`ERROR: not enough free space`**
-Docker Desktop's virtual disk is full. Settings → Resources → Disk image size → raise to 100 GB+. Or prune: `docker system prune -af && docker builder prune -af`
+Docker Desktop's virtual disk is full. Settings → Resources → Disk image size → raise to 100 GB+. Or reclaim space from unused images: `docker system prune -af`
 
 ---
 
@@ -48,7 +49,7 @@ BACKEND_PORT=8100
 ---
 
 **Backend never reaches `Application startup complete`**
-- Check RAM: `docker info | grep -i memory` — Docker needs ≥ 8 GB
+- Check RAM: `docker info | grep -i memory` (Docker needs ≥ 8 GB)
 - Check for migration errors: `docker compose logs backend | grep -i error`
 - Run migrations manually: `docker compose exec backend python manage.py migrate`
 
@@ -62,16 +63,15 @@ BACKEND_PORT=8100
 ---
 
 **`code-executor` crashes with `clone: Operation not permitted`**
-Host platform blocks `privileged: true`. Won't work on Fargate, Cloud Run, or restricted Kubernetes. Use EC2, GCE, or bare metal. The rest of the stack runs — only code-based eval features are unavailable.
+Host platform blocks `privileged: true`. Won't work on Fargate, Cloud Run, or restricted Kubernetes. Use EC2, GCE, or bare metal. The rest of the stack runs, and only code-based eval features are unavailable.
 
 ---
 
 ## Network and UI errors
 
 **Frontend blank page or CORS errors**
-`VITE_HOST_API` in `.env` doesn't match the current backend URL. Rebuild:
+`VITE_HOST_API` in `.env` doesn't match the current backend URL. It's written into `config.js` when the frontend container starts, so recreating the container is enough and no rebuild is involved:
 ```bash
-docker compose build --no-cache frontend
 docker compose up -d frontend
 ```
 
@@ -88,16 +88,16 @@ Backend isn't healthy. Check: `docker compose logs backend` and `docker compose 
 PeerDB init ran before Django migrations completed. Fix:
 ```bash
 docker compose logs -f backend      # wait for "Application startup complete"
-docker compose run --rm peerdb-init bash /setup.sh
+docker compose run --rm peerdb-init
 ```
-Verify at [http://localhost:3001](http://localhost:3001) — mirrors should show `running`.
+Verify at [http://localhost:3001](http://localhost:3001), where mirrors should show `running`.
 
 ---
 
 **Analytics data is stale**
 PeerDB replication has fallen behind. Check mirror lag in the PeerDB UI. Re-run init if a mirror shows an error:
 ```bash
-docker compose run --rm peerdb-init bash /setup.sh
+docker compose run --rm peerdb-init
 ```
 
 ---
@@ -118,10 +118,10 @@ docker compose exec backend python manage.py migrate
 If a conflict persists, check the release notes for manual steps.
 
 **Everything worked before the upgrade, now it doesn't**
+Roll back by pinning the image versions in `.env` to the previous release tag, then bringing the stack up again. Nothing is built locally, so a `git checkout` on its own changes no running code. The full procedure is in [Upgrades & rollback](/docs/self-hosting/production/upgrades-rollback).
 ```bash
-git log --oneline -5
-git checkout <previous-hash>
-docker compose build && docker compose up -d
+FUTURE_AGI_VERSION=v1.25.0    # and the other four version variables
+docker compose up -d
 ```
 
 ---
@@ -134,13 +134,13 @@ docker compose logs > all-logs.txt 2>&1
 docker compose ps >> all-logs.txt
 ```
 
-## Next Steps
+## Dive deeper
 
 <CardGroup cols={2}>
   <Card title="Requirements" icon="server" href="/docs/self-hosting/requirements">
-    Verify your platform and resources meet the minimums.
+    Verify your platform and resources meet the minimums
   </Card>
   <Card title="Production" icon="shield" href="/docs/self-hosting/production">
-    Hardening, backups, and monitoring once the stack is stable.
+    Hardening, backups, and monitoring once the stack is stable
   </Card>
 </CardGroup>


### PR DESCRIPTION
Review-fix pass on top of [#798](https://github.com/future-agi/docs/pull/798), targeting that PR's branch so its own review history stays intact.

## What was wrong

Two root causes ran through the whole Self-hosting section.

**Nothing in the stack is built locally.** `docker-compose.yml` has zero `build:` keys; every service runs a published image. So every `docker compose build` instruction was a no-op. That broke the documented upgrade path, the rollback path, three Troubleshooting fixes, the arm64 note, and the frontend env warning. Six occurrences across five pages, all saying to run a command that does nothing.

**Secrets ship as working values, not placeholders.** `CHANGEME` appears nowhere in the repo, yet `environment.mdx` told readers to replace it in five places. The real defaults are `PG_PASSWORD=futureagi`, `MINIO_ROOT_PASSWORD=futureagi`, `SECRET_KEY=local-dev-only-not-for-production-replace-me`, `AGENTCC_INTERNAL_API_KEY=local-dev-only-shared-secret-replace-me`. Anyone grepping for `CHANGEME` found nothing and concluded there was nothing to change, while running with `futureagi` as their database password.

## What changed

| Page | Change |
|---|---|
| `requirements.mdx` | Compose floor v2.20 → v2.24; four missing ports; PodSecurityPolicy → Pod Security Admission |
| `installation.mdx` | fi-collector is pulled, not built; arm64 note corrected; `--purge` scope |
| `configuration/environment.mdx` | Five `CHANGEME` corrections; `VITE_HOST_API` is runtime, not build-time |
| `configuration/profiles.mdx` | Core-13 as bullets; what staying light costs; heading hierarchy |
| `configuration/launch-mode.mdx` | Container column on the check table; deduped profile contrast |
| `configuration/system.mdx` | `workers` and `observability` profiles named; `peerdb-init` form unified |
| `production.mdx` | Secrets wording aligned; "five steps" reconciled with its grouping |
| `production/checklist.mdx` | `FAST_STARTUP` already defaults to `false`; `check --deploy` warns and continues |
| `production/security-tls.mdx` | Loopback binding so `:3000`/`:8000` can't bypass TLS; stale card link |
| `production/backups-restore.mdx` | Volume table moved out of the Postgres section; dead-letter volume explained |
| `production/monitoring.mdx` | Backend `/health/` added; `/healthz` documented as a span-loss alarm |
| `production/upgrades-rollback.mdx` | Rewritten around `docker compose pull` and version pins |
| `troubleshooting.mdx` | Three build fixes corrected; banned `About` heading; title matches sidebar |
| `support.mdx` | Security disclosure path per `SECURITY.md`; release version in the checklist |

## Why

Everything was resolved against `origin/main` of the monorepo, which is what `git clone` gives a self-hoster, and reproduced rather than read:

- Service counts `13/19/15/23/21/31` via `docker compose config --services`
- Compose v2.24 floor from the `env_file` long form, five uses in `docker-compose.yml`
- Image platforms from `release-images.yml`: five of six are multi-arch, only `futureagi/future-agi` is amd64-only
- Loopback binding tested: `FRONTEND_PORT=127.0.0.1:3000` renders `host_ip: 127.0.0.1`
- `/healthz` contract from `fi-collector/cmd/fi-collector/main.go:17`
- Version pins from `.env.example:14-20`, tag format `vX.Y.Z` from `build-image.yml`

## Test cases

| # | Scenario | Expected |
|---|----------|----------|
| 1 | `node scripts/audit-links.mjs` | 0 broken nav links, 0 broken content links |
| 2 | Every `docker compose build` in the section | None remain on any sidebar page |
| 3 | `CHANGEME` across the section | No occurrences |
| 4 | Em-dashes across the section | None on any sidebar page |
| 5 | Card layouts | `cols={3}` where count is 3, `cols={2}` where 2 |

## Commands

```bash
node scripts/audit-links.mjs
```

## Not in this PR

- **No screenshots.** `launch-mode.mdx` still describes a UI screen end to end without one, gated on the same release as its copy
- **Three orphan pages untouched**: `configuration.mdx`, `docker-compose.mdx`, `user-management.mdx`. None are in the sidebar; `docker-compose.mdx` still says "all 21 services" and links the stale `/configuration`
- **#798's merge gate is unchanged.** It says "merge after future-agi/future-agi#2023", but #2023 targets `dev`, so the real gate is the release that carries it into `main`

## Videos and screenshots

None. Text-only changes; verified via the link audit above.