### PR TITLE
ci: make PR checks fork-safe by dropping the unused chat-widget fetch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,19 +17,6 @@ jobs:
         with:
           node-version: '20'
 
-      # Fetch the chat-widget from the landing-page repo (pre-built dist is committed)
-      - name: Fetch @futureagi/chat-widget
-        run: |
-          git clone --depth 1 \
-            https://x-access-token:${{ secrets.GH_PAT }}@github.com/future-agi/landing-page.git .landing-tmp
-          cp -r .landing-tmp/docs-agent/packages/chat-widget ./chat-widget
-          rm -rf .landing-tmp
-
-      # Replace workspace:* with local file reference so npm can install it
-      - name: Patch chat-widget dependency
-        run: |
-          sed -i 's|"@futureagi/chat-widget": "workspace:\*"|"@futureagi/chat-widget": "file:./chat-widget"|' package.json
-
       - name: Cache npm dependencies
         uses: actions/cache@v4
         with:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -19,27 +19,8 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Fetch @futureagi/chat-widget
-        run: |
-          git clone --depth 1 \
-            https://x-access-token:${{ secrets.GH_PAT }}@github.com/future-agi/landing-page.git .landing-tmp
-          cp -r .landing-tmp/docs-agent/packages/chat-widget ./chat-widget
-          rm -rf .landing-tmp
-
-      - name: Patch chat-widget dependency
-        run: |
-          sed -i 's|"@futureagi/chat-widget": "workspace:\*"|"@futureagi/chat-widget": "file:./chat-widget"|' package.json
-
-      - name: Cache npm dependencies
-        uses: actions/cache@v4
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json', 'package.json') }}
-          restore-keys: ${{ runner.os }}-npm-
-
-      - name: Install dependencies
-        run: npm install
-
+      # The audit scripts use only Node built-ins: no install, no secrets,
+      # so this job also runs on fork PRs, which never receive repo secrets
       - name: Check broken nav & content links
         run: node scripts/audit-links.mjs
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "@astrojs/mdx": "^4.3.12",
     "@astrojs/react": "^4.3.1",
     "@astrojs/sitemap": "^3.6.0",
-    "@futureagi/chat-widget": "workspace:*",
     "@giscus/react": "^3.1.0",
     "@tailwindcss/vite": "^4.1.17",
     "astro": "^5.16.3",


### PR DESCRIPTION
## What

Removes the `@futureagi/chat-widget` fetch from CI and the vestigial dependency from package.json. The link-audit job now runs on bare Node with no secrets and no install; deploy loses two inert steps.

## Why

PR #822 (an external contribution) failed the link audit before any checking ran: the job clones the private landing-page repo using `secrets.GH_PAT`, and GitHub withholds repository secrets from fork-PR runs, so the clone fails with exit 128. Every future external PR would fail the same way.

## What cases were covered

- `@futureagi/chat-widget` is imported nowhere in src, astro config, or plugins; package-lock.json contains zero references to it. AiChatWidget.astro is self-contained and talks to the docs-agent service over HTTP
- Both audit scripts (`audit-links.mjs`, `check-deleted-pages.mjs`) import only Node built-ins (fs, path, child_process, url); ran both locally on a clean tree, both exit 0 with no node_modules involvement
- deploy still runs `npm install` for the real build dependencies; only the fetch and patch steps are removed

## How

Deleted the fetch/patch/cache/install steps from pr-checks.yml, the fetch/patch steps from deploy.yml, and the workspace dependency line from package.json.

## Recording

Not applicable: CI-only change. Proof is #822's check going green on rerun once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)