### PR TITLE
ci: redirect check accepts deletions whose route is still served

### DIFF
--- a/scripts/check-deleted-pages.mjs
+++ b/scripts/check-deleted-pages.mjs
@@ -6,7 +6,7 @@
  * Default base branch: dev
  */
 import { execSync } from 'child_process';
-import { readFileSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 
 const baseBranch = process.argv[2] || 'dev';
 
@@ -48,6 +48,14 @@ function fileToPath(file) {
     .replace(/\/index$/, '') || '/';
 }
 
+// A deleted file needs no redirect when its route is still served by another
+// page file (e.g. deleting foo.mdx while foo/index.mdx exists)
+function routeStillServed(urlPath) {
+  const base = `src/pages${urlPath === '/' ? '' : urlPath}`;
+  return ['.mdx', '.astro', '.md', '/index.mdx', '/index.astro', '/index.md']
+    .some(suffix => existsSync(`${base}${suffix}`));
+}
+
 // Load redirects map
 const redirectsRaw = readFileSync('src/lib/redirects.ts', 'utf-8');
 const redirectEntries = [...redirectsRaw.matchAll(/["']([^"']+)["']:\s*["']([^"']+)["']/g)];
@@ -57,6 +65,10 @@ const redirectMap = new Set(redirectEntries.map(([, from]) => from));
 const missing = [];
 for (const file of deletedPages) {
   const urlPath = fileToPath(file);
+  if (routeStillServed(urlPath)) {
+    console.log(`  ${urlPath} still served by another page file, no redirect needed. ✓`);
+    continue;
+  }
   if (!redirectMap.has(urlPath)) {
     missing.push({ file, urlPath });
   }


### PR DESCRIPTION
## What

Teaches `scripts/check-deleted-pages.mjs` to skip a deleted page when its URL is still served by another page file (.mdx/.astro/.md sibling or index variant). Genuinely dead routes still require a redirect and still fail the check.

## Why

#822 correctly deletes `admin-settings.mdx` to resolve a duplicate-route collision: `admin-settings/index.mdx` keeps serving `/docs/admin-settings`, so no redirect is possible or needed. The check failed it anyway, and would fail every future dedupe deletion the same way.

## What cases were covered

- Reproduced #822's scenario locally (temp commit deleting `admin-settings.mdx`): script passes with "still served by another page file, no redirect needed" and exit 0
- A made-up dead route still returns false from the new check, so missing redirects keep failing
- No-deletion branches keep their early exit

## How

One `routeStillServed()` helper checking the six page-file variants that could own the URL, consulted before the redirect lookup.

## Recording

Not applicable: CI-only change. Proof is #822 going green after Update branch once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)