### PR TITLE
docs(release-notes): add weeks of Jul 22 to Aug 10, 2026

### DIFF
--- a/src/pages/docs/release-notes.mdx
+++ b/src/pages/docs/release-notes.mdx
@@ -5,6 +5,115 @@ description: "Latest Future AGI release notes covering new features, improvement
 
 {/* release-notes:insert-below — automation inserts new releases here; do not remove */}
 
+## Week of 2026-08-10
+
+<div class="mb-12 pb-8 border-b border-[var(--color-border-subtle)] last:border-b-0">
+
+<div class="mt-6 mb-3 text-lg font-semibold">Features</div>
+
+- **Enterprise Code Joins the Open-Source Repository:** Future AGI's enterprise code, which used to live in a separate private repository, now sits in the same open-source repository as the core, behind a license. Capabilities like the Cluster RCA agent, guardrails, and agent optimization now build from one place alongside the Apache 2.0 core, so self-hosted and licensed deployments come from a single source. github.com/future-agi/future-agi.
+
+<div class="mt-6 mb-3 text-lg font-semibold">Bugs/Improvements</div>
+
+- **Sharper Error Clustering:** The Error Feed's clustering engine got a precision upgrade. It reads each turn in full context, groups related failures more tightly, and titles every cluster from the shared pattern across its traces, so each cluster gives you a cleaner, more accurate picture of what is actually going wrong and how widespread it is.
+
+- **Model Lifecycle Awareness:** Future AGI now tracks when a model is renamed or retired from the catalog. Historical runs that reference a retired model continue to load reliably, the model is clearly flagged as deprecated, and starting a new run on an unavailable model returns a clear message pointing you to a supported one.
+
+</div>
+
+## Week of 2026-08-04
+
+<div class="mb-12 pb-8 border-b border-[var(--color-border-subtle)] last:border-b-0">
+
+<div class="mt-6 mb-3 text-lg font-semibold">Features</div>
+
+- **Guided Setup for Self-Hosting:** Standing up your own Future AGI instance is now a smooth, guided experience. A setup screen walks you through the infrastructure checks and lets you move ahead as soon as your stack is ready, the first admin account signs in the moment it is created, and you can invite your team with shareable links, no email server required.
+
+<div class="mt-6 mb-3 text-lg font-semibold">Bugs/Improvements</div>
+
+- **Click-to-Map Variable Mapping:** When mapping variables for evaluations, simulations, and datasets, you can now click a column or value to assign it, instead of typing the path by hand. If there is one variable it maps straight away; if there are several, a short menu lets you pick the one you want or copy the path.
+
+- **Smoother Cluster RCA Investigations:** Following an investigation in the Fix tab is now easier to read as it streams. You can scroll back through the reasoning without being pulled down to the newest step, the steps you open stay open, and every run ends with a clear outcome. Each investigation is also faster and more consistent.
+
+- **Voice Recording Playback:** Voice call recordings now play more reliably across browsers, falling back to your browser's built-in player when needed.
+
+- **Annotation Queue: View Session:** Items in an annotation queue now have a View Session action, so you can open the full session an item belongs to without leaving the queue.
+
+</div>
+
+## Week of 2026-07-28
+
+<div class="mb-12 pb-8 border-b border-[var(--color-border-subtle)] last:border-b-0">
+
+<div class="mt-6 mb-3 text-lg font-semibold">Features</div>
+
+- **Bland.ai Voice Integration:** Bland.ai is now a supported voice provider, alongside VAPI and Retell. Connect your inbound and outbound Bland voice agents so their production calls are verified, ingested, and fully observable in Future AGI, and run simulations against them like any other agent.
+
+- **OSS Mode and Unified Docker Setup:** The open-source build now ships with a unified Docker setup and cleanly gates enterprise-only features, with a CLI-based setup flow for first run.
+
+<div class="mt-6 mb-3 text-lg font-semibold">Bugs/Improvements</div>
+
+- **New Model Support:** Claude 5 and the Gemini 3.x family, including Gemini 3.6 Flash, are now in the model catalog and available through the gateway, with pricing.
+
+- **Faster Annotation Queues:** A round of performance work makes the annotation grid, bulk review, submit, and assign noticeably faster on large queues.
+
+- **Faster, More Resilient Observe Lists:** Trace and span lists load faster with a smaller default page size, and a single row with an unreadable date value no longer prevents the Observe page from loading.
+
+- **Dark Mode Readability:** Some surfaces and controls in the evals, trace, and Error Feed views were low-contrast in dark mode. They now use proper dark-theme colors.
+
+- **Simulation Fixes:** Choice-based evaluation results previously failed to load in the Analytics tab under certain conditions. This has been resolved, and the Analytics tab now displays results reliably for all evaluation types.
+
+- **Voice Fixes:** Fixed a case where the Observe voice call detail view could come up empty, and combined recordings now play.
+
+</div>
+
+## Week of 2026-07-22
+
+<div class="mb-12 pb-8 border-b border-[var(--color-border-subtle)] last:border-b-0">
+
+<div class="mt-6 mb-3 text-lg font-semibold">Features</div>
+
+- **Cluster RCA Agent (Enterprise):** The Error Feed can investigate a cluster of failing traces for you. It reads each trace, correlates the failure across version, model, region, and error type, and returns a root cause, a suggested fix, and a confidence level, streamed live in the Fix tab.
+
+- **Faster Telemetry at Scale (ClickHouse 25.3):** The telemetry backend moved to ClickHouse 25.3, so traces, sessions, and voice calls all load faster and hold up as your volume grows.
+
+- **Eval Usage Tab:** Every eval template now has a Usage tab showing run counts, pass rate over time, and the exact eval version behind each score.
+
+- **GPT-5 and o-Series on the Gateway:** The gateway now sends max_completion_tokens to OpenAI and Azure, so GPT-5, its mini and nano variants, and the o-series work through the gateway with no client change.
+
+- **Sessions and Users Filtering:** The Sessions and User tabs can now be filtered by session, by user, and by first or last message.
+
+- **Write-Access Controls (RBAC):** Write actions in the agent playground and dashboards are now gated behind write access.
+
+- **API Hardening:** Request and response contracts and serializers were standardized across the platform for a consistent, well-typed API surface, part of our open-source-readiness work.
+
+<div class="mt-6 mb-3 text-lg font-semibold">Bugs/Improvements</div>
+
+- **Error Feed Refresh:** Redesigned Overview, Traces, Trends, and Fix tabs, with feed views loading 80 to 85 percent faster.
+
+- **Edited Custom-Eval Prompts Now Apply:** Editing a custom eval on the dataset page now uses your updated prompt at runtime, and each dataset pins the exact eval version it runs.
+
+- **Optional Variable Mapping for Agent Evals:** When an agent eval task already receives trace or session context, you no longer have to map every variable.
+
+- **Users CSV Export:** Export large user lists to CSV, with streaming for big exports.
+
+- **Redesigned JSON and Array Column Picker:** The dataset variable-mapping column picker was redesigned to handle nested JSON and array fields.
+
+- **Larger Dataset Uploads:** The dataset upload size cap was raised from 10 MB to 25 MB.
+
+- **Simulation Fixes:** The chat simulation results view is now easier to read. Evaluations run inside a simulation no longer receive empty inputs from a mapping issue. Scenarios now show their Failed or Processing status, and running a simulation on a scenario with no data is blocked with a clear message.
+
+- **Prompt Fixes:** In a prompt's Evaluation tab, newly added rows are no longer lost when you run an evaluation. In the prompt workbench, comparing versions no longer shows a version's variables as missing by mistake, and opening a prompt now shows the correct version's content.
+
+- **Observe and Voice Fixes:** Some voice calls would not load in Observe due to a provider configuration issue; these calls now load reliably. Filtering and columns in Observe lists are cleaner. The Users grid now supports up to 50 rows per page.
+
+- **Dataset Fixes:** CSV files whose cells contain curly or smart quotes now upload correctly.
+
+- **API Key Configuration:** Fixes to API-key configuration and additional security hardening.
+
+</div>
+
+
 ## Week of 2026-06-18
 
 <div class="mb-12 pb-8 border-b border-[var(--color-border-subtle)] last:border-b-0">


### PR DESCRIPTION
Adds four release-notes weeks to the What's New page, inserted newest-first below the automation marker:

- Week of 2026-08-10
- Week of 2026-08-04
- Week of 2026-07-28
- Week of 2026-07-22

Content is the approved release-notes copy, formatted to match the existing page (Features and Bugs/Improvements sections in the standard div wrappers). No existing entries were modified.