### PR TITLE
docs: close the seventh audit's verified findings

### DIFF
--- a/src/pages/docs/command-center/api/chat.mdx
+++ b/src/pages/docs/command-center/api/chat.mdx
@@ -272,7 +272,7 @@ curl -X POST https://gateway.futureagi.com/v1/chat/completions \
 
 ### Streaming behavior
 
-- **Pre-request plugins** (guardrails, rate limiting, etc.) run before the stream starts. If a guardrail blocks the request, you get a JSON error response, not a stream.
+- **Pre-request plugins** (guardrails, rate limiting, etc.) run before the stream starts. If a guardrail blocks the request, you get a 403 JSON error response with `"code": "content_blocked"`, not a stream.
 - **Post-response plugins** (cost, logging, metrics) run after the final chunk, once token usage is known.
 - **Cache**: Streaming requests bypass the cache entirely, both on read and write.
 - **Failover**: Not supported mid-stream. If the provider fails after streaming starts, the error appears as an SSE data event.

--- a/src/pages/docs/command-center/concepts/api-reference.mdx
+++ b/src/pages/docs/command-center/concepts/api-reference.mdx
@@ -79,15 +79,15 @@ Agent Command Center returns standard HTTP error codes with structured JSON erro
 
 ### Guardrail blocked (403)
 
-When a guardrail is set to Enforce mode and triggers on a request, Agent Command Center returns 403 before the LLM is ever called:
+When a guardrail whose action is `block` triggers on a request, Agent Command Center returns 403. A pre-stage check returns it before the LLM is ever called; a post-stage check returns it instead of the model's response. A guardrail whose action is `warn` or `log` does not change the status: the call returns 200 with the header `x-agentcc-guardrail-triggered: true`.
 
 ```json
 {
   "error": {
-    "type": "guardrail_triggered",
-    "code": "forbidden",
+    "type": "guardrail_error",
+    "code": "content_blocked",
     "message": "Request blocked by guardrail: pii-detector",
-    "guardrail": "pii-detector"
+    "param": null
   }
 }
 ```

--- a/src/pages/docs/command-center/concepts/platform-integration.mdx
+++ b/src/pages/docs/command-center/concepts/platform-integration.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Command Center Platform Integration"
-description: "How Agent Command Center feeds signals into Future AGI Observe, Evaluate, Protect, and Experiment to close the loop between production traffic and model quality."
+description: "How Agent Command Center feeds signals into Future AGI Observe, Evaluate, and Protect to close the loop between production traffic and model quality."
 ---
 
 ## About
 
-Agent Command Center is not a standalone gateway. It's the data collection and enforcement layer of the Future AGI platform. Every request through Agent Command Center generates signals that flow into Observe, Evaluate, Protect, and Experiment — closing the loop between production traffic and model quality.
+Agent Command Center is not a standalone gateway. It's the data collection and enforcement layer of the Future AGI platform. Every request through Agent Command Center generates signals that flow into Observe, Evaluate, and Protect, closing the loop between production traffic and model quality.
 
 ---
 
@@ -21,9 +21,9 @@ Your application
   │         │    guardrail scores          ┌──────────┐
   │         │ ─────────────────────────── │ Evaluate │
   │         │                              └──────────┘
-  │         │    shadow results            ┌───────────┐
-  │         │ ─────────────────────────── │ Experiment│
-  └─────────┘                              └───────────┘
+  │         │    shadow results            ┌──────────┐
+  │         │ ─────────────────────────── │ Evaluate │
+  └─────────┘                              └──────────┘
 ```
 
 ---
@@ -82,16 +82,16 @@ Guardrail scores and decisions are logged in both Agent Command Center (for traf
 
 ---
 
-## Agent Command Center → Experiment
+## Agent Command Center → Evaluate (shadow experiments)
 
-Shadow experiments in Agent Command Center generate comparison data that feeds directly into Experiment pipelines.
+Shadow experiments in Agent Command Center generate comparison data that feeds directly into Evaluate.
 
 When you configure traffic mirroring, Agent Command Center collects:
 - Production model responses
 - Shadow model responses
 - Latency and token deltas for each request pair
 
-These paired results appear in the Experiment product where you can:
+These paired results appear in Evaluate, where you can:
 - Run automated scoring on response pairs using evaluation metrics
 - Calculate win rates across hundreds or thousands of production requests
 - Make evidence-based migration decisions before switching providers
@@ -114,7 +114,7 @@ client = AgentCC(
 )
 ```
 
-Shadow results are automatically synced to the Experiment product for analysis.
+Shadow results are automatically synced to Evaluate for analysis.
 
 ---
 
@@ -122,7 +122,7 @@ Shadow results are automatically synced to the Experiment product for analysis.
 
 The `x-agentcc-metadata` header (or `metadata=` parameter in the SDK) is how you connect Agent Command Center data to your application's dimensions. Tags set on requests flow through to all connected products:
 
-| Tag | Use in Observe | Use in Evaluate | Use in Experiment |
+| Tag | Use in Observe | Use in Evaluate | Use in Evaluate (experiments) |
 |-----|---------------|-----------------|-------------------|
 | `metadata.team` | Cost breakdown by team | Quality trends per team | Experiment scoping by team |
 | `metadata.feature` | Latency per feature | Regression alerts per feature | A/B test segmentation |

--- a/src/pages/docs/command-center/features/caching.mdx
+++ b/src/pages/docs/command-center/features/caching.mdx
@@ -33,6 +33,10 @@ No client-side cache logic needed. Caching works for all providers through the s
 Streaming requests bypass cache entirely - both on read and write. Cache only applies to non-streaming completions.
 </Note>
 
+<Warning>
+An exact match hit returns the stored response as it was stored, without a provider call. [Guardrails](/docs/command-center/features/guardrails) that check the request (Pre stage) do not run on that request, so a guardrail you enable after an entry is cached does not apply to it until the entry expires. Guardrails that check the response (Post stage) still run on what is served.
+</Warning>
+
 ---
 
 ## Configuration

--- a/src/pages/docs/command-center/features/guardrails.mdx
+++ b/src/pages/docs/command-center/features/guardrails.mdx
@@ -7,6 +7,10 @@ description: "Enforce PII detection, prompt injection blocking, and content mode
 
 Guardrails are safety checks that run on every request and response flowing through Agent Command Center. They catch dangerous or unwanted content before it reaches the LLM (pre-processing) or before it reaches your users (post-processing).
 
+<Warning>
+When [caching](/docs/command-center/features/caching) is on and a request is served from an exact match hit, guardrails that check the request (Pre stage) do not run on that request. Guardrails that check the response (Post stage) still run on the cached response before it is returned. Disable caching for traffic that must be screened on every request.
+</Warning>
+
 ---
 
 ## When to use
@@ -421,7 +425,7 @@ Guardrails work with streaming responses. Pre-processing guardrails run before s
 
 - **Sync + block**: The stream terminates immediately if a violation is detected
 - **Sync + warn**: A warning header is added, the stream continues
-- **Async**: The guardrail runs fire-and-forget in the background — the stream is never interrupted
+- **Async**: The guardrail runs fire-and-forget in the background: the stream is never interrupted
 
 <CodeGroup>
 ```python Python

--- a/src/pages/docs/command-center/guides/errors.mdx
+++ b/src/pages/docs/command-center/guides/errors.mdx
@@ -39,7 +39,7 @@ The `type` field groups errors into categories. The `code` field identifies the 
 | 400 | `missing_messages` | `messages` field is missing or empty |
 | 400 | `invalid_request_error` | Other request validation failures |
 | 401 | `unauthorized` | API key is missing or invalid |
-| 403 | `content_blocked` | A guardrail blocked the request (enforce mode) |
+| 403 | `content_blocked` | A guardrail whose action is `block` stopped the request. Guardrails set to `warn` or `log` return 200 instead |
 | 404 | `model_not_found` | Model not configured for any provider. Check `model_map` or use `provider/model` format. |
 | 429 | `rate_limit_exceeded` | Per-key or per-org rate limit exceeded |
 | 429 | `budget_exceeded` | Organization budget limit reached |
@@ -117,9 +117,10 @@ Budget resets at the start of the next period (daily/weekly/monthly). Increase t
 ```json
 {
   "error": {
-    "type": "guardrail_triggered",
+    "type": "guardrail_error",
     "code": "content_blocked",
-    "message": "Request blocked by guardrail: pii-detector"
+    "message": "Request blocked by guardrail: pii-detector",
+    "param": null
   }
 }
 ```

--- a/src/pages/docs/command-center/index.mdx
+++ b/src/pages/docs/command-center/index.mdx
@@ -168,7 +168,7 @@ See [Manage Providers](/docs/command-center/features/providers) for the full lis
     Understand the building blocks: gateways, virtual keys, organizations, and providers
   </Card>
   <Card title="Platform Integration" icon="link" href="/docs/command-center/concepts/platform-integration">
-    How Command Center connects to Observe, Evaluate, and Experiment
+    How Command Center connects to Observe and Evaluate
   </Card>
   <Card title="Self-Hosted" icon="server" href="/docs/command-center/deployment/self-hosted">
     Deploy Command Center on your own infrastructure

--- a/src/pages/docs/protect/concepts/understanding-protect.mdx
+++ b/src/pages/docs/protect/concepts/understanding-protect.mdx
@@ -13,7 +13,7 @@ A **guardrail** wraps a check and adds three settings you configure in [Agent Co
 
 A stage of **both** isn't a third mode. It's the same check running twice, once on the way in and once on the way out. Stage belongs to the guardrail rather than to the check it wraps, which is why a single **gateway**, the Agent Command Center surface your guardrails live on, can carry a mix: some watching only what the caller sent, others only what the model sent back.
 
-The threshold runs from 0.0 to 1.0: raising it makes the check fire only on higher-confidence matches, lowering it makes it fire more readily. Threshold and action are independent settings. The threshold decides how often a check fires; the action decides what the caller experiences when it does. Loosening a threshold on a check set to Log changes nothing a caller can see. For the response status each action produces, see [Guardrail checks](/docs/protect/reference/guardrail-checks#response-statuses).
+The threshold runs from 0.0 to 1.0: raising it makes the check fire only on higher-confidence matches, lowering it makes it fire more readily. Threshold and action are independent settings. The threshold decides how often a check fires; the action decides what the caller experiences when it does. Loosening a threshold on a check set to Log changes nothing a caller can see. Only Block changes the gateway's response status, to `403`; Warn and Log let the call return `200`. For the status each action produces, see [Guardrail checks](/docs/protect/reference/guardrail-checks#response-statuses).
 
 Every guardrail wraps a check, and the Rules tab groups checks under two headers that mark a single split: where the check runs. **Rule-Based Checks** are [first-party](/docs/protect/reference/guardrail-checks): they run inside Protect without an external provider. **AI-Powered Checks** call a provider you configure under **Provider Settings** in that check's own settings.
 
@@ -46,7 +46,7 @@ A support agent's traffic has a guardrail named PII Detection enabled, set to Bl
 
 That outcome doesn't disappear once the request is blocked. Every request is recorded with whether a guardrail triggered and the result of each check that ran, and that record is what shows up in Logs and Analytics for this request. From there, feedback on the verdict can mark it correct or wrong, telling you whether PII Detection's threshold and action are actually tuned right, not just switched on.
 
-This record belongs to the dashboard-guardrail surface, while `protect()` returns its verdict directly to your code as the function's response; see the [Protect SDK reference](/docs/sdk/protect) for the response shape.
+This record belongs to the dashboard-guardrail surface, while `protect()` returns its verdict directly to your code as the function's response; see the [Protect SDK reference](/docs/sdk/protect) for the response shape. The status codes differ with the surface: only the gateway turns a verdict into a `403`, whereas `protect()` always returns a normal `200` and puts the verdict in the body as `status`.
 
 ## Why it matters
 

--- a/src/pages/docs/protect/guides/test-a-guardrail.mdx
+++ b/src/pages/docs/protect/guides/test-a-guardrail.mdx
@@ -32,7 +32,7 @@ Press **Run Test**. It stays disabled until there's a prompt in the box, whether
 
 ## Read the result
 
-When the test finishes, a result chip reports the outcome: "BLOCKED (446)" if a guardrail stopped the request, "WARNING (246)" if a guardrail flagged it without stopping it, or "OK" with the status code the call actually returned if it passed cleanly. See [Guardrail checks](/docs/protect/reference/guardrail-checks#response-statuses) for the status each action produces. For the PII test walkthrough above, expect "BLOCKED (446)".
+When the test finishes, a result chip reports the outcome: "BLOCKED" if a guardrail stopped the request, or "OK" with the status code the call actually returned if it passed cleanly. A blocked call returns `403`; a check set to Warn or Log never stops the call, so it comes back `200` and shows as OK. See [Guardrail checks](/docs/protect/reference/guardrail-checks#response-statuses) for the status each action produces. For the PII test walkthrough above, expect "BLOCKED".
 
 Below the chip, **Guardrail Headers** and **Response Body** show the guardrail headers and the response body the call returned. Open them when you're wiring your own client to react to blocked or warned responses and need the exact shape it will get, not just the summarized chip.
 

--- a/src/pages/docs/protect/reference/guardrail-checks.mdx
+++ b/src/pages/docs/protect/reference/guardrail-checks.mdx
@@ -118,15 +118,15 @@ These apply to every check on the gateway rather than to an individual check.
 
 ## Response statuses
 
-A check that blocks or warns changes the gateway call's response status to one of these codes.
+These are the statuses the [Agent Command Center](/docs/command-center) gateway returns on a guardrail decision. Only the Block action changes the status; Warn and Log let the call through.
 
-| Status | Meaning |
-|---|---|
-| `403` | Blocked |
-| `446` | Blocked |
-| `246` | Warned |
+| Action | Status | What the caller gets |
+|---|---|---|
+| Block | `403` | An error body with `"type": "guardrail_error"` and `"code": "content_blocked"`. A pre-stage check returns it before the model is ever called |
+| Warn | `200` | The normal response, plus the header `x-agentcc-guardrail-triggered: true` |
+| Log | `200` | The normal response, plus the header `x-agentcc-guardrail-triggered: true` |
 
-<Note>Both `403` and `446` indicate a blocked call. The condition that selects one over the other isn't documented here, so treat both as blocked when writing code that branches on status.</Note>
+<Note>`protect()` from the SDK is a different surface and does not use these statuses. It returns a normal `200` with the verdict in the response body; see [Run Protect from the SDK](/docs/protect/guides/run-protect-from-the-sdk).</Note>
 
 ## Keep exploring
 

--- a/src/pages/docs/protect/troubleshooting/guardrail-changes-not-taking-effect.mdx
+++ b/src/pages/docs/protect/troubleshooting/guardrail-changes-not-taking-effect.mdx
@@ -27,7 +27,7 @@ If you flipped the **Enabled** switch on the guardrail's row in the **Overview**
 
 ## Confirm with a Test tab run
 
-The fastest way to know whether any of these fixes worked, rather than waiting on real traffic, is one run in [**Gateway** > **Guardrails** > **Test**](/docs/protect/guides/test-a-guardrail). Send a prompt that should trigger the check and read the result chip in the Result card: it reads **BLOCKED (446)**, **WARNING (246)**, or **OK** with the status code, showing whether the guardrail fired on that prompt or let it through.
+The fastest way to know whether any of these fixes worked, rather than waiting on real traffic, is one run in [**Gateway** > **Guardrails** > **Test**](/docs/protect/guides/test-a-guardrail). Send a prompt that should trigger the check and read the result chip in the Result card: it reads **BLOCKED** when a check with the Block action stopped the call, which the gateway returns as `403`, or **OK** with the status code when the call went through. Checks set to Warn or Log never stop a call, so they show as OK on `200`.
 
 ## If the test still doesn't fire
 

--- a/src/pages/docs/protect/troubleshooting/guardrail-fires-on-the-wrong-requests.mdx
+++ b/src/pages/docs/protect/troubleshooting/guardrail-fires-on-the-wrong-requests.mdx
@@ -34,7 +34,7 @@ Click **Save** in the dialog to stage the change, then back on the Rules tab, cl
 
 ## Re-test after each change
 
-After each change, switch to **Gateway** > **Guardrails** > **Test** (see [Test a guardrail](/docs/protect/guides/test-a-guardrail) for what it shows) and click the example chip that matches the case you're chasing, whether that's PII, an injection attempt, secrets, or toxic content, then run it. The result chip in the Result card reads BLOCKED (446), WARNING (246), or OK with the status code; that's the verdict to check against what you meant to happen. Re-running that chip after every threshold or Action change is how you confirm the change did what you meant, instead of stacking up several changes and losing track of which one mattered.
+After each change, switch to **Gateway** > **Guardrails** > **Test** (see [Test a guardrail](/docs/protect/guides/test-a-guardrail) for what it shows) and click the example chip that matches the case you're chasing, whether that's PII, an injection attempt, secrets, or toxic content, then run it. The result chip in the Result card reads BLOCKED, which the gateway returns as `403`, or OK with the status code the call came back on; that's the verdict to check against what you meant to happen. Re-running that chip after every threshold or Action change is how you confirm the change did what you meant, instead of stacking up several changes and losing track of which one mattered.
 
 ## Record the verdict as feedback
 

--- a/src/pages/docs/sdk/simulate.mdx
+++ b/src/pages/docs/sdk/simulate.mdx
@@ -1,19 +1,30 @@
 ---
-title: "Simulation Testing: Voice AI Agent Testing SDK Module"
-description: "Test voice AI agents at scale with simulated customer personas. Run conversations, capture audio, and score agent performance automatically."
+title: "Simulation Testing: AI Agent Testing SDK Module"
+description: "Test AI agents at scale with simulated customer personas. Run multi-turn conversations against your agent and score the results automatically."
 ---
 
 <TLDR>
 - `pip install agent-simulate` — separate package from the core SDK
 - Simulate multi-turn conversations with configurable customer personas
-- Two modes: local (LiveKit) or cloud (Backend API)
+- Cloud mode needs only the base install; local voice mode is an optional `[livekit]` extra
 </TLDR>
 
-Simulation testing lets you run automated conversations against your voice AI agents using synthetic customer personas. For the full platform guide, see [Simulation docs](/docs/simulation). Each simulation produces a transcript, optional audio recordings, and evaluation scores.
+Simulation testing lets you run automated conversations against your AI agents using synthetic customer personas. For the full platform guide, see [Simulation docs](/docs/simulation). Each simulation produces a transcript and evaluation scores, plus audio recordings when you run the local voice mode.
 
 <Note>
-  Requires `pip install agent-simulate` and `FI_API_KEY` + `FI_SECRET_KEY` in your environment. For LiveKit mode, also install `pip install agent-simulate[livekit]`.
+  Requires `pip install agent-simulate` and `FI_API_KEY` + `FI_SECRET_KEY` in your environment. The local voice mode is not installed by default; it needs `pip install agent-simulate[livekit]` and a LiveKit deployment your agent is already connected to.
 </Note>
+
+## Two modes
+
+`TestRunner.run_test()` is one method that picks its mode from the arguments you pass.
+
+| Mode | Selected by | What happens | Requires |
+|---|---|---|---|
+| Cloud | `run_id` or `run_test_name` | Future AGI orchestrates the simulated customer and calls your `agent_callback` each turn | `FI_API_KEY` and `FI_SECRET_KEY` |
+| Local voice | `agent_definition` | A simulated customer joins your agent's LiveKit room over WebRTC | `agent-simulate[livekit]` and a running LiveKit deployment |
+
+Passing neither raises `ValueError`. The two argument sets do not combine: if you pass both, `run_id` or `run_test_name` wins and the local-mode arguments are ignored.
 
 ## Quick Example
 
@@ -31,9 +42,10 @@ async def my_agent(input: AgentInput) -> str:
 asyncio.run(runner.run_test(
     run_test_name="basic-test",
     agent_callback=my_agent,
-    num_scenarios=3,
 ))
 ```
+
+`run_test_name` must match the name of a run test you created on the platform. Pass `run_id` instead if you already have its ID.
 
 ## TestRunner
 
@@ -50,28 +62,45 @@ runner = TestRunner(
 
 ### run_test()
 
+Cloud mode:
+
 ```python
 await runner.run_test(
-    run_test_name="my-test",
+    run_test_name="my-test",   # or run_id="<uuid>"
     agent_callback=my_agent,
-    num_scenarios=5,
-    min_turn_messages=8,
-    max_seconds=45.0,
-    record_audio=False,
+    concurrency=5,
 )
 ```
 
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `run_test_name` | str | None | Name for this test run |
-| `agent_callback` | callable | None | Your agent function (cloud mode) |
-| `num_scenarios` | int | 1 | Number of conversations to simulate |
-| `topic` | str or None | None | Topic for auto-generated scenarios |
-| `min_turn_messages` | int | 8 | Minimum messages per conversation |
-| `max_seconds` | float | 45.0 | Maximum duration per conversation |
-| `record_audio` | bool | False | Capture audio recordings |
-| `scenario` | Scenario | None | Pre-defined scenario with personas (local mode) |
-| `agent_definition` | AgentDefinition | None | Agent config for LiveKit mode |
+Local voice mode, which needs the `[livekit]` extra:
+
+```python
+await runner.run_test(
+    agent_definition=agent,    # your deployed agent's LiveKit room
+    scenario=scenario,
+    record_audio=True,
+    max_seconds=45.0,
+)
+```
+
+| Parameter | Type | Default | Mode | Description |
+|-----------|------|---------|------|-------------|
+| `run_id` | str or None | None | Cloud | ID of the run test to execute |
+| `run_test_name` | str or None | None | Cloud | Name of the run test, resolved to an ID for you; use instead of `run_id` |
+| `agent_callback` | callable or AgentWrapper | None | Cloud | Your agent function or wrapper instance |
+| `concurrency` | int | 5 | Cloud | How many calls run in parallel |
+| `agent_definition` | AgentDefinition | None | Local | The deployed voice agent to dial into |
+| `scenario` | Scenario or None | None | Local | Pre-defined scenario with personas |
+| `simulator` | SimulatorAgentDefinition or None | None | Local | Overrides the simulated customer's LLM, TTS, STT, and VAD settings |
+| `num_scenarios` | int | 1 | Local | Scenarios to generate when `scenario` is omitted |
+| `topic` | str or None | None | Local | Topic for auto-generated scenarios |
+| `record_audio` | bool | False | Local | Capture per-speaker and combined WAV files |
+| `min_turn_messages` | int | 8 | Local | Minimum messages per conversation |
+| `max_seconds` | float | 45.0 | Local | Maximum duration per conversation |
+
+<Note>
+`run_test` returns a `TestReport` in both modes, but in cloud mode its `results` field is always empty. Transcripts, metrics, and evaluations live on the platform; read them from the dashboard. A cloud conversation also stops after 50 turns if the platform hasn't ended it first.
+</Note>
 
 ## Agent Callback
 
@@ -115,10 +144,17 @@ async def advanced_agent(input: AgentInput) -> AgentResponse:
 
 ## Scenarios and Personas
 
-Define custom test scenarios with specific customer personas.
+A `Scenario` is a named list of personas. It is a local voice mode argument: in cloud mode the personas come from the run test you configured on the platform, and a `scenario` passed to `run_test` is ignored.
 
 ```python
-from fi.simulate import Scenario, Persona
+from fi.simulate import AgentDefinition, Scenario, Persona
+
+agent = AgentDefinition(
+    name="billing-support-agent",
+    url="wss://your-livekit-server.com",
+    room_name="support-room",
+    system_prompt="You are a helpful billing support agent.",
+)
 
 scenario = Scenario(
     name="billing-complaints",
@@ -138,9 +174,8 @@ scenario = Scenario(
 )
 
 asyncio.run(runner.run_test(
-    run_test_name="billing-test",
+    agent_definition=agent,
     scenario=scenario,
-    agent_callback=my_agent,
 ))
 ```
 

--- a/src/pages/llms-full.txt.ts
+++ b/src/pages/llms-full.txt.ts
@@ -148,6 +148,12 @@ function stripFrontmatterAndImports(content: string): string {
   // Remove frontmatter
   let result = content.replace(/^---[\s\S]*?---\s*/, '');
 
+  // Turn Mermaid components into fenced blocks so the diagram source survives
+  // the JSX stripping below
+  result = result.replace(/<Mermaid\s+chart=\{`([\s\S]*?)`\}\s*\/>/g, (_m, chart: string) => {
+    return '\n```mermaid\n' + chart.trim() + '\n```\n';
+  });
+
   // Park fenced code so the prose rules below can't edit sample code
   const fences: string[] = [];
   result = result.replace(/```[\s\S]*?```/g, (block) => {


### PR DESCRIPTION
## What

Closes the five actionable findings from the seventh docs audit, every one verified against product source before a page changed.

- Mermaid diagram source now survives into `llms-full.txt` as fenced blocks (51 diagrams across 47 pages were stripped with the JSX)
- `sdk/simulate` rewritten around the SDK's single dual-mode `run_test()`: cloud args and local LiveKit args dispatch differently and never combine; the examples had been mixing them, which silently dropped parameters
- Guardrail status codes aligned with the gateway across 8 pages: block returns 403 with a `guardrail_error`/`content_blocked` body; warn and log return 200 plus the `x-agentcc-guardrail-triggered` header. The 446/246 convention never shipped
- Warnings on the caching and guardrails pages: an exact cache hit skips request-side guardrail screening; response-side checks still run
- Experiment is no longer presented as a product; those signals flow into Evaluate

## Why

An independent 742-page audit surfaced five claims that break working code or misrepresent the product. Verification confirmed three fully, narrowed one (cache bypass is input-side only), and disproved parts of another (446/246 exist only in dead code and an unwired client SDK).

## What cases were covered

- `run_test` verified against the released `agent-simulate` 0.1.3 wheel and its dispatch logic, not just repo source; the reference page checked out fully and was left untouched
- Status codes traced to the gateway's error construction and header-setting call sites; Protect's SDK path confirmed to return plain 200s
- Cache short-circuit traced through the plugin pipeline, including the post-stage skip list
- Mermaid conversion tested against the corpus: 51 of 51 components convert
- Four product bugs found during verification were filed separately, not papered over in docs

## How

Four source-verification agents (simulate SDK, gateway pipeline, status codes, product framing) plus an extractor change, each landing the smallest edit that resolves its finding.

## Recording

Not applicable: text and export changes only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)