### PR TITLE
docs(release-notes): week of 2026-08-17

### DIFF
--- a/src/pages/docs/release-notes.mdx
+++ b/src/pages/docs/release-notes.mdx
@@ -5,6 +5,46 @@ description: "Latest Future AGI release notes covering new features, improvement
 
 {/* release-notes:insert-below — automation inserts new releases here; do not remove */}
 
+## Week of 2026-08-17
+
+<div class="mb-12 pb-8 border-b border-[var(--color-border-subtle)] last:border-b-0">
+
+<div class="mt-6 mb-3 text-lg font-semibold">Features</div>
+
+{/* REVIEW: confirm the hosted voice-simulation path is live in cloud prod (this window's dev->main merge was reverted then re-applied) and confirm which providers are covered before merge */}
+
+- **Voice Agent Simulations, Run on the Platform:** You can now launch and run voice agent simulations directly on Future AGI, with no runner to stand up yourself. Multi-row jobs draw personas from a dataset, you can cap how many calls run at once, you choose which side speaks first, and a live per-call status lets you watch a run progress call by call. The simulator speaks and listens in each persona's own language, so non-English scenarios sound native. Runs started through the Simulation SDK flow back into the same views, with transcript, recording, per-turn detail, words per minute, CSAT, and token cost recomputed server-side so they match a natively run simulation.
+
+- **Explicit WebRTC and Telephony Modes for Voice Agents:** Voice agents now carry a clear transport choice instead of inferring web-versus-phone from a blank number field. Pick WebRTC for a browser call, or Telephony for PSTN and SIP, which then collects and requires a phone number. WebRTC targets no longer ask for an API key or assistant ID before you can create them, and there is now a phone (SIP) option and a call-type indicator on each agent.
+
+- **Export AI Gateway Traces over OTLP/HTTP:** Self-hosted AI Gateway deployments can now export traces over OTLP/HTTP to any compatible endpoint, with configurable authentication headers and optional prompt and completion bodies on each span. Coverage spans chat, image, audio, embedding, and retrieval calls, with flattened message attributes so every trace renders in full.
+
+- **Re-run an Eval Task from Its Header:** Eval task runs now have a Re-run control in the task detail header, reachable from any tab including Logs, so you can re-trigger a completed run without going back to the Details tab.
+
+<div class="mt-6 mb-3 text-lg font-semibold">Bugs/Improvements</div>
+
+- **Chart Scores from Structured Evals:** Dashboard widgets can now graph the numeric score from evals that return a structured or choice output, not only scalar evals. Average, median, min, max, percentile, and pass-rate all read the real score, so those evaluations can be tracked as a time series alongside the rest. Scalar-output evals are unchanged.
+
+- **One Pie per Metric on Dashboards:** A pie widget with several metrics selected now draws a separate pie for each metric instead of adding unrelated values into a single ring, and it is offered only when a breakdown is set. The editor preview and the saved widget compute their values the same way.
+
+- **Completed Voice Calls Show Their Final Status and Recordings:** The voice call detail view now always serves the latest version of a re-ingested call, so a finished call shows its ended status and rehosted recordings, and repeated ingestion no longer duplicates the child spans under it.
+
+- **Restore Annotation Labels across Workspaces:** Restoring an archived annotation label now resolves against your active organization, so it works for members who joined by invite or have switched workspaces.
+
+- **Clearer Annotation-Queue Archiving:** The Archive action in annotation-queue menus is now legible in the light theme and uses consistent archive and restore icons across both tables, queues can be archived from the settings tab, and the search and Active/Archived filters stay reachable even when a tab has no rows.
+
+- **Editable Dataset Filter Chips:** Applied filter chips in the Datasets data tab are now clickable. Selecting one reopens the filter panel with its field, operator, and value loaded for editing, instead of deleting and recreating the filter.
+
+- **Readable Dark-Theme Checkboxes:** Checkboxes are now visible in every state on the dark theme, including the selected state in the dataset Add Evaluation dialog, fixed once across the product rather than per dialog.
+
+- **More Reliable MCP Tool Calls through the Gateway:** The gateway now validates required fields on MCP tool calls even when the argument map is empty, and it accepts MCP messages up to 1 MiB, so large tool schemas and results come through cleanly.
+
+- **Self-Hosted Credential Encryption Works Out of the Box:** Fresh self-hosted installs now start with a valid integration-credential encryption key, so stored integration credentials are encrypted from the first run.
+
+- **Simulation Scenario Picker Loads Reliably:** The scenario selector in simulations keeps its loading state correct while paging and stays reachable when the results fit on a single page.
+
+</div>
+
 ## Week of 2026-08-10
 
 <div class="mb-12 pb-8 border-b border-[var(--color-border-subtle)] last:border-b-0">
@@ -112,7 +152,6 @@ description: "Latest Future AGI release notes covering new features, improvement
 - **API Key Configuration:** Fixes to API-key configuration and additional security hardening.
 
 </div>
-
 
 ## Week of 2026-06-18
 


### PR DESCRIPTION
Draft release notes for **Week of 2026-08-17** (platform v1.28.0–v1.29.0), produced by the `/release-notes` editorial pass over the discovered changeset (Linear-enriched).

- `check.sh` clean — leak gates (ticket IDs / SHAs / commit scopes / internal mechanism / internal gates) and house style; customer-name denylist applied.
- Fresh-context reviewer pass cleared (accuracy, prod-only, scope, leakage, coverage).
- **Human review + merge required.** Opened as a draft; merging is a human step.

**Coverage:** 4 Features + 10 Bugs/Improvements (14 bullets), bundled by product flow from ~22 PRs / 15 Linear tickets in the release window.

**Confirm before merge**
- One non-rendering `{/* REVIEW */}` note on the voice-simulation feature: confirm the hosted path is live in cloud prod (this window's dev→main merge was reverted then re-applied) and confirm which providers are in scope.

**Excluded by policy:** signup work-email validation (anti-abuse gate), no-behavior annotation API contract alignment, and merge/release/README churn.

**Relationship to existing PRs:** supersedes the raw per-release notes for v1.28.0 (#828) and v1.29.0 (#830) — please close those once this merges. This is 1 of a 3-PR set for the pending weeks (08-17 → 08-31); merge oldest-first so the page stays newest-on-top. Each PR inserts its week directly below the `insert-below` marker and will need a trivial rebase after the previous one merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
