### PR TITLE
docs: document OTLP request size limits

### DIFF
--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -639,6 +639,7 @@ export const tabNavigation: NavTab[] = [
             title: 'Reference',
             items: [
               { title: 'Filters', href: '/docs/observe/reference/filters' },
+              { title: 'Export & endpoints', href: '/docs/observe/reference/export-formats' },
               { title: 'traceAI', href: '/docs/observe/concepts/traceai' },
             ]
           },

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -639,7 +639,7 @@ export const tabNavigation: NavTab[] = [
             title: 'Reference',
             items: [
               { title: 'Filters', href: '/docs/observe/reference/filters' },
-              { title: 'Export & endpoints', href: '/docs/observe/reference/export-formats' },
+              { title: 'Export and endpoints', href: '/docs/observe/reference/export-formats' },
               { title: 'traceAI', href: '/docs/observe/concepts/traceai' },
             ]
           },

--- a/src/pages/docs/observe/reference/export-formats.mdx
+++ b/src/pages/docs/observe/reference/export-formats.mdx
@@ -73,12 +73,12 @@ The ingestion endpoint is an **OTLP/traces** receiver — you don't call it dire
 | Auth | `FI_API_KEY` + `FI_SECRET_KEY` from the [keys page](https://app.futureagi.com/dashboard/keys), sent by the SDK on every export. Keys are workspace-scoped. |
 | Success | The exporter batches spans and sends them in the background; a successful export returns no payload. Spans appear in Observe within seconds. |
 | Errors | A `401` means the keys are wrong for this workspace; a `4xx` means a malformed/oversized batch; transient `5xx`/network errors are retried by the batch exporter. |
-| Limits | FutureAGI Cloud accepts OTLP requests up to 16 MiB over HTTP or gRPC. See [Ingestion request limits](#ingestion-request-limits). |
+| Limits | Spans are sent by the **batch** span processor on an interval, so a short-lived process must call `trace_provider.force_flush()` before exit or the last batch is lost. Very large payloads (huge prompts/outputs) can be dropped — [mask or trim](/docs/sdk/tracing/mask-span-attributes) them at the SDK. Future AGI Cloud accepts OTLP requests up to 16 MiB over HTTP or gRPC. See [Ingestion request limits](#ingestion-request-limits). |
 | Versioning | Pin `fi-instrumentation-otel` and each instrumentor to a tested version so a release can't change span shape under you; the wire format follows the OTLP version the SDK ships. |
 
 ### Ingestion request limits
 
-FutureAGI Cloud enforces the same supported request limit for both OTLP transports:
+Future AGI Cloud enforces the same supported request limit for both OTLP transports:
 
 | Transport | Maximum request size | Error when exceeded |
 |---|---:|---|
@@ -92,7 +92,7 @@ OTEL_BSP_MAX_EXPORT_BATCH_SIZE=256
 ```
 
 <Note>
-  These limits apply to FutureAGI Cloud. For a self-hosted deployment, the configured collector and proxy limits apply.
+  These limits apply to Future AGI Cloud. For a self-hosted deployment, the configured collector and proxy limits apply.
 </Note>
 
 <Warning>

--- a/src/pages/docs/observe/reference/export-formats.mdx
+++ b/src/pages/docs/observe/reference/export-formats.mdx
@@ -73,8 +73,27 @@ The ingestion endpoint is an **OTLP/traces** receiver — you don't call it dire
 | Auth | `FI_API_KEY` + `FI_SECRET_KEY` from the [keys page](https://app.futureagi.com/dashboard/keys), sent by the SDK on every export. Keys are workspace-scoped. |
 | Success | The exporter batches spans and sends them in the background; a successful export returns no payload. Spans appear in Observe within seconds. |
 | Errors | A `401` means the keys are wrong for this workspace; a `4xx` means a malformed/oversized batch; transient `5xx`/network errors are retried by the batch exporter. |
-| Limits | Spans are sent by the **batch** span processor on an interval, so a short-lived process must call `trace_provider.force_flush()` before exit or the last batch is lost. Very large payloads (huge prompts/outputs) can be dropped — [mask or trim](/docs/sdk/tracing/mask-span-attributes) them at the SDK. |
+| Limits | FutureAGI Cloud accepts OTLP requests up to 16 MiB over HTTP or gRPC. See [Ingestion request limits](#ingestion-request-limits). |
 | Versioning | Pin `fi-instrumentation-otel` and each instrumentor to a tested version so a release can't change span shape under you; the wire format follows the OTLP version the SDK ships. |
+
+### Ingestion request limits
+
+FutureAGI Cloud enforces the same supported request limit for both OTLP transports:
+
+| Transport | Maximum request size | Error when exceeded |
+|---|---:|---|
+| OTLP/HTTP | 16 MiB | `413 Request Entity Too Large` |
+| OTLP/gRPC | 16 MiB | `RESOURCE_EXHAUSTED` |
+
+An oversized request is rejected as a whole and its spans are not stored. If you see either error in your exporter logs, reduce the number of spans sent in each batch. OpenTelemetry's default maximum export batch size is 512 spans. Start with:
+
+```bash
+OTEL_BSP_MAX_EXPORT_BATCH_SIZE=256
+```
+
+<Note>
+  These limits apply to FutureAGI Cloud. For a self-hosted deployment, the configured collector and proxy limits apply.
+</Note>
 
 <Warning>
   Span input and output can carry customer data before they leave your process. Redact at the SDK with `TraceConfig` or the `FI_HIDE_*` variables — see [Mask span attributes](/docs/sdk/tracing/mask-span-attributes).

--- a/src/pages/docs/observe/troubleshooting/no-traces-appearing.mdx
+++ b/src/pages/docs/observe/troubleshooting/no-traces-appearing.mdx
@@ -55,7 +55,7 @@ The most common cause is a short-lived process that exited before its spans flus
 | Wrong `project_type` | App runs, keys are valid, but traces never land in the project you expect | Set `project_type=ProjectType.OBSERVE` (and the matching `project_name`) in `register()`. |
 | Missing `FI_API_KEY` / `FI_SECRET_KEY` | Export fails or is silently dropped; nothing reaches Observe | Set both env vars to this workspace's keys before the app starts. |
 | Instrumented after the client was created | Some or all spans never emit because the client wasn't wrapped | Call `register()` and the instrumentor **before** constructing the framework client. |
-| Export request is too large | The exporter logs HTTP `413 Request Entity Too Large` or gRPC `RESOURCE_EXHAUSTED` | Set `OTEL_BSP_MAX_EXPORT_BATCH_SIZE=256` and restart the application. If the error continues, use `128`. See [ingestion request limits](/docs/observe/reference/export-formats#ingestion-request-limits). |
+| Export request is too large | The exporter logs HTTP `413 Request Entity Too Large` or gRPC `RESOURCE_EXHAUSTED` | Set `OTEL_BSP_MAX_EXPORT_BATCH_SIZE=256` and restart the application. If the error continues, use `128`. This cannot fix a single span over 16 MiB; [mask or trim span attributes](/docs/sdk/tracing/mask-span-attributes) instead. See [ingestion request limits](/docs/observe/reference/export-formats#ingestion-request-limits). |
 | Date-picker window too narrow | The trace exists but is filtered out of the view | Widen the date range to **Today** and enable **Auto refresh**. |
 
 ## Diagnostic commands

--- a/src/pages/docs/observe/troubleshooting/no-traces-appearing.mdx
+++ b/src/pages/docs/observe/troubleshooting/no-traces-appearing.mdx
@@ -44,6 +44,7 @@ The most common cause is a short-lived process that exited before its spans flus
 - The process **stays alive** long enough to export, or calls `force_flush()` before exiting.
 - `FI_API_KEY` and `FI_SECRET_KEY` are set to this workspace's keys.
 - `register()` is called with the correct `project_type` and `project_name`, **before** the framework client is created.
+- The exporter logs do not contain HTTP `413 Request Entity Too Large` or gRPC `RESOURCE_EXHAUSTED` errors.
 - The date picker is widened to **Today** (not the default 7-day window) and **Auto refresh** is on.
 
 ## Causes and fixes
@@ -54,6 +55,7 @@ The most common cause is a short-lived process that exited before its spans flus
 | Wrong `project_type` | App runs, keys are valid, but traces never land in the project you expect | Set `project_type=ProjectType.OBSERVE` (and the matching `project_name`) in `register()`. |
 | Missing `FI_API_KEY` / `FI_SECRET_KEY` | Export fails or is silently dropped; nothing reaches Observe | Set both env vars to this workspace's keys before the app starts. |
 | Instrumented after the client was created | Some or all spans never emit because the client wasn't wrapped | Call `register()` and the instrumentor **before** constructing the framework client. |
+| Export request is too large | The exporter logs HTTP `413 Request Entity Too Large` or gRPC `RESOURCE_EXHAUSTED` | Set `OTEL_BSP_MAX_EXPORT_BATCH_SIZE=256` and restart the application. If the error continues, use `128`. See [ingestion request limits](/docs/observe/reference/export-formats#ingestion-request-limits). |
 | Date-picker window too narrow | The trace exists but is filtered out of the view | Widen the date range to **Today** and enable **Auto refresh**. |
 
 ## Diagnostic commands


### PR DESCRIPTION
## Summary

- document the 16 MiB request limit for OTLP/HTTP and OTLP/gRPC
- explain oversized-request errors and exporter batch-size mitigation
- add the limit to trace troubleshooting and expose the reference page in navigation

Fixed TH-7889

## Validation

- `npm run audit-links`
- `npm run build`